### PR TITLE
Track pacifist

### DIFF
--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -292,6 +292,8 @@ void e6y_InitCommandLine(void)
     M_AddParam("-turbo");
     M_AddParam("50");
   }
+  
+  track_pacifist = M_CheckParm("-track_pacifist"); // dsda - track pacifist
 
   // TAS-tracers
   InitTracers();
@@ -834,6 +836,7 @@ int I_MessageBox(const char* text, unsigned int type)
 
 int stats_level;
 int stroller;
+int track_pacifist; // dsda - track pacifist
 int numlevels = 0;
 int levels_max = 0;
 timetable_t *stats = NULL;

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -292,6 +292,8 @@ const char* WINError(void);
 
 extern int stats_level;
 extern int stroller;
+extern int track_pacifist; // dsda - track pacifist
+
 void e6y_G_DoCompleted(void);
 void e6y_WriteStats(void);
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1177,6 +1177,18 @@ void G_Ticker (void)
             }
         }
     }
+    
+    // dsda - track pacifist
+    if (!pacifist && track_pacifist)
+    {
+      static dboolean pacifist_note_shown = false;
+      
+      if (!pacifist_note_shown)
+      {
+        pacifist_note_shown = true;
+        doom_printf ("Not pacifist!");
+      }
+    }
   }
 
   // cph - if the gamestate changed, we may need to clean up the old gamestate

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -85,6 +85,8 @@ int monsters_infight = 0; // e6y: Dehacked support - monsters infight
 int maxammo[NUMAMMO]  = {200, 50, 300, 50};
 int clipammo[NUMAMMO] = { 10,  4,  20,  1};
 
+dboolean pacifist = true; // dsda - track pacifist
+
 //
 // GET STUFF
 //
@@ -926,6 +928,15 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
   if (source && target)
   {
     CheckGivenDamageTracer(source, damage);
+  }
+
+  // dsda - track pacifist (10000 = telefrags allowed)
+  if (((source && source->player) || inflictor->player_damaged_barrel) && damage != 10000)
+  {
+    if (target->type == MT_BARREL)
+      target->player_damaged_barrel = true;
+    else if (!target->player)
+      pacifist = false;
   }
 
   // do the damage

--- a/prboom2/src/p_inter.h
+++ b/prboom2/src/p_inter.h
@@ -73,4 +73,6 @@ extern int bfgcells;
 extern int monsters_infight; // e6y: Dehacked support - monsters infight
 extern int maxammo[], clipammo[];
 
+extern dboolean pacifist; // dsda - track pacifist
+
 #endif

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -371,6 +371,8 @@ typedef struct mobj_s
     int iden_nums;		// hi word stores thing num, low word identifier num
 
     fixed_t             pad; // cph - needed so I can get the size unambiguously on amd64
+    
+    dboolean player_damaged_barrel; // dsda - track barrel (chains) for pacifist
 
     // SEE WARNING ABOVE ABOUT POINTER FIELDS!!!
 } mobj_t;


### PR DESCRIPTION
Not pacifist:
- direct damage
- splash damage
- shooting a barrel which eventually damages a monster (either immediately, after a monster blows it up, or if it causes a chain of barrel explosions that damage a monster)
- keen / lost soul / romero all count as monsters for this category

Pacifist:
- damaging self
- damaging other players
- damaging voodoo dolls
- telefrags
- crushers