### PR TITLE
Add instakill sectors

### DIFF
--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -56,8 +56,6 @@
 #include "heretic/def.h"
 #include "heretic/sb_bar.h"
 
-#define BONUSADD        6
-
 // Ty 03/07/98 - add deh externals
 // Maximums and such were hardcoded values.  Need to externalize those for
 // dehacked support (and future flexibility).  Most var names came from the key

--- a/prboom2/src/p_inter.h
+++ b/prboom2/src/p_inter.h
@@ -44,6 +44,8 @@
 /* Ty 03/09/98 Moved to an int in p_inter.c for deh and externalization */
 #define MAXHEALTH maxhealth
 
+#define BONUSADD        6
+
 /* follow a player exlusively for 3 seconds */
 #define BASETHRESHOLD   (100)
 

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2436,28 +2436,13 @@ void P_PlayerInSpecialSector (player_t* player)
   {
     if (mbf21 && sector->special & DEATH_MASK)
     {
-      switch ((sector->special & DAMAGE_MASK) >> DAMAGE_SHIFT)
-      {
-        case 0: // heal
-          if (player->health < maxhealth)
-          {
-            P_GiveBody(player, maxhealth);
-            player->bonuscount += BONUSADD;
-            if (player == &players[displayplayer])
-              S_StartSound (player->mo, sfx_getpow);
-          }
-          break;
-        case 1: // instant death without radsuit
-          if (!player->powers[pw_ironfeet])
-            P_DamageMobj(player->mo, NULL, NULL, 10000);
-          break;
-        case 2: // instant death even with radsuit
-          P_DamageMobj(player->mo, NULL, NULL, 10000);
-          break;
-        case 3:
-          // reserved
-          break;
-      }
+      dboolean invulnerable = player->cheats & CF_GODMODE || player->powers[pw_invulnerability];
+
+      if (
+        (!invulnerable                || sector->special & DEATH_INVULN) &&
+        (!player->powers[pw_ironfeet] || sector->special & DEATH_RADSUIT)
+      )
+        P_DamageMobj(player->mo, NULL, NULL, 10000);
     }
     else
     {

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2436,11 +2436,9 @@ void P_PlayerInSpecialSector (player_t* player)
   {
     if (mbf21 && sector->special & DEATH_MASK)
     {
-      dboolean invulnerable = player->cheats & CF_GODMODE || player->powers[pw_invulnerability];
-
       if (
-        (!invulnerable                || sector->special & DEATH_INVULN) &&
-        (!player->powers[pw_ironfeet] || sector->special & DEATH_RADSUIT)
+        (!player->powers[pw_invulnerability] || sector->special & DEATH_INVULN) &&
+        (!player->powers[pw_ironfeet]        || sector->special & DEATH_RADSUIT)
       )
         P_DamageMobj(player->mo, NULL, NULL, 10000);
     }

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2434,28 +2434,55 @@ void P_PlayerInSpecialSector (player_t* player)
   }
   else //jff 3/14/98 handle extended sector types for secrets and damage
   {
-    switch ((sector->special&DAMAGE_MASK)>>DAMAGE_SHIFT)
+    if (mbf21 && sector->special & DEATH_MASK)
     {
-      case 0: // no damage
-        break;
-      case 1: // 2/5 damage per 31 ticks
-        if (!player->powers[pw_ironfeet])
-          if (!(leveltime&0x1f))
-            P_DamageMobj (player->mo, NULL, NULL, 5);
-        break;
-      case 2: // 5/10 damage per 31 ticks
-        if (!player->powers[pw_ironfeet])
-          if (!(leveltime&0x1f))
-            P_DamageMobj (player->mo, NULL, NULL, 10);
-        break;
-      case 3: // 10/20 damage per 31 ticks
-        if (!player->powers[pw_ironfeet]
-            || (P_Random(pr_slimehurt)<5))  // take damage even with suit
-        {
-          if (!(leveltime&0x1f))
-            P_DamageMobj (player->mo, NULL, NULL, 20);
-        }
-        break;
+      switch ((sector->special & DAMAGE_MASK) >> DAMAGE_SHIFT)
+      {
+        case 0: // no damage
+          break;
+        case 1: // instant death without radsuit
+          if (!player->powers[pw_ironfeet])
+            P_DamageMobj(player->mo, NULL, NULL, 10000);
+          break;
+        case 2: // instant death even with radsuit
+          P_DamageMobj(player->mo, NULL, NULL, 10000);
+          break;
+        case 3: // heal
+          if (player->health < maxhealth)
+          {
+            P_GiveBody(player, maxhealth);
+            player->bonuscount += BONUSADD;
+            if (player == &players[displayplayer])
+              S_StartSound (player->mo, sfx_getpow);
+          }
+          break;
+      }
+    }
+    else
+    {
+      switch ((sector->special&DAMAGE_MASK)>>DAMAGE_SHIFT)
+      {
+        case 0: // no damage
+          break;
+        case 1: // 2/5 damage per 31 ticks
+          if (!player->powers[pw_ironfeet])
+            if (!(leveltime&0x1f))
+              P_DamageMobj (player->mo, NULL, NULL, 5);
+          break;
+        case 2: // 5/10 damage per 31 ticks
+          if (!player->powers[pw_ironfeet])
+            if (!(leveltime&0x1f))
+              P_DamageMobj (player->mo, NULL, NULL, 10);
+          break;
+        case 3: // 10/20 damage per 31 ticks
+          if (!player->powers[pw_ironfeet]
+              || (P_Random(pr_slimehurt)<5))  // take damage even with suit
+          {
+            if (!(leveltime&0x1f))
+              P_DamageMobj (player->mo, NULL, NULL, 20);
+          }
+          break;
+      }
     }
     if (sector->special&SECRET_MASK)
     {

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -2438,7 +2438,14 @@ void P_PlayerInSpecialSector (player_t* player)
     {
       switch ((sector->special & DAMAGE_MASK) >> DAMAGE_SHIFT)
       {
-        case 0: // no damage
+        case 0: // heal
+          if (player->health < maxhealth)
+          {
+            P_GiveBody(player, maxhealth);
+            player->bonuscount += BONUSADD;
+            if (player == &players[displayplayer])
+              S_StartSound (player->mo, sfx_getpow);
+          }
           break;
         case 1: // instant death without radsuit
           if (!player->powers[pw_ironfeet])
@@ -2447,14 +2454,8 @@ void P_PlayerInSpecialSector (player_t* player)
         case 2: // instant death even with radsuit
           P_DamageMobj(player->mo, NULL, NULL, 10000);
           break;
-        case 3: // heal
-          if (player->health < maxhealth)
-          {
-            P_GiveBody(player, maxhealth);
-            player->bonuscount += BONUSADD;
-            if (player == &players[displayplayer])
-              S_StartSound (player->mo, sfx_getpow);
-          }
+        case 3:
+          // reserved
           break;
       }
     }

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -86,6 +86,13 @@
 #define PUSH_MASK       0x200
 #define PUSH_SHIFT      9
 
+// reserved by boom spec - not implemented?
+// bit 10: suppress all sounds within the sector
+// bit 11: disable any sounds due to floor or ceiling motion by the sector
+
+// mbf21
+#define DEATH_MASK 0x1000 // 12th bit
+
 //jff 02/04/98 Define masks, shifts, for fields in
 // generalized linedef types
 

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -92,6 +92,8 @@
 
 // mbf21
 #define DEATH_MASK 0x1000 // 12th bit
+#define DEATH_RADSUIT 0x20 // 5th bit
+#define DEATH_INVULN 0x40 // 6th bit
 
 //jff 02/04/98 Define masks, shifts, for fields in
 // generalized linedef types

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -91,9 +91,9 @@
 // bit 11: disable any sounds due to floor or ceiling motion by the sector
 
 // mbf21
-#define DEATH_MASK 0x1000 // 12th bit
-#define DEATH_RADSUIT 0x20 // 5th bit
-#define DEATH_INVULN 0x40 // 6th bit
+#define DEATH_MASK 0x1000 // bit 12
+#define DEATH_RADSUIT 0x20 // bit 5
+#define DEATH_INVULN 0x40 // bit 6
 
 //jff 02/04/98 Define masks, shifts, for fields in
 // generalized linedef types


### PR DESCRIPTION
Bit 12 of sector special toggles the meaning of the damage bits (5, 6):

```
Dec Bit 6-5   Description
--------------------------------------------------------------------------------
0   00        Kills a player if they have neither a rad suit nor invulnerability
32  01        Kills a player unless they have invulnerability
64  10        Kills a player unless they have a radsuit
96  11        Kills a player
```

---

Nothing here is set in stone yet - this is putting the logic in place but if it needs to be other bits then it can be changed.