### PR TITLE
Adjust mouse input

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1427,8 +1427,8 @@ static void I_ReadMouse(void)
     {
       event.type = ev_mouse;
       event.data1 = I_SDLtoDoomMouseState(sdl_mouse_state);
-      event.data2 = x << 1;
-      event.data3 = -y << 1;
+      event.data2 = x;
+      event.data3 = -y;
 
       D_PostEvent(&event);
     }

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1411,6 +1411,7 @@ void I_UpdateVideoMode(void)
 static void ActivateMouse(void)
 {
   SDL_SetRelativeMouseMode(SDL_TRUE);
+  SDL_GetRelativeMouseState(NULL, NULL);
 }
 
 static void DeactivateMouse(void)

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -317,17 +317,6 @@ while (SDL_PollEvent(Event))
     }
   }
   break;
-  case SDL_MOUSEMOTION:
-    if (mouse_enabled && window_focused)
-    {
-      int xrel, yrel;
-      event.type = ev_mouse;
-      event.data1 = I_SDLtoDoomMouseState(SDL_GetRelativeMouseState(&xrel, &yrel));
-      event.data2 = xrel << 4;
-      event.data3 = -yrel << 4;
-      D_PostEvent(&event);
-    }
-    break;
 
   case SDL_WINDOWEVENT:
     if (Event->window.windowID == windowid)
@@ -1426,6 +1415,25 @@ static void DeactivateMouse(void)
 // motion event.
 static void I_ReadMouse(void)
 {
+  if (mouse_enabled && window_focused)
+  {
+    int x, y;
+    unsigned int sdl_mouse_state;
+    event_t event;
+
+    sdl_mouse_state = SDL_GetRelativeMouseState(&x, &y);
+
+    if (x != 0 || y != 0)
+    {
+      event.type = ev_mouse;
+      event.data1 = I_SDLtoDoomMouseState(sdl_mouse_state);
+      event.data2 = x << 1;
+      event.data3 = -y << 1;
+
+      D_PostEvent(&event);
+    }
+  }
+
   if (!usemouse)
     return;
 

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -236,8 +236,6 @@ static void I_GetEvent(void)
   SDL_Event SDLEvent;
   SDL_Event *Event = &SDLEvent;
 
-  static int mwheeluptic = 0, mwheeldowntic = 0;
-
 while (SDL_PollEvent(Event))
 {
   switch (Event->type) {
@@ -303,16 +301,22 @@ while (SDL_PollEvent(Event))
   {
     if (Event->wheel.y > 0)
     {
-      event.type = ev_keydown;
       event.data1 = KEYD_MWHEELUP;
-      mwheeluptic = gametic;
+
+      event.type = ev_keydown;
+      D_PostEvent(&event);
+
+      event.type = ev_keyup;
       D_PostEvent(&event);
     }
     else if (Event->wheel.y < 0)
     {
-      event.type = ev_keydown;
       event.data1 = KEYD_MWHEELDOWN;
-      mwheeldowntic = gametic;
+
+      event.type = ev_keydown;
+      D_PostEvent(&event);
+
+      event.type = ev_keyup;
       D_PostEvent(&event);
     }
   }
@@ -342,22 +346,6 @@ while (SDL_PollEvent(Event))
     break;
   }
 }
-
-  if(mwheeluptic && mwheeluptic + 1 < gametic)
-  {
-    event.type = ev_keyup;
-    event.data1 = KEYD_MWHEELUP;
-    D_PostEvent(&event);
-    mwheeluptic = 0;
-  }
-
-  if(mwheeldowntic && mwheeldowntic + 1 < gametic)
-  {
-    event.type = ev_keyup;
-    event.data1 = KEYD_MWHEELDOWN;
-    D_PostEvent(&event);
-    mwheeldowntic = 0;
-  }
 }
 
 //

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1406,15 +1406,14 @@ static void I_ReadMouse(void)
   if (mouse_enabled && window_focused)
   {
     int x, y;
-    unsigned int sdl_mouse_state;
-    event_t event;
 
-    sdl_mouse_state = SDL_GetRelativeMouseState(&x, &y);
+    SDL_GetRelativeMouseState(&x, &y);
 
     if (x != 0 || y != 0)
     {
-      event.type = ev_mouse;
-      event.data1 = I_SDLtoDoomMouseState(sdl_mouse_state);
+      event_t event;
+      event.type = ev_mousemotion;
+      event.data1 = 0;
       event.data2 = x;
       event.data3 = -y;
 

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -404,6 +404,16 @@ static void AM_SetFPointFloatValue(fpoint_t *p)
 #endif
 }
 
+static dboolean stop_zooming;
+static int zoom_leveltime;
+
+static void AM_StopZooming(void)
+{
+  mtof_zoommul = FRACUNIT;
+  ftom_zoommul = FRACUNIT;
+  stop_zooming = false;
+}
+
 //
 // AM_activateNewScale()
 //
@@ -906,6 +916,7 @@ dboolean AM_Responder
     mtof_zoommul = M_ZOOMOUT;
     ftom_zoommul = M_ZOOMIN;
     curr_mtof_zoommul = mtof_zoommul;
+    zoom_leveltime = leveltime;
 
     return true;
   }
@@ -917,6 +928,7 @@ dboolean AM_Responder
     mtof_zoommul = M_ZOOMIN;
     ftom_zoommul = M_ZOOMOUT;
     curr_mtof_zoommul = mtof_zoommul;
+    zoom_leveltime = leveltime;
 
     return true;
   }
@@ -1000,8 +1012,10 @@ dboolean AM_Responder
     )
   )
   {
-    mtof_zoommul = FRACUNIT;
-    ftom_zoommul = FRACUNIT;
+    stop_zooming = true;
+
+    if (leveltime != zoom_leveltime)
+      AM_StopZooming();
   }
 
   return false;
@@ -2459,6 +2473,9 @@ void AM_Drawer (void)
   // Change the zoom if necessary
   if (ftom_zoommul != FRACUNIT)
     AM_changeWindowScale();
+
+  if (stop_zooming)
+    AM_StopZooming();
 
   // Change x,y location
   if (m_paninc.x || m_paninc.y)

--- a/prboom2/src/d_event.h
+++ b/prboom2/src/d_event.h
@@ -49,6 +49,7 @@ typedef enum
   ev_keydown,
   ev_keyup,
   ev_mouse,
+  ev_mousemotion,
   ev_joystick
 } evtype_t;
 

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -31,6 +31,7 @@ int dsda_tas;
 int dsda_skip_next_wipe;
 int dsda_wipe_at_full_speed;
 int dsda_track_attempts;
+int dsda_fine_sensitivity;
 
 void dsda_InitSettings(void) {
   dsda_ChangeStrictMode();
@@ -59,6 +60,10 @@ void dsda_ChangeStrictMode(void) {
 
 void dsda_SetTas(void) {
   dsda_tas = true;
+}
+
+double dsda_FineSensitivity(int base) {
+  return (double) base + (double) dsda_fine_sensitivity / 100;
 }
 
 dboolean dsda_StrictMode(void) {

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -27,11 +27,13 @@ extern int dsda_cycle_ghost_colors;
 extern int dsda_exhud;
 extern int dsda_track_attempts;
 extern int dsda_wipe_at_full_speed;
+extern int dsda_fine_sensitivity;
 
 void dsda_InitSettings(void);
 int dsda_CompatibilityLevel(void);
 void dsda_ChangeStrictMode(void);
 void dsda_SetTas(void);
+double dsda_FineSensitivity(int base);
 dboolean dsda_StrictMode(void);
 dboolean dsda_CycleGhostColors(void);
 dboolean dsda_AlwaysSR50(void);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1091,7 +1091,6 @@ dboolean G_Responder (event_t* ev)
       return true;    // eat key down events
 
     case ev_mouse:
-      //e6y
       mousex += (AccelerateMouse(ev->data2) * (mouseSensitivity_horiz));  /* killough */
       if(GetMouseLook())
         if (movement_mouseinvert)
@@ -1099,7 +1098,7 @@ dboolean G_Responder (event_t* ev)
         else
           mlooky -= (AccelerateMouse(ev->data3) * (mouseSensitivity_mlook));
       else
-        mousey += (AccelerateMouse(ev->data3) * (mouseSensitivity_vert)) / 4;
+        mousey += (AccelerateMouse(ev->data3) * (mouseSensitivity_vert)) / 8;
 
       return true;    // eat events
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1127,11 +1127,11 @@ dboolean G_Responder (event_t* ev)
       {
         double value;
 
-        value = (double) mouseSensitivity_horiz * AccelerateMouse(ev->data2);
+        value = dsda_FineSensitivity(mouseSensitivity_horiz) * AccelerateMouse(ev->data2);
         mousex += G_CarryDouble(carry_mousex, value);
         if(GetMouseLook())
         {
-          value = (double) mouseSensitivity_mlook * AccelerateMouse(ev->data3);
+          value = dsda_FineSensitivity(mouseSensitivity_mlook) * AccelerateMouse(ev->data3);
           if (movement_mouseinvert)
             mlooky += G_CarryDouble(carry_mousey, value);
           else

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1131,7 +1131,7 @@ dboolean G_Responder (event_t* ev)
         mousex += G_CarryDouble(carry_mousex, value);
         if(GetMouseLook())
         {
-          value = dsda_FineSensitivity(mouseSensitivity_mlook) * AccelerateMouse(ev->data3);
+          value = (double) mouseSensitivity_mlook * AccelerateMouse(ev->data3);
           if (movement_mouseinvert)
             mlooky += G_CarryDouble(carry_mousey, value);
           else

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1092,14 +1092,14 @@ dboolean G_Responder (event_t* ev)
 
     case ev_mouse:
       //e6y
-      mousex += (AccelerateMouse(ev->data2)*(mouseSensitivity_horiz))/10;  /* killough */
+      mousex += (AccelerateMouse(ev->data2) * (mouseSensitivity_horiz));  /* killough */
       if(GetMouseLook())
         if (movement_mouseinvert)
-          mlooky += (AccelerateMouse(ev->data3)*(mouseSensitivity_mlook))/10;
+          mlooky += (AccelerateMouse(ev->data3) * (mouseSensitivity_mlook));
         else
-          mlooky -= (AccelerateMouse(ev->data3)*(mouseSensitivity_mlook))/10;
+          mlooky -= (AccelerateMouse(ev->data3) * (mouseSensitivity_mlook));
       else
-        mousey += (AccelerateMouse(ev->data3)*(mouseSensitivity_vert))/40;
+        mousey += (AccelerateMouse(ev->data3) * (mouseSensitivity_vert)) / 4;
 
       return true;    // eat events
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -780,7 +780,18 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   }
   if (strafe)
   {
-    side += mousex / movement_mousestrafedivisor; /* mead  Don't want to strafe as fast as turns.*/
+    static double mousestrafe_carry = 0;
+    int delta;
+    double true_delta;
+
+    true_delta = mousestrafe_carry +
+                 (double) mousex / movement_mousestrafedivisor;
+
+    delta = (int) true_delta;
+    delta = (delta / 2) * 2;
+    mousestrafe_carry = true_delta - delta;
+
+    side += delta;
     side = (side / 2) * 2; // only even values are possible
   }
   else

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -647,7 +647,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
   if (dsda_InputActive(dsda_input_fire))
     cmd->buttons |= BT_ATTACK;
 
-  if (dsda_InputActive(dsda_input_use))
+  if (dsda_InputActive(dsda_input_use) || dsda_InputTickActivated(dsda_input_use))
     {
       cmd->buttons |= BT_USE;
       // clear double clicks if hit use button

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1123,7 +1123,7 @@ dboolean G_Responder (event_t* ev)
     case ev_keydown:
       return true;    // eat key down events
 
-    case ev_mouse:
+    case ev_mousemotion:
       {
         double value;
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1098,7 +1098,19 @@ dboolean G_Responder (event_t* ev)
         else
           mlooky -= (AccelerateMouse(ev->data3) * (mouseSensitivity_mlook));
       else
-        mousey += (AccelerateMouse(ev->data3) * (mouseSensitivity_vert)) / 8;
+      {
+        static double vertmouse_carry = 0;
+        int delta;
+        double true_delta;
+
+        true_delta = vertmouse_carry +
+                     (double)(AccelerateMouse(ev->data3) * (mouseSensitivity_vert)) / 8;
+
+        delta = (int) true_delta;
+        vertmouse_carry = true_delta - delta;
+
+        mousey += delta;
+      }
 
       return true;    // eat events
 

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -297,26 +297,18 @@ extern int mouse_acceleration;
 
 void MN_DrawMouse(void)
 {
-  int mhmx,mvmx; /* jff 4/3/98 clamp drawn position    99max mead */
+  MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_HORIZ_INDEX,
+                200, mouseSensitivity_horiz);
 
-  //jff 4/3/98 clamp horizontal sensitivity display
-  mhmx = mouseSensitivity_horiz > 99 ? 99 : mouseSensitivity_horiz; /*mead*/
-  MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_HORIZ_INDEX, 100, mhmx);
-
-  //jff 4/3/98 clamp vertical sensitivity display
-  mvmx = mouseSensitivity_vert > 99 ? 99 : mouseSensitivity_vert; /*mead*/
-  MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_VERT_INDEX, 100, mvmx);
+  MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_VERT_INDEX,
+                200, mouseSensitivity_vert);
 
   //e6y
-  {
-    int mpmx;
+  MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_MLOOK_INDEX,
+                200, mouseSensitivity_mlook);
 
-    mpmx = mouseSensitivity_mlook > 99 ? 99 : mouseSensitivity_mlook;
-    MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_MLOOK_INDEX, 100, mpmx);
-
-    mpmx = mouse_acceleration > 99 ? 99 : mouse_acceleration;
-    MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_ACCEL_INDEX, 100, mpmx);
-  }
+  MN_DrawSlider(MouseDef.x - 8, MouseDef.y + ITEM_HEIGHT * MOUSE_ACCEL_INDEX,
+                200, mouse_acceleration);
 }
 
 void MN_DrawSound(void)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1304,28 +1304,22 @@ menu_t MouseDef =
 
 void M_DrawMouse(void)
 {
-  int mhmx,mvmx; /* jff 4/3/98 clamp drawn position    99max mead */
-
   if (heretic) return MN_DrawMouse();
 
   // CPhipps - patch drawing updated
   V_DrawNamePatch(60, 15, 0, "M_MSENS", CR_DEFAULT, VPT_STRETCH);//e6y
 
-  //jff 4/3/98 clamp horizontal sensitivity display
-  mhmx = mouseSensitivity_horiz>99? 99 : mouseSensitivity_horiz; /*mead*/
-  M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_horiz+1),100,mhmx);
-  //jff 4/3/98 clamp vertical sensitivity display
-  mvmx = mouseSensitivity_vert>99? 99 : mouseSensitivity_vert; /*mead*/
-  M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_vert+1),100,mvmx);
+  M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_horiz + 1),
+               200, mouseSensitivity_horiz);
 
-  //e6y
-  {
-    int mpmx;
-    mpmx = mouseSensitivity_mlook>99? 99 : mouseSensitivity_mlook;
-    M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_mlook+1),100,mpmx);
-    mpmx = mouse_acceleration>99? 99 : mouse_acceleration;
-    M_DrawThermo(MouseDef.x,MouseDef.y+LINEHEIGHT*(mouse_accel+1),100,mpmx);
-  }
+  M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_vert + 1),
+               200, mouseSensitivity_vert);
+
+  M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_mlook + 1),
+               200, mouseSensitivity_mlook);
+
+  M_DrawThermo(MouseDef.x, MouseDef.y + LINEHEIGHT * (mouse_accel + 1),
+               200, mouse_acceleration);
 }
 
 void M_ChangeSensitivity(int choice)
@@ -1364,8 +1358,7 @@ void M_Mouse(int choice, int *sens)
         --*sens;
       break;
     case 1:
-      if (*sens < 99)
-        ++*sens;              /*mead*/
+      ++*sens;
       break;
     }
 }
@@ -6181,6 +6174,7 @@ void M_DrawThermo(int x,int y,int thermWidth,int thermDot )
 {
   int          xx;
   int           i;
+  char num[4];
   int horizScaler; //Used to allow more thermo range for mouse sensitivity.
 
   if (heretic) return MN_DrawSlider(x, y, thermWidth, thermDot);
@@ -6207,6 +6201,18 @@ void M_DrawThermo(int x,int y,int thermWidth,int thermDot )
   xx += (8 - horizScaler);  /* make the right end look even */
 
   V_DrawNamePatch(xx, y, 0, "M_THERMR", CR_DEFAULT, VPT_STRETCH);
+
+  // [crispy] print the value
+  snprintf(num, 4, "%3d", thermDot);
+  strcpy(menu_buffer, num);
+  M_DrawMenuString(xx + 12, y + 3, g_menu_cr_select);
+
+  // [crispy]
+  if (thermDot >= thermWidth)
+  {
+    thermDot = thermWidth - 1;
+  }
+
   V_DrawNamePatch((x+8)+thermDot*horizScaler,y,0,"M_THERMO",CR_DEFAULT,VPT_STRETCH);
 }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3480,6 +3480,7 @@ setup_menu_t dsda_gen_settings[] = {
   { "Use Extended Hud", S_YESNO, m_null, G_X, G_Y + 6 * 8, { "dsda_exhud" } },
   { "Wipe At Full Speed", S_YESNO, m_null, G_X, G_Y + 7 * 8, { "dsda_wipe_at_full_speed" } },
   { "Track Demo Attempts", S_YESNO, m_null, G_X, G_Y + 8 * 8, { "dsda_track_attempts" } },
+  { "Fine Sensitivity", S_NUM, m_null, G_X, G_Y + 9 * 8, { "dsda_fine_sensitivity" } },
 
 #ifdef GL_DOOM
   { "<- PREV", S_SKIP | S_PREV, m_null, KB_PREV, KB_Y + 20 * 8, { gen_settings8 } },

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1293,11 +1293,6 @@ menu_t MouseDef =
   0
 };
 
-
-// I'm using a scale of 100 since I don't know what's normal -- killough.
-
-#define MOUSE_SENS_MAX 100
-
 //
 // Change Mouse Sensitivities -- killough
 //

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1074,6 +1074,7 @@ default_t defaults[] =
   { "dsda_exhud", { &dsda_exhud }, { 0 }, 0, 1, def_bool, ss_stat },
   { "dsda_wipe_at_full_speed", { &dsda_wipe_at_full_speed }, { 1 }, 0, 1, def_bool, ss_stat },
   { "dsda_track_attempts", { &dsda_track_attempts }, { 1 }, 0, 1, def_bool, ss_stat },
+  { "dsda_fine_sensitivity", { &dsda_fine_sensitivity }, { 0 }, 0, 99, def_int, ss_stat },
 
   // NSM
   {"Video capture encoding settings",{NULL},{0},UL,UL,def_none,ss_none},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1023,7 +1023,7 @@ default_t defaults[] =
    def_int,ss_none},
   {"mouse_doubleclick_as_use", {&mouse_doubleclick_as_use},  {1},0,1,
    def_bool,ss_stat},
-  {"mouse_carrytics", {&mouse_carrytics}, {0},0,1,
+  {"mouse_carrytics", {&mouse_carrytics}, {1},0,1,
    def_bool,ss_stat},
 
   {"Prboom-plus demos settings",{NULL},{0},UL,UL,def_none,ss_none},


### PR DESCRIPTION
This PR changes the mouse scale (removes existing scaling and makes it 1:1 with input). To achieve the same sensitivity, multiply your old value by `1.6`. Use the "fine sensitivity" option to set the decimal `0-99` sensitivity, if necessary.

Changes:
- Set mouse_carrytics default to on
- Zero mouse position when activating (fixes a bug where the first instance of mouse input can cause a jump)
- Track mouse position only once per game tic
- Unscale mouse input
- Carry fractional vertmouse
- Carry fractional mouse strafe
- Carry mousex / mousey
- Properly track mousewheel activation duration
- Support non-integer sensitivity
- Unlock mouse sensitivity scales
- Show mouse scale values