### PR TITLE
Mess with time

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,20 +17,6 @@ jobs:
       matrix:
         config:
         - {
-            name: "Visual Studio 64-bit",
-            os: windows-2019,
-            build_type: "Release",
-            extra_options: "-A x64",
-            package_name: "vs_x64"
-          }
-        - {
-            name: "Visual Studio 32-bit",
-            os: windows-2019,
-            build_type: "Release",
-            extra_options: "-A Win32",
-            package_name: "vs_win32"
-          }
-        - {
             name: "Linux GCC",
             os: ubuntu-20.04,
             build_type: "Release",

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -37,6 +37,8 @@ set(COMMON_SRC
     dsda/palette.h
     dsda/settings.c
     dsda/settings.h
+    dsda/time.c
+    dsda/time.h
     dstrings.c
     dstrings.h
     d_deh.c

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -97,6 +97,7 @@
 
 #include "z_zone.h"
 
+#include "dsda/settings.h"
 #include "dsda/time.h"
 
 void I_uSleep(unsigned long usecs)
@@ -121,9 +122,10 @@ int I_GetTime_RealTime (void)
 
   t = dsda_ElapsedTime(dsda_timer_realtime);
 
-  if (ms_to_next_tick > 1000/TICRATE || ms_to_next_tick<1) ms_to_next_tick = 1;
   i = t * TICRATE / 1000000;
   ms_to_next_tick = (i + 1) * 1000 / TICRATE - t / 1000;
+  if (ms_to_next_tick > 1000 / TICRATE) ms_to_next_tick = 1;
+  if (ms_to_next_tick < 1) ms_to_next_tick = dsda_LaggySleepMode();
   return i;
 }
 

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -106,20 +106,24 @@ void I_uSleep(unsigned long usecs)
 
 int ms_to_next_tick;
 
-static int basetime = 0;
 int I_GetTime_RealTime (void)
 {
+  static dboolean started = false;
   int i;
-  int t = SDL_GetTicks();
+  unsigned long long t;
 
   //e6y: removing startup delay
-  if (basetime == 0)
-    basetime = t;
-  t -= basetime;
+  if (!started)
+  {
+    started = true;
+    dsda_StartTimer(dsda_timer_realtime);
+  }
 
-  i = t*(TICRATE/5)/200;
-  ms_to_next_tick = (i+1)*200/(TICRATE/5) - t;
+  t = dsda_ElapsedTime(dsda_timer_realtime);
+
   if (ms_to_next_tick > 1000/TICRATE || ms_to_next_tick<1) ms_to_next_tick = 1;
+  i = t * TICRATE / 1000000;
+  ms_to_next_tick = (i + 1) * 1000 / TICRATE - t / 1000;
   return i;
 }
 

--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -505,7 +505,7 @@ void TryRunTics (void)
 #endif
         M_Ticker(); return;
       }
-      //if ((displaytime) < (tic_vars.next-SDL_GetTicks()))
+
       if (gametic > 0)
       {
         WasRenderedInTryRunTics = true;

--- a/prboom2/src/dsda/key_frame.c
+++ b/prboom2/src/dsda/key_frame.c
@@ -15,7 +15,7 @@
 //	DSDA Key Frame
 //
 
-#include "time.h"
+#include <time.h>
 
 #include "doomstat.h"
 #include "s_advsound.h"

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -32,6 +32,7 @@ int dsda_skip_next_wipe;
 int dsda_wipe_at_full_speed;
 int dsda_track_attempts;
 int dsda_fine_sensitivity;
+int dsda_laggy_sleep_mode;
 
 void dsda_InitSettings(void) {
   dsda_ChangeStrictMode();
@@ -60,6 +61,10 @@ void dsda_ChangeStrictMode(void) {
 
 void dsda_SetTas(void) {
   dsda_tas = true;
+}
+
+dboolean dsda_LaggySleepMode(void) {
+  return dsda_laggy_sleep_mode;
 }
 
 double dsda_FineSensitivity(int base) {

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -28,11 +28,13 @@ extern int dsda_exhud;
 extern int dsda_track_attempts;
 extern int dsda_wipe_at_full_speed;
 extern int dsda_fine_sensitivity;
+extern int dsda_laggy_sleep_mode;
 
 void dsda_InitSettings(void);
 int dsda_CompatibilityLevel(void);
 void dsda_ChangeStrictMode(void);
 void dsda_SetTas(void);
+dboolean dsda_LaggySleepMode(void);
 double dsda_FineSensitivity(int base);
 dboolean dsda_StrictMode(void);
 dboolean dsda_CycleGhostColors(void);

--- a/prboom2/src/dsda/time.c
+++ b/prboom2/src/dsda/time.c
@@ -1,0 +1,35 @@
+//
+// Copyright(C) 2020 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Time
+//
+
+#include <time.h>
+
+#include "time.h"
+
+static struct timespec dsda_time[DSDA_TIMER_COUNT];
+
+void dsda_StartTimer(int timer) {
+  clock_gettime(CLOCK_MONOTONIC, &dsda_time[timer]);
+}
+
+unsigned long long dsda_ElapsedTime(int timer) {
+  struct timespec now;
+
+  clock_gettime(CLOCK_MONOTONIC, &now);
+
+  return (now.tv_nsec - dsda_time[timer].tv_nsec) / 1000 +
+         (now.tv_sec - dsda_time[timer].tv_sec) * 1000000;
+}

--- a/prboom2/src/dsda/time.h
+++ b/prboom2/src/dsda/time.h
@@ -1,0 +1,31 @@
+//
+// Copyright(C) 2020 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Time
+//
+
+#ifndef __DSDA_TIME__
+#define __DSDA_TIME__
+
+typedef enum {
+  dsda_timer_displaytime,
+  dsda_timer_tic,
+  dsda_timer_realtime,
+  DSDA_TIMER_COUNT
+} dsda_timer_t;
+
+void dsda_StartTimer(int timer);
+unsigned long long dsda_ElapsedTime(int timer);
+
+#endif

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3482,6 +3482,7 @@ setup_menu_t dsda_gen_settings[] = {
   { "Wipe At Full Speed", S_YESNO, m_null, G_X, G_Y + 7 * 8, { "dsda_wipe_at_full_speed" } },
   { "Track Demo Attempts", S_YESNO, m_null, G_X, G_Y + 8 * 8, { "dsda_track_attempts" } },
   { "Fine Sensitivity", S_NUM, m_null, G_X, G_Y + 9 * 8, { "dsda_fine_sensitivity" } },
+  { "Laggy Sleep Mode", S_YESNO, m_null, G_X, G_Y + 10 * 8, { "dsda_laggy_sleep_mode" } },
 
 #ifdef GL_DOOM
   { "<- PREV", S_SKIP | S_PREV, m_null, KB_PREV, KB_Y + 20 * 8, { gen_settings8 } },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1075,6 +1075,7 @@ default_t defaults[] =
   { "dsda_wipe_at_full_speed", { &dsda_wipe_at_full_speed }, { 1 }, 0, 1, def_bool, ss_stat },
   { "dsda_track_attempts", { &dsda_track_attempts }, { 1 }, 0, 1, def_bool, ss_stat },
   { "dsda_fine_sensitivity", { &dsda_fine_sensitivity }, { 0 }, 0, 99, def_int, ss_stat },
+  { "dsda_laggy_sleep_mode", { &dsda_laggy_sleep_mode }, { 0 }, 0, 1, def_bool, ss_stat },
 
   // NSM
   {"Video capture encoding settings",{NULL},{0},UL,UL,def_none,ss_none},

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -83,7 +83,7 @@ void M_ChangeUncappedFrameRate(void)
 
 void R_InitInterpolation(void)
 {
-  tic_vars.msec = dsda_RealticClockRate() * TICRATE / 100000.0f;
+  tic_vars.tics_per_usec = dsda_RealticClockRate() * TICRATE / 100000000.0f;
 }
 
 typedef fixed_t fixed2_t[2];

--- a/prboom2/src/r_fps.h
+++ b/prboom2/src/r_fps.h
@@ -44,11 +44,8 @@ extern dboolean isExtraDDisplay;
 extern int interpolation_maxobjects;
 
 typedef struct {
-  unsigned int start;
-  unsigned int next;
-  unsigned int step;
+  double tics_per_usec;
   fixed_t frac;
-  float msec;
 } tic_vars_t;
 
 extern tic_vars_t tic_vars;


### PR DESCRIPTION
This PR migrates tick and interpolation timing from `SDL_GetTicks()` to `clock_gettime()`, which pushes our clock precision to microseconds instead of milliseconds.

Why?

### Problem 1
When interpolating frames, we calculate the draw time (thus the `frac` variable) as the current time (in milliseconds) plus the time it took to display the last frame (in milliseconds). Well, unless you're rendering at an exact number of milliseconds, this introduces some odd behaviour in the interpolation code. Let's say you're rendering every 2.5ms, so the displaytime is alternating between 2 and 3.

Frame x: time = x, displaytime = 3 -> draw time = x + 3
Frame x + 1: time = x + 2 (2.5 rounded down), displaytime = 2 -> draw time = x + 4
Frame x + 2: time = x + 5 (2.5 * 2), displaytime = 3 -> draw time = x + 8
Frame x + 3: time = x + 7 (2.5 * 3), displaytime = 2 -> draw time = x + 9

Our interpolation has a variable rate, even though the framerate in this example is constant.

If our rendering time is under a millisecond (often the case for opengl), the displaytime is usually 0 but sometimes 1. This means that when the time finally reaches the next millisecond, we calculate the draw time at +1 (last frame "took" 1 millisecond). On the next frame we calculate the draw time at +0 ("no time" passed in the last frame), so we actually go back in time!

### Problem 2
At 35 fps, there are 28.57 ms per tick. If we measure time in milliseconds, then we advance to the next game tick up to 1 millisecond late. In other words we have on average 0.5ms lag just because of our timer precision.

### Problem 3
With capped fps, we sleep in between tics. Because we're using milliseconds, we truncate our sleep time, which ends up being off by up to 1 ms. Then we loop around and see we are still too early, so we sleep for the last millisecond. In addition to the fact that 1ms is too long at this point, there is also a problem of sleep precision. I tested this out on my computer and any call to SDL_Delay takes at least 2ms. So, with capped fps we have up to 2 ms of lag due to our timer precision and the precision of the sleep function.