### PR TITLE
Clean up some checks / comments

### DIFF
--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -208,7 +208,6 @@ static void dsda_InitHeretic(void) {
   dsda_SetSfx(heretic_S_sfx, HERETIC_NUMSFX);
   dsda_SetMusic(heretic_S_music, HERETIC_NUMMUSIC);
 
-  // HERETIC_TODO: of course, 2 levels requires complete rework...
   weaponinfo = wpnlev1info;
 
   g_mt_player = HERETIC_MT_PLAYER;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -802,7 +802,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   // killough 3/26/98, 4/2/98: fix autoswitch when no weapons are left
 
   // Make Boom insert only a single weapon change command on autoswitch.
-  if ((!heretic && !demo_compatibility && players[consoleplayer].attackdown && // killough
+  if ((!demo_compatibility && players[consoleplayer].attackdown && // killough
        !P_CheckAmmo(&players[consoleplayer]) && !done_autoswitch && boom_autoswitch) ||
        gamekeydown[key_weapontoggle])
   {
@@ -843,7 +843,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
       // Switch to fist or chainsaw based on preferences.
       // Switch to shotgun or SSG based on preferences.
 
-      if (!heretic && !demo_compatibility)
+      if (!demo_compatibility)
         {
           const player_t *player = &players[consoleplayer];
 
@@ -1519,7 +1519,7 @@ void G_Ticker (void)
       // Z_FreeTags(PU_LEVEL, PU_PURGELEVEL-1);
       break;
     case GS_INTERMISSION:
-      WI_End(); // HERETIC_TODO: heretic equivalent intermission cleanup?
+      WI_End();
     default:
       break;
     }
@@ -1536,7 +1536,6 @@ void G_Ticker (void)
   switch (gamestate)
     {
     case GS_LEVEL:
-      // HERETIC_TODO: P SB AM CT _Ticker();
       P_Ticker ();
       P_WalkTicker();
       mlooky = 0;
@@ -1546,7 +1545,7 @@ void G_Ticker (void)
       break;
 
     case GS_INTERMISSION:
-       WI_Ticker (); // HERETIC_TODO: IN_Ticker();
+       WI_Ticker ();
       break;
 
     case GS_FINALE:
@@ -2145,7 +2144,7 @@ frommapinfo:
     StatCopy(&wminfo);
   }
 
-  WI_Start (&wminfo); // HERETIC_TODO: IN_Start();
+  WI_Start (&wminfo);
 }
 
 //

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -261,7 +261,6 @@ int EV_DoCeiling
   secnum = -1;
   rtn = 0;
 
-  // HERETIC_TODO: I think this is irrelevant for our purposes
   if (ProcessNoTagLines(line, &sec, &secnum)) {if (zerotag_manual) goto manual_ceiling; else {return rtn;}};//e6y
   // Reactivate in-stasis ceilings...for certain types.
   // This restarts a crusher after it has been stopped

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -138,7 +138,6 @@ void T_VerticalDoor (vldoor_t* door)
       // http://sourceforge.net/tracker/index.php?func=detail&aid=1411400&group_id=148658&atid=772943
       // Old code: if (door->lighttag && door->topheight - door->sector->floorheight)
       if (
-        !heretic &&
         door->lighttag &&
         door->topheight - door->sector->floorheight &&
         compatibility_level >= mbf_compatibility
@@ -255,7 +254,6 @@ void T_VerticalDoor (vldoor_t* door)
       // http://sourceforge.net/tracker/index.php?func=detail&aid=1411400&group_id=148658&atid=772943
       // Old code: if (door->lighttag && door->topheight - door->sector->floorheight)
       if (
-        !heretic &&
         door->lighttag &&
         door->topheight - door->sector->floorheight &&
         compatibility_level >= mbf_compatibility
@@ -867,7 +865,7 @@ void Heretic_EV_VerticalDoor(line_t * line, mobj_t * thing)
     door->speed = VDOORSPEED;
     door->topwait = VDOORWAIT;
     door->line = line; // HERETIC_TODO: this is from doom
-    door->lighttag = 0; // HERETIC_TODO: !comp[comp_doorlight] does line->tag
+    door->lighttag = 0;
     switch (line->special)
     {
         case 1:

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -152,7 +152,7 @@ static dboolean P_CheckMeleeRange(mobj_t *actor)
     (
       P_AproxDistance(pl->x-actor->x, pl->y-actor->y) <
       (
-        (compatibility_level == doom_12_compatibility || heretic) ?
+        (compatibility_level == doom_12_compatibility) ?
         MELEERANGE :
         MELEERANGE - 20*FRACUNIT + pl->info->radius
       )
@@ -913,7 +913,7 @@ static dboolean P_LookForMonsters(mobj_t *actor, dboolean allaround)
 {
   thinker_t *cap, *th;
 
-  if (heretic || demo_compatibility)
+  if (demo_compatibility)
     return false;
 
   if (actor->lastenemy && actor->lastenemy->health > 0 && monsters_remember &&
@@ -1169,7 +1169,7 @@ void A_Chase(mobj_t *actor)
     actor->reactiontime--;
 
   if (actor->threshold) { /* modify target threshold */
-    if (compatibility_level == doom_12_compatibility || heretic)
+    if (compatibility_level == doom_12_compatibility)
     {
       actor->threshold--;
     }

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -116,7 +116,7 @@ result_e T_MovePlane
             /* cph - make more compatible with original Doom, by
              *  reintroducing this code. This means floors can't lower
              *  if objects are stuck in the ceiling */
-            if ((flag == true) && (heretic || comp[comp_floors])) {
+            if ((flag == true) && comp[comp_floors]) {
               sector->floorheight = lastpos;
               P_ChangeSector(sector,crush);
               return crushed;
@@ -128,7 +128,7 @@ result_e T_MovePlane
           // Moving a floor up
           // jff 02/04/98 keep floor from moving thru ceilings
           // jff 2/22/98 weaken check to demo_compatibility
-          destheight = (heretic || comp[comp_floors] || dest<sector->ceilingheight)?
+          destheight = (comp[comp_floors] || dest<sector->ceilingheight)?
                           dest : sector->ceilingheight;
           if (sector->floorheight + speed > destheight)
           {
@@ -151,7 +151,7 @@ result_e T_MovePlane
             if (flag == true)
             {
         /* jff 1/25/98 fix floor crusher */
-              if (heretic || comp[comp_floors]) {
+              if (comp[comp_floors]) {
 
                 //e6y: warning about potential desynch
                 if (crush == STAIRS_UNINITIALIZED_CRUSH_FIELD_VALUE)
@@ -180,7 +180,7 @@ result_e T_MovePlane
           // moving a ceiling down
           // jff 02/04/98 keep ceiling from moving thru floors
           // jff 2/22/98 weaken check to demo_compatibility
-          destheight = (heretic || comp[comp_floors] || dest>sector->floorheight)?
+          destheight = (comp[comp_floors] || dest>sector->floorheight)?
                           dest : sector->floorheight;
           if (sector->ceilingheight - speed < destheight)
           {
@@ -353,7 +353,7 @@ void T_MoveFloor(floormove_t* floor)
 
     // Moving floors (but not plats) in versions <= v1.2 did not
     // make floor stop sound
-    if (!heretic && compatibility_level > doom_12_compatibility)
+    if (compatibility_level > doom_12_compatibility)
         S_StartSound((mobj_t *)&floor->sector->soundorg, sfx_pstop);
   }
 }
@@ -529,7 +529,7 @@ manual_floor://e6y
         floor->sector = sec;
         floor->speed = FLOORSPEED * 4;
         floor->floordestheight = P_FindHighestFloorSurrounding(sec);
-        if (heretic || compatibility_level == doom_12_compatibility ||
+        if (compatibility_level == doom_12_compatibility ||
             floor->floordestheight != sec->floorheight)
           floor->floordestheight += 8*FRACUNIT;
         break;
@@ -600,7 +600,7 @@ manual_floor://e6y
           side_t*     side;
 
     /* jff 3/13/98 no ovf */
-          if (!heretic && !comp[comp_model]) minsize = 32000<<FRACBITS;
+          if (!comp[comp_model]) minsize = 32000<<FRACBITS;
           floor->direction = 1;
           floor->sector = sec;
           floor->speed = FLOORSPEED;
@@ -611,18 +611,18 @@ manual_floor://e6y
               side = getSide(secnum,i,0);
               // jff 8/14/98 don't scan texture 0, its not real
               if (side->bottomtexture > 0 ||
-                  ((heretic || comp[comp_model]) && !side->bottomtexture))
+                  (comp[comp_model] && !side->bottomtexture))
                 if (textureheight[side->bottomtexture] < minsize)
                   minsize = textureheight[side->bottomtexture];
               side = getSide(secnum,i,1);
               // jff 8/14/98 don't scan texture 0, its not real
               if (side->bottomtexture > 0 ||
-                  ((heretic || comp[comp_model]) && !side->bottomtexture))
+                  (comp[comp_model] && !side->bottomtexture))
                 if (textureheight[side->bottomtexture] < minsize)
                   minsize = textureheight[side->bottomtexture];
             }
           }
-          if (heretic || comp[comp_model])
+          if (comp[comp_model])
             floor->floordestheight = floor->sector->floorheight + minsize;
           else
           {
@@ -892,7 +892,7 @@ manual_stair://e6y
    * cph 2001/02/06: stair bug fix should be controlled by comp_stairs,
    *  except if we're emulating MBF which perversly reverted the fix
    */
-        if (heretic || comp[comp_stairs] || (compatibility_level == mbf_compatibility))
+        if (comp[comp_stairs] || (compatibility_level == mbf_compatibility))
           height += stairsize; // jff 6/28/98 change demo compatibility
 
         // if sector's floor already moving, look for another
@@ -900,7 +900,7 @@ manual_stair://e6y
           continue;
 
   /* cph - see comment above - do this iff we didn't do so above */
-        if (!heretic && !comp[comp_stairs] && (compatibility_level != mbf_compatibility))
+        if (!comp[comp_stairs] && (compatibility_level != mbf_compatibility))
           height += stairsize;
 
         sec = tsec;
@@ -989,7 +989,7 @@ int EV_DoDonut(line_t*  line)
     // pillar must be two-sided
     if (!s2)
     {
-      if (heretic || demo_compatibility)
+      if (demo_compatibility)
       {
         lprintf(LO_ERROR,
           "EV_DoDonut: lowest numbered line (linedef: %d) "
@@ -1006,7 +1006,7 @@ int EV_DoDonut(line_t*  line)
 
     /* do not start the donut if the pool is already moving
      * cph - DEMOSYNC - was !compatibility */
-    if (!heretic && !comp[comp_floors] && P_SectorActive(floor_special,s2))
+    if (!comp[comp_floors] && P_SectorActive(floor_special,s2))
       continue;                           //jff 5/7/98
 
     // find a two sided line around the pool whose other side isn't the pillar
@@ -1014,7 +1014,7 @@ int EV_DoDonut(line_t*  line)
     {
       //jff 3/29/98 use true two-sidedness, not the flag
       // killough 4/5/98: changed demo_compatibility to compatibility
-      if (heretic || comp[comp_model])
+      if (comp[comp_model])
       {
         // original code:   !s2->lines[i]->flags & ML_TWOSIDED
         // equivalent to:   (!s2->lines[i]->flags) & ML_TWOSIDED , i.e. 0

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -1172,13 +1172,11 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
 
   target->reactiontime = 0;           // we're awake now...
 
-  // HERETIC_TODO: make heretic -> compatibility_level == doom_12_compatibility ?
-
   /* killough 9/9/98: cleaned up, made more consistent: */
   //e6y: Monsters could commit suicide in Doom v1.2 if they damaged themselves by exploding a barrel
   if (
     source &&
-    (source != target || compatibility_level == doom_12_compatibility || heretic) &&
+    (source != target || compatibility_level == doom_12_compatibility) &&
     source->type != MT_VILE &&
     (!target->threshold || target->type == MT_VILE) &&
     ((source->flags ^ target->flags) & MF_FRIEND || monster_infighting || !mbf_features) &&

--- a/prboom2/src/p_lights.c
+++ b/prboom2/src/p_lights.c
@@ -401,7 +401,7 @@ int EV_LightTurnOn(line_t *line, int bright)
 
       //jff 5/17/98 unless compatibility optioned
       //then maximum near ANY tagged sector
-      if (heretic || comp[comp_model])
+      if (comp[comp_model])
   bright = tbright;
     }
   return 1;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -734,7 +734,7 @@ static dboolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
   // Correction of wrong return value with demo_compatibility.
   // There is no more synch on http://www.doomworld.com/sda/dwdemo/w303-115.zip
   // (with correction in setMobjInfoValue)
-  if (heretic || (demo_compatibility && !prboom_comp[PC_TREAT_NO_CLIPPING_THINGS_AS_NOT_BLOCKING].state))
+  if (demo_compatibility && !prboom_comp[PC_TREAT_NO_CLIPPING_THINGS_AS_NOT_BLOCKING].state)
     return !(thing->flags & MF_SOLID);
   else
     return !((thing->flags & MF_SOLID && !(thing->flags & MF_NOCLIP))
@@ -992,7 +992,7 @@ dboolean P_TryMove(mobj_t* thing,fixed_t x,fixed_t y,
      */
     if (!(thing->flags & (MF_DROPOFF|MF_FLOAT)))
     {
-      if (heretic || comp[comp_dropoff])
+      if (comp[comp_dropoff])
       {
         // e6y
         // Fix demosync bug in mbf compatibility mode
@@ -1004,7 +1004,6 @@ dboolean P_TryMove(mobj_t* thing,fixed_t x,fixed_t y,
         // http://www.doomworld.com/idgames/index.php?id=11138
         if (
           (
-            heretic ||
             compatibility ||
             !dropoff ||
             (
@@ -1317,8 +1316,7 @@ void P_HitSlideLine (line_t* ld)
   else
   {
     extern dboolean onground;
-    icyfloor = !heretic &&
-               !compatibility &&
+    icyfloor = !compatibility &&
                variable_friction &&
                slidemo->player &&
                onground &&
@@ -1365,7 +1363,7 @@ void P_HitSlideLine (line_t* ld)
   // The moveangle+=10 breaks v1.9 demo compatibility in
   // some demos, so it needs demo_compatibility switch.
 
-  if (!heretic && !demo_compatibility)
+  if (!demo_compatibility)
     moveangle += 10; // prevents sudden path reversal due to        // phares
                      // rounding error                              //   |
   deltaangle = moveangle-lineangle;                                 //   V
@@ -1762,7 +1760,7 @@ dboolean PTR_ShootTraverse (intercept_t* in)
         // fix bullet-eaters -- killough:
         // WARNING: Almost all demos will lose sync without this
         // demo_compatibility flag check!!! killough 1/18/98
-      if (heretic || demo_compatibility || li->backsector->ceilingheight < z)
+      if (demo_compatibility || li->backsector->ceilingheight < z)
         return false;
       }
 
@@ -1946,7 +1944,7 @@ dboolean PTR_UseTraverse (intercept_t* in)
   //WAS can't use for than one special line in a row
   //jff 3/21/98 NOW multiple use allowed with enabling line flag
 
-  return (!heretic && !demo_compatibility && ((in->d.line->flags&ML_PASSUSE) || comperr(comperr_passuse)))?//e6y
+  return (!demo_compatibility && ((in->d.line->flags&ML_PASSUSE) || comperr(comperr_passuse)))?//e6y
           true : false;
 }
 
@@ -2002,7 +2000,7 @@ void P_UseLines (player_t*  player)
   // This added test makes the "oof" sound work on 2s lines -- killough:
 
   if (P_PathTraverse ( x1, y1, x2, y2, PT_ADDLINES, PTR_UseTraverse ))
-    if (!heretic && !comp[comp_sound] && !P_PathTraverse ( x1, y1, x2, y2, PT_ADDLINES, PTR_NoWayTraverse ))
+    if (!comp[comp_sound] && !P_PathTraverse ( x1, y1, x2, y2, PT_ADDLINES, PTR_NoWayTraverse ))
       S_StartSound (usething, sfx_noway);
 }
 
@@ -2128,7 +2126,7 @@ dboolean PIT_ChangeSector (mobj_t* thing)
     {
     if (!heretic) P_SetMobjState (thing, S_GIBS);
 
-    if (!heretic && compatibility_level != doom_12_compatibility)
+    if (compatibility_level != doom_12_compatibility)
     {
       thing->flags &= ~MF_SOLID;
     }

--- a/prboom2/src/p_maputl.c
+++ b/prboom2/src/p_maputl.c
@@ -155,7 +155,7 @@ fixed_t PUREFUNC P_InterceptVector2(const divline_t *v2, const divline_t *v1)
 
 fixed_t PUREFUNC P_InterceptVector(const divline_t *v2, const divline_t *v1)
 {
-  if (heretic || compatibility_level < prboom_4_compatibility)
+  if (compatibility_level < prboom_4_compatibility)
     return P_InterceptVector2(v2, v1);
   else {
     /* cph - This was introduced at prboom_4_compatibility - no precision/overflow problems */
@@ -380,7 +380,7 @@ dboolean P_BlockLinesIterator(int x, int y, dboolean func(line_t*))
   // Most demos go out of sync, and maybe other problems happen, if we
   // don't consider linedef 0. For safety this should be qualified.
 
-  if (!heretic && !demo_compatibility) // killough 2/22/98: demo_compatibility check
+  if (!demo_compatibility) // killough 2/22/98: demo_compatibility check
     list++;     // skip 0 starting delimiter                      // phares
   for ( ; *list != -1 ; list++)                                   // phares
     {

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -252,7 +252,6 @@ static void P_XYMovement (mobj_t* mo)
     // to pass through walls.
     // CPhipps - compatibility optioned
 
-    // HERETIC_TODO: I assume third condition is false for cl 3 (not in heretic)
     if (xmove > MAXMOVE / 2 ||
         ymove > MAXMOVE / 2 ||
         (!comp[comp_moveblock] && (xmove < -MAXMOVE/2 || ymove < -MAXMOVE/2)))
@@ -337,7 +336,7 @@ static void P_XYMovement (mobj_t* mo)
                 mo->momz = -FRACUNIT;
                 return;
             }
-            else if (heretic || demo_compatibility ||  // killough
+            else if (demo_compatibility ||  // killough
                      mo->z > ceilingline->backsector->ceilingheight)
             {
               // Hack to prevent missiles exploding
@@ -396,7 +395,6 @@ static void P_XYMovement (mobj_t* mo)
       !player ||
       !(player->cmd.forwardmove | player->cmd.sidemove) ||
       (
-        !heretic && // HERETIC_TODO: can remove when compatibility set
         player->mo != mo &&
         compatibility_level >= lxdoom_1_compatibility
       )
@@ -455,7 +453,7 @@ static void P_XYMovement (mobj_t* mo)
      */
 
     //e6y
-    if (heretic || (compatibility_level <= boom_201_compatibility && !prboom_comp[PC_PRBOOM_FRICTION].state))
+    if (compatibility_level <= boom_201_compatibility && !prboom_comp[PC_PRBOOM_FRICTION].state)
     {
       if (mo->flags2 & MF2_FLY && !(mo->z <= mo->floorz)
           && !(mo->flags2 & MF2_ONMOBJ))
@@ -624,7 +622,7 @@ static void P_ZMovement (mobj_t* mo)
   // check for smooth step up
 
   if (mo->player && //e6y: restoring original visual behaviour for demo_compatibility
-      (heretic || demo_compatibility || mo->player->mo == mo) &&  // killough 5/12/98: exclude voodoo dolls
+      (demo_compatibility || mo->player->mo == mo) &&  // killough 5/12/98: exclude voodoo dolls
       mo->z < mo->floorz)
   {
     mo->player->viewheight -= mo->floorz - mo->z;
@@ -713,9 +711,7 @@ floater:
      *  mimic the bug and do it further down instead)
      */
 
-    // HERETIC_TODO: again, once compatibility is set up, remove heretic check
     if (
-      !heretic &&
       mo->flags & MF_SKULLFLY &&
       (
         !comp[comp_soul] ||
@@ -748,7 +744,7 @@ floater:
           // but can be applied globally for all demo_compatibility complevels,
           // because original sources do not exclude voodoo dolls from condition above,
           // but Boom does it.
-          (heretic || demo_compatibility || mo->player->mo == mo) &&
+          (demo_compatibility || mo->player->mo == mo) &&
           mo->momz < -GRAVITY * 8 &&
           !(mo->flags2 & MF2_FLY)
         )
@@ -781,7 +777,7 @@ floater:
      * incorrectly reverse it, so we might still need this for demo sync
      */
     if (mo->flags & MF_SKULLFLY &&
-	     (heretic || compatibility_level <= doom2_19_compatibility))
+	     compatibility_level <= doom2_19_compatibility)
       mo->momz = -mo->momz; // the skull slammed into something
 
     if (mo->info->crashstate && (mo->flags & MF_CORPSE))
@@ -817,7 +813,7 @@ floater:
      * Lost souls were meant to bounce off of ceilings;
      *  new comp_soul compatibility option added
      */
-    if (!heretic && !comp[comp_soul] && mo->flags & MF_SKULLFLY)
+    if (!comp[comp_soul] && mo->flags & MF_SKULLFLY)
       mo->momz = -mo->momz; // the skull slammed into something
 
     // hit the ceiling
@@ -832,7 +828,7 @@ floater:
      *  lowering on us), so for old demos we must still do the buggy
      *  momentum reversal here
      */
-    if ((heretic || comp[comp_soul]) && mo->flags & MF_SKULLFLY)
+    if (comp[comp_soul] && mo->flags & MF_SKULLFLY)
       mo->momz = -mo->momz; // the skull slammed into something
 
     if ((mo->flags & MF_MISSILE) && !(mo->flags & MF_NOCLIP))
@@ -884,7 +880,7 @@ static void P_NightmareRespawn(mobj_t* mobj)
    *   and the logic is reversed (i.e. like the rest of comp_ it *disables*
    *   the fix)
    */
-  if(!heretic && !comp[comp_respawn] && !x && !y)
+  if(!comp[comp_respawn] && !x && !y)
   {
      // spawnpoint was zeroed out, so use point of death instead
      x = mobj->x;
@@ -1142,7 +1138,7 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   mobj->height = info->height;                                      // phares
   mobj->flags  = info->flags;
   mobj->flags2 = info->flags2;
-  if (heretic) mobj->damage = info->damage; // HERETIC_TODO: doom doesn't do this, but why?
+  if (heretic) mobj->damage = info->damage;
 
   /* killough 8/23/98: no friends, bouncers, or touchy things in old demos */
   if (!mbf_features)
@@ -1579,14 +1575,12 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
   // bits that weren't used in Doom (such as HellMaker wads). So we should
   // then simply ignore all upper bits.
 
-  // HERETIC_TODO: remove heretic check once heretic == demo_compatibility
   if (
-    heretic ||
     demo_compatibility ||
     (compatibility_level >= lxdoom_1_compatibility && options & MTF_RESERVED)
   )
   {
-    if (!heretic && !demo_compatibility) // cph - Add warning about bad thing flags
+    if (!demo_compatibility) // cph - Add warning about bad thing flags
       lprintf(LO_WARN, "P_SpawnMapThing: correcting bad flags (%u) (thing type %d)\n", options, thingtype);
     options &= MTF_EASY|MTF_NORMAL|MTF_HARD|MTF_AMBUSH|MTF_NOTSINGLE;
   }
@@ -1596,7 +1590,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
   // doom2.exe has at most 10 deathmatch starts
   if (thingtype == 11)
   {
-    if ((heretic || compatibility) && deathmatch_p - deathmatchstarts >= 10)
+    if (compatibility && deathmatch_p - deathmatchstarts >= 10)
     {
   		return NULL;
     }

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2250,7 +2250,7 @@ static int P_GroupLines (void)
     sector->bbox[3] = sector->blockbox[3] >> FRACTOMAPBITS;
 
     // set the degenmobj_t to the middle of the bounding box
-    if (heretic || comp[comp_sound])
+    if (comp[comp_sound])
     {
       sector->soundorg.x = (bbox[BOXRIGHT]+bbox[BOXLEFT])/2;
       sector->soundorg.y = (bbox[BOXTOP]+bbox[BOXBOTTOM])/2;
@@ -2337,7 +2337,7 @@ static void P_RemoveSlimeTrails(void)         // killough 10/98
   int i;
   // Correction of desync on dv04-423.lmp/dv.wad
   // http://www.doomworld.com/vb/showthread.php?s=&postid=627257#post627257
-  int apply_for_real_vertexes = (!heretic && (compatibility_level>=lxdoom_1_compatibility || prboom_comp[PC_REMOVE_SLIME_TRAILS].state));
+  int apply_for_real_vertexes = (compatibility_level>=lxdoom_1_compatibility || prboom_comp[PC_REMOVE_SLIME_TRAILS].state);
 
   for (i=0; i<numvertexes; i++)
   {

--- a/prboom2/src/p_sight.c
+++ b/prboom2/src/p_sight.c
@@ -857,7 +857,7 @@ dboolean P_CheckSight(mobj_t *t1, mobj_t *t2)
   const sector_t *s1, *s2;
   int pnum;
 
-  if (heretic || compatibility_level == doom_12_compatibility)
+  if (compatibility_level == doom_12_compatibility)
   {
     return P_CheckSight_12(t1, t2);
   }

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -298,7 +298,7 @@ int twoSided
   //jff 1/26/98 return what is actually needed, whether the line
   //has two sidedefs, rather than whether the 2S flag is set
 
-  return (heretic || comp[comp_model]) ?
+  return (comp[comp_model]) ?
     (sectors[sector].lines[line])->flags & ML_TWOSIDED
     :
     (sectors[sector].lines[line])->sidenum[1] != NO_INDEX;
@@ -320,14 +320,14 @@ sector_t* getNextSector
   //returns NULL if the line is not two sided, and does so from
   //the actual two-sidedness of the line, rather than its 2S flag
 
-  if (heretic || comp[comp_model])
+  if (comp[comp_model])
   {
     if (!(line->flags & ML_TWOSIDED))
       return NULL;
   }
 
   if (line->frontsector == sec) {
-    if (heretic || comp[comp_model] || line->backsector!=sec)
+    if (comp[comp_model] || line->backsector!=sec)
       return line->backsector; //jff 5/3/98 don't retn sec unless compatibility
     else                       // fixes an intra-sector line breaking functions
       return NULL;             // like floor->highest floor
@@ -382,7 +382,7 @@ fixed_t P_FindHighestFloorSurrounding(sector_t *sec)
 
   //jff 1/26/98 Fix initial value for floor to not act differently
   //in sections of wad that are below -500 units
-  if (!heretic && !comp[comp_model])       /* jff 3/12/98 avoid ovf */
+  if (!comp[comp_model])       /* jff 3/12/98 avoid ovf */
     floor = -32000*FRACUNIT;   // in height calculations
 
   for (i=0 ;i < sec->linecount ; i++)
@@ -418,7 +418,7 @@ fixed_t P_FindNextHighestFloor(sector_t *sec, int currentheight)
   // e6y
   // Original P_FindNextHighestFloor() is restored for demo_compatibility
   // Adapted for prboom's complevels
-  if ((heretic || demo_compatibility) && !prboom_comp[PC_FORCE_BOOM_FINDNEXTHIGHESTFLOOR].state)
+  if (demo_compatibility && !prboom_comp[PC_FORCE_BOOM_FINDNEXTHIGHESTFLOOR].state)
   {
     int h;
     int min;
@@ -458,7 +458,7 @@ fixed_t P_FindNextHighestFloor(sector_t *sec, int currentheight)
         // 21: can be emulated;
         // 22..26: overflow affects saved registers - unpredictable behaviour, can crash;
         // 27: overflow affects return address - crash with high probability;
-        if ((heretic || compatibility_level < dosdoom_compatibility) && h >= MAX_ADJOINING_SECTORS)
+        if (compatibility_level < dosdoom_compatibility && h >= MAX_ADJOINING_SECTORS)
         {
           // HERETIC_TODO: crispy actually doesn't go here, but probably it should be done
           lprintf(LO_WARN, "P_FindNextHighestFloor: Overflow of heightlist[%d] array is detected.\n", MAX_ADJOINING_SECTORS);
@@ -478,7 +478,7 @@ fixed_t P_FindNextHighestFloor(sector_t *sec, int currentheight)
       }
 
       // Check for overflow. Warning.
-      if (!heretic && compatibility_level >= dosdoom_compatibility && h >= MAX_ADJOINING_SECTORS)
+      if (compatibility_level >= dosdoom_compatibility && h >= MAX_ADJOINING_SECTORS)
       {
         lprintf( LO_WARN, "Sector with more than 20 adjoining sectors\n" );
         break;
@@ -497,7 +497,7 @@ fixed_t P_FindNextHighestFloor(sector_t *sec, int currentheight)
       // It's not *quite* random stack noise. If this function is called
       // as part of a loop, heightlist will be at the same location as in
       // the previous call. Doing it this way fixes 1_ON_1.WAD.
-      return ((heretic || compatibility_level < doom_1666_compatibility) ? last_height_0 : currentheight);
+      return (compatibility_level < doom_1666_compatibility ? last_height_0 : currentheight);
     }
 
     last_height_0 = heightlist[0];
@@ -644,7 +644,7 @@ fixed_t P_FindLowestCeilingSurrounding(sector_t* sec)
   fixed_t             height = INT_MAX;
 
   /* jff 3/12/98 avoid ovf in height calculations */
-  if (!heretic && !comp[comp_model]) height = 32000*FRACUNIT;
+  if (!comp[comp_model]) height = 32000*FRACUNIT;
 
   for (i=0 ;i < sec->linecount ; i++)
   {
@@ -680,7 +680,7 @@ fixed_t P_FindHighestCeilingSurrounding(sector_t* sec)
   /* jff 1/26/98 Fix initial value for floor to not act differently
    * in sections of wad that are below 0 units
    * jff 3/12/98 avoid ovf in height calculations */
-  if (!heretic && !comp[comp_model]) height = -32000*FRACUNIT;
+  if (!comp[comp_model]) height = -32000*FRACUNIT;
 
   for (i=0 ;i < sec->linecount ; i++)
   {
@@ -1116,7 +1116,7 @@ dboolean P_CanUnlockGenDoor
 //
 dboolean PUREFUNC P_SectorActive(special_e t, const sector_t *sec)
 {
-  if (heretic || demo_compatibility)  // return whether any thinker is active
+  if (demo_compatibility)  // return whether any thinker is active
     return sec->floordata != NULL || sec->ceilingdata != NULL || sec->lightingdata != NULL;
   else
     switch (t)             // return whether thinker of same type is active
@@ -1148,7 +1148,7 @@ int P_CheckTag(line_t *line)
 {
   /* tag not zero, allowed, or
    * killough 11/98: compatibility option */
-  if (heretic || comp[comp_zerotags] || line->tag || comperr(comperr_zerotag))//e6y
+  if (comp[comp_zerotags] || line->tag || comperr(comperr_zerotag))//e6y
     return 1;
 
   switch(line->special)
@@ -2179,7 +2179,7 @@ void P_ShootSpecialLine
   line_t*       line )
 {
   //jff 02/04/98 add check here for generalized linedef
-  if (!heretic && !demo_compatibility)
+  if (!demo_compatibility)
   {
     // pointer to line function is NULL by default, set non-null if
     // line special is gun triggered generalized linedef type
@@ -2302,7 +2302,7 @@ void P_ShootSpecialLine
   {
     case 24:
       // 24 G1 raise floor to highest adjacent
-      if (EV_DoFloor(line,raiseFloor) || heretic || demo_compatibility)
+      if (EV_DoFloor(line,raiseFloor) || demo_compatibility)
         P_ChangeSwitchTexture(line,0);
       break;
 
@@ -2314,7 +2314,7 @@ void P_ShootSpecialLine
 
     case 47:
       // 47 G1 raise floor to nearest and change texture and type
-      if (EV_DoPlat(line,raiseToNearestAndChange,0) || heretic || demo_compatibility)
+      if (EV_DoPlat(line,raiseToNearestAndChange,0) || demo_compatibility)
         P_ChangeSwitchTexture(line,0);
       break;
 
@@ -2322,7 +2322,7 @@ void P_ShootSpecialLine
     // killough 1/31/98: added demo_compatibility check, added inner switch
 
     default:
-      if (!heretic && !demo_compatibility)
+      if (!demo_compatibility)
         switch (line->special)
         {
           case 197:

--- a/prboom2/src/p_switch.c
+++ b/prboom2/src/p_switch.c
@@ -203,7 +203,7 @@ void P_ChangeSwitchTexture
   /* use the sound origin of the linedef (its midpoint)
    * unless in a compatibility mode */
   soundorg = (mobj_t *)&line->soundorg;
-  if (heretic || comp[comp_sound] || compatibility_level < prboom_6_compatibility) {
+  if (comp[comp_sound] || compatibility_level < prboom_6_compatibility) {
     /* usually NULL, unless there is another button already pressed in,
      * in which case it's the sound origin of that button press... */
     soundorg = buttonlist->soundorg;

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -171,8 +171,7 @@ void P_CalcHeight (player_t* player)
   }
   else
   {
-    // HERETIC_TODO: probably heretic will / should imply demo_compatibility
-    if (heretic || demo_compatibility || player_bobbing || prboom_comp[PC_FORCE_INCORRECT_BOBBING_IN_BOOM].state)
+    if (demo_compatibility || player_bobbing || prboom_comp[PC_FORCE_INCORRECT_BOBBING_IN_BOOM].state)
     {
       player->bob = (FixedMul(player->mo->momx, player->mo->momx) +
         FixedMul(player->mo->momy, player->mo->momy)) >> 2;

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -178,9 +178,6 @@ typedef struct
 #ifdef GL_DOOM
   int fakegroup[2];
 #endif
-
-  // heretic (covered by ceilingdata / etc?)
-  // void *specialdata; // thinker_t for reversible actions
 } sector_t;
 
 //


### PR DESCRIPTION
For heretic:
```
demo_compatibility = true;
compatibility_level = doom_12_compatibility = 0;
comp[x] = true;
```
Given these assumptions, we can remove a bunch of redundant checks (verified by demo syncing).
This also removes a few comments I ran into while going through things.