### PR TITLE
Refine key frames

### DIFF
--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -129,6 +129,12 @@ extern int SCREEN_320x200;
 // The maximum number of players, multiplayer/networking.
 #define MAXPLAYERS       4
 
+// killough 2/28/98: A ridiculously large number
+// of players, the most you'll ever need in a demo
+// or savegame. This is used to prevent problems, in
+// case more players in a game are supported later.
+#define MIN_MAXPLAYERS 32
+
 // phares 5/14/98:
 // DOOM Editor Numbers (aka doomednum in mobj_t)
 

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -73,7 +73,7 @@ void dsda_InitDemo(char* name) {
   dsda_demo_write_buffer_length = INITIAL_DEMO_BUFFER_SIZE;
 }
 
-void dsda_WriteToDemo(byte* buffer, size_t length) {
+void dsda_WriteToDemo(void* buffer, size_t length) {
   dsda_EnsureDemoBufferSpace(length);
 
   memcpy(dsda_demo_write_buffer_p, buffer, length);
@@ -98,6 +98,15 @@ void dsda_WriteDemoToFile(void) {
 
 int dsda_DemoBufferOffset(void) {
   return dsda_demo_write_buffer_p - dsda_demo_write_buffer;
+}
+
+int dsda_CopyDemoBuffer(void* buffer) {
+  int offset;
+
+  offset = dsda_DemoBufferOffset();
+  memcpy(buffer, dsda_demo_write_buffer, offset);
+
+  return offset;
 }
 
 void dsda_SetDemoBufferOffset(int offset) {

--- a/prboom2/src/dsda/demo.h
+++ b/prboom2/src/dsda/demo.h
@@ -19,9 +19,10 @@
 #define __DSDA_DEMO__
 
 void dsda_InitDemo(char* name);
-void dsda_WriteToDemo(byte* buffer, size_t length);
+void dsda_WriteToDemo(void* buffer, size_t length);
 void dsda_WriteDemoToFile(void);
 int dsda_DemoBufferOffset(void);
+int dsda_CopyDemoBuffer(void* buffer);
 void dsda_SetDemoBufferOffset(int offset);
 
 #endif

--- a/prboom2/src/dsda/key_frame.c
+++ b/prboom2/src/dsda/key_frame.c
@@ -165,7 +165,8 @@ void dsda_StoreKeyFrame(byte** buffer, byte complete) {
   savebuffer = save_p = NULL;
 
   if (complete) {
-    dsda_ExportKeyFrame(*buffer, length);
+    if (demo_write_buffer_offset)
+      dsda_ExportKeyFrame(*buffer, length);
 
     doom_printf("Stored key frame");
   }

--- a/prboom2/src/dsda/key_frame.h
+++ b/prboom2/src/dsda/key_frame.h
@@ -19,6 +19,7 @@
 #define __DSDA_KEY_FRAME__
 
 void dsda_InitKeyFrame(void);
+void dsda_ContinueKeyFrame(void);
 void dsda_StoreKeyFrame(unsigned char** buffer, byte complete);
 void dsda_RestoreKeyFrame(unsigned char* buffer, byte complete);
 int dsda_KeyFrameRestored(void);

--- a/prboom2/src/dsda/key_frame.h
+++ b/prboom2/src/dsda/key_frame.h
@@ -19,8 +19,8 @@
 #define __DSDA_KEY_FRAME__
 
 void dsda_InitKeyFrame(void);
-void dsda_StoreKeyFrame(unsigned char** buffer, int log);
-void dsda_RestoreKeyFrame(unsigned char* buffer);
+void dsda_StoreKeyFrame(unsigned char** buffer, byte complete);
+void dsda_RestoreKeyFrame(unsigned char* buffer, byte complete);
 int dsda_KeyFrameRestored(void);
 void dsda_StoreQuickKeyFrame(void);
 void dsda_RestoreQuickKeyFrame(void);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -3538,6 +3538,8 @@ void G_BeginRecording (void)
   }
 
   dsda_WriteToDemo(demostart, demo_p - demostart);
+  dsda_ContinueKeyFrame();
+
   free(demostart);
 }
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1998,13 +1998,6 @@ void G_DoWorldDone (void)
   e6y_G_DoWorldDone();//e6y
 }
 
-// killough 2/28/98: A ridiculously large number
-// of players, the most you'll ever need in a demo
-// or savegame. This is used to prevent problems, in
-// case more players in a game are supported later.
-
-#define MIN_MAXPLAYERS 32
-
 extern dboolean setsizeneeded;
 
 //CPhipps - savename variable redundant


### PR DESCRIPTION
Fixes 3 issues:

- ordering of objects in the blockmap was not preserved in saves
- objects marked for deletion but still relevant for the game logic were not preserved in saves
- it was possible to rewind to a state no longer matching the demo buffer in certain cases

New stuff:

- Key frames store all the header-related information and the entire demo buffer
- Manual key frames while recording are backed up to a file backup-ttt.kf (ttt = tics).
- You can record from a key frame (continuing a previous demo) with `-from_key_frame x.kf` (you still need to supply `-record` and `-complevel`).