### PR TITLE
Add "Ammo per shot" DEHACKED field

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1252,7 +1252,8 @@ static const char *deh_weapon[] = // CPhipps - static const*
   "Select frame",   // .downstate
   "Bobbing frame",  // .readystate
   "Shooting frame", // .atkstate
-  "Firing frame"    // .flashstate
+  "Firing frame",   // .flashstate
+  "Ammo per shot",  // .ammopershot [XA] new to mbf21
 };
 
 // CHEATS - Dehacked block name = "Cheat"
@@ -2357,7 +2358,13 @@ static void deh_procWeapon(DEHFILE *fpin, FILE* fpout, char *line)
                 if (!deh_strcasecmp(key,deh_weapon[5]))  // Firing frame
                   weaponinfo[indexnum].flashstate = (int)value;
                 else
-                  if (fpout) fprintf(fpout,"Invalid weapon string index for '%s'\n",key);
+                  if (!deh_strcasecmp(key,deh_weapon[6]))  // Ammo per shot
+                    {
+                      weaponinfo[indexnum].ammopershot = (int)value;
+                      weaponinfo[indexnum].intflags |= WIF_ENABLEAPS;
+                    }
+                  else
+                    if (fpout) fprintf(fpout,"Invalid weapon string index for '%s'\n",key);
     }
   return;
 }
@@ -2635,7 +2642,7 @@ static void deh_procMisc(DEHFILE *fpin, FILE* fpout, char *line) // done
                                   idkfa_armor_class = (int)value;
                                 else
                                   if (!deh_strcasecmp(key,deh_misc[14]))  // BFG Cells/Shot
-                                    bfgcells = (int)value;
+                                    weaponinfo[MT_BFG].ammopershot = bfgcells = (int)value;
                                   else
                                     if (!deh_strcasecmp(key,deh_misc[15])) { // Monsters Infight
                                       // e6y: Dehacked support - monsters infight

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -57,6 +57,18 @@
 #define TRUE 1
 #define FALSE 0
 
+static dboolean bfgcells_modified = false;
+
+void CheckDehConsistency(void)
+{
+  if (
+    bfgcells_modified &&
+    weaponinfo[MT_BFG].intflags & WIF_ENABLEAPS &&
+    bfgcells != weaponinfo[MT_BFG].ammopershot
+  )
+    I_Error("Mismatch between bfgcells and bfg ammo per shot modifications! Check your dehacked.");
+}
+
 // e6y: for compatibility with BOOM deh parser
 int deh_strcasecmp(const char *str1, const char *str2)
 {
@@ -2719,7 +2731,10 @@ static void deh_procMisc(DEHFILE *fpin, FILE* fpout, char *line) // done
                                   idkfa_armor_class = (int)value;
                                 else
                                   if (!deh_strcasecmp(key,deh_misc[14]))  // BFG Cells/Shot
+                                  {
                                     weaponinfo[MT_BFG].ammopershot = bfgcells = (int)value;
+                                    bfgcells_modified = true;
+                                  }
                                   else
                                     if (!deh_strcasecmp(key,deh_misc[15])) { // Monsters Infight
                                       // e6y: Dehacked support - monsters infight

--- a/prboom2/src/d_deh.h
+++ b/prboom2/src/d_deh.h
@@ -45,6 +45,7 @@
 extern int deh_apply_cheats;
 
 void ProcessDehFile(const char *filename, const char *outfilename, int lumpnum);
+void CheckDehConsistency(void);
 
 //
 //      Ty 03/22/98 - note that we are keeping the english versions and

--- a/prboom2/src/d_items.c
+++ b/prboom2/src/d_items.c
@@ -64,7 +64,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_PUNCH,
     S_PUNCH1,
     S_NULL,
-    S_NULL
+    S_NULL,
+    0,
+    0
   },
   {
     // pistol
@@ -74,7 +76,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_PISTOL,
     S_PISTOL1,
     S_NULL,
-    S_PISTOLFLASH
+    S_PISTOLFLASH,
+    1,
+    0
   },
   {
     // shotgun
@@ -84,7 +88,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_SGUN,
     S_SGUN1,
     S_NULL,
-    S_SGUNFLASH1
+    S_SGUNFLASH1,
+    1,
+    0
   },
   {
     // chaingun
@@ -94,7 +100,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_CHAIN,
     S_CHAIN1,
     S_NULL,
-    S_CHAINFLASH1
+    S_CHAINFLASH1,
+    1,
+    0
   },
   {
     // missile launcher
@@ -104,7 +112,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_MISSILE,
     S_MISSILE1,
     S_NULL,
-    S_MISSILEFLASH1
+    S_MISSILEFLASH1,
+    1,
+    0
   },
   {
     // plasma rifle
@@ -114,7 +124,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_PLASMA,
     S_PLASMA1,
     S_NULL,
-    S_PLASMAFLASH1
+    S_PLASMAFLASH1,
+    1,
+    0
   },
   {
     // bfg 9000
@@ -124,7 +136,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_BFG,
     S_BFG1,
     S_NULL,
-    S_BFGFLASH1
+    S_BFGFLASH1,
+    40,
+    0
   },
   {
     // chainsaw
@@ -134,7 +148,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_SAW,
     S_SAW1,
     S_NULL,
-    S_NULL
+    S_NULL,
+    0,
+    0
   },
   {
     // super shotgun
@@ -144,7 +160,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_DSGUN,
     S_DSGUN1,
     S_NULL,
-    S_DSGUNFLASH1
+    S_DSGUNFLASH1,
+    2,
+    0
   },
 
   // dseg03:00082D90                 weaponinfo_t <5, 46h, 45h, 43h, 47h, 0>
@@ -162,7 +180,9 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_NULL,
     S_NULL,
-    S_NULL
+    S_NULL,
+    0,
+    0
   },
   {
     // preved medved weapon
@@ -172,13 +192,15 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_NULL,
     S_NULL,
-    S_NULL
+    S_NULL,
+    0,
+    0
   },
 };
 
-int ammopershot[NUMWEAPONS+2] = {0, 1, 1, 1, 1, 1, 40, 0, 2, 0, 0};
-
 // heretic
+
+#include "heretic/def.h"
 
 weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     {                           // Staff
@@ -188,7 +210,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_STAFFREADY,              // readystate
      HERETIC_S_STAFFATK1_1,             // atkstate
      HERETIC_S_STAFFATK1_1,             // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     0,                                 // ammopershot
+     0                                  // intflags
      },
     {                           // Gold wand
      am_goldwand,               // ammo
@@ -197,7 +221,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_GOLDWANDREADY,           // readystate
      HERETIC_S_GOLDWANDATK1_1,          // atkstate
      HERETIC_S_GOLDWANDATK1_1,          // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_GWND_AMMO_1,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Crossbow
      am_crossbow,               // ammo
@@ -206,7 +232,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_CRBOW1,                  // readystate
      HERETIC_S_CRBOWATK1_1,             // atkstate
      HERETIC_S_CRBOWATK1_1,             // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_CBOW_AMMO_1,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Blaster
      am_blaster,                // ammo
@@ -215,7 +243,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_BLASTERREADY,            // readystate
      HERETIC_S_BLASTERATK1_1,           // atkstate
      HERETIC_S_BLASTERATK1_3,           // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_BLSR_AMMO_1,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Skull rod
      am_skullrod,               // ammo
@@ -224,7 +254,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_HORNRODREADY,            // readystae
      HERETIC_S_HORNRODATK1_1,           // atkstate
      HERETIC_S_HORNRODATK1_1,           // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_SKRD_AMMO_1,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Phoenix rod
      am_phoenixrod,             // ammo
@@ -233,7 +265,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_PHOENIXREADY,            // readystate
      HERETIC_S_PHOENIXATK1_1,           // atkstate
      HERETIC_S_PHOENIXATK1_1,           // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_PHRD_AMMO_1,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Mace
      am_mace,                   // ammo
@@ -242,7 +276,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_MACEREADY,               // readystate
      HERETIC_S_MACEATK1_1,              // atkstate
      HERETIC_S_MACEATK1_2,              // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_MACE_AMMO_1,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Gauntlets
      am_noammo,                 // ammo
@@ -251,7 +287,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_GAUNTLETREADY,           // readystate
      HERETIC_S_GAUNTLETATK1_1,          // atkstate
      HERETIC_S_GAUNTLETATK1_3,          // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     0,                                  // ammopershot
+     0                                  // intflags
      },
     {                           // Beak
      am_noammo,                 // ammo
@@ -260,7 +298,9 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
      HERETIC_S_BEAKREADY,               // readystate
      HERETIC_S_BEAKATK1_1,              // atkstate
      HERETIC_S_BEAKATK1_1,              // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     0,                                 // ammopershot
+     0                                  // intflags
      }
 };
 
@@ -272,7 +312,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_STAFFREADY2_1,           // readystate
      HERETIC_S_STAFFATK2_1,             // atkstate
      HERETIC_S_STAFFATK2_1,             // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     0,                                 // ammopershot
+     0                                  // intflags
      },
     {                           // Gold wand
      am_goldwand,               // ammo
@@ -281,7 +323,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_GOLDWANDREADY,           // readystate
      HERETIC_S_GOLDWANDATK2_1,          // atkstate
      HERETIC_S_GOLDWANDATK2_1,          // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_GWND_AMMO_2,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Crossbow
      am_crossbow,               // ammo
@@ -290,7 +334,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_CRBOW1,                  // readystate
      HERETIC_S_CRBOWATK2_1,             // atkstate
      HERETIC_S_CRBOWATK2_1,             // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_CBOW_AMMO_2,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Blaster
      am_blaster,                // ammo
@@ -299,7 +345,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_BLASTERREADY,            // readystate
      HERETIC_S_BLASTERATK2_1,           // atkstate
      HERETIC_S_BLASTERATK2_3,           // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_BLSR_AMMO_2,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Skull rod
      am_skullrod,               // ammo
@@ -308,7 +356,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_HORNRODREADY,            // readystae
      HERETIC_S_HORNRODATK2_1,           // atkstate
      HERETIC_S_HORNRODATK2_1,           // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_SKRD_AMMO_2,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Phoenix rod
      am_phoenixrod,             // ammo
@@ -317,7 +367,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_PHOENIXREADY,            // readystate
      HERETIC_S_PHOENIXATK2_1,           // atkstate
      HERETIC_S_PHOENIXATK2_2,           // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_PHRD_AMMO_2,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Mace
      am_mace,                   // ammo
@@ -326,7 +378,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_MACEREADY,               // readystate
      HERETIC_S_MACEATK2_1,              // atkstate
      HERETIC_S_MACEATK2_1,              // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     USE_MACE_AMMO_2,                   // ammopershot
+     0                                  // intflags
      },
     {                           // Gauntlets
      am_noammo,                 // ammo
@@ -335,7 +389,9 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_GAUNTLETREADY2_1,        // readystate
      HERETIC_S_GAUNTLETATK2_1,          // atkstate
      HERETIC_S_GAUNTLETATK2_3,          // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     0,                                 // ammopershot
+     0                                  // intflags
      },
     {                           // Beak
      am_noammo,                 // ammo
@@ -344,6 +400,8 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
      HERETIC_S_BEAKREADY,               // readystate
      HERETIC_S_BEAKATK2_1,              // atkstate
      HERETIC_S_BEAKATK2_1,              // holdatkstate
-     HERETIC_S_NULL                     // flashstate
+     HERETIC_S_NULL,                    // flashstate
+     0,                                 // ammopershot
+     0                                  // intflags
      }
 };

--- a/prboom2/src/d_items.h
+++ b/prboom2/src/d_items.h
@@ -44,7 +44,7 @@
 //
 // Internal weapon flags
 //
-#define WIF_ENABLEAPS (0x0000000000000001) // [XA] enable "ammo per shot" field for native Doom weapon codepointers
+#define WIF_ENABLEAPS 0x00000001 // [XA] enable "ammo per shot" field for native Doom weapon codepointers
 
 // haleyjd 09/11/07: weapon flags
 //

--- a/prboom2/src/d_items.h
+++ b/prboom2/src/d_items.h
@@ -41,6 +41,10 @@
 #pragma interface
 #endif
 
+//
+// Internal weapon flags
+//
+#define WIF_ENABLEAPS (0x0000000000000001) // [XA] enable "ammo per shot" field for native Doom weapon codepointers
 
 /* Weapon info: sprite frames, ammunition use. */
 typedef struct
@@ -52,10 +56,11 @@ typedef struct
   int         atkstate;
   int         holdatkstate;
   int         flashstate;
+  int         ammopershot;
+  int         intflags;
 } weaponinfo_t;
 
 extern weaponinfo_t doom_weaponinfo[NUMWEAPONS+2];
-extern int ammopershot[NUMWEAPONS+2];
 
 // heretic
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1896,6 +1896,7 @@ static void D_DoomMainSetup(void)
 	  }
   }
 
+  CheckDehConsistency();
 
   V_InitColorTranslation(); //jff 4/24/98 load color translation lumps
 

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -1377,7 +1377,7 @@ void HU_widget_build_ammo(void)
 
     // set the display color from the percentage of total ammo held
     w_ammo.cm = HU_GetAmmoColor(ammo, fullammo, CR_BLUE,
-      ammopershot[plr->readyweapon], plr->backpack);
+      weaponinfo[plr->readyweapon].ammopershot, plr->backpack);
   }
   // transfer the init string to the widget
   s = hud_ammostr;
@@ -1681,7 +1681,7 @@ void HU_widget_build_weapon(void)
     hud_weapstr[i++] = '\x1b'; //jff 3/26/98 use ESC not '\' for paths
     if (weaponinfo[w].ammo==am_noammo) //jff 3/14/98 show berserk on HUD
       hud_weapstr[i++] = plr->powers[pw_strength]? '0'+CR_GREEN : '0'+CR_GRAY;
-    else if (ammo<ammopershot[w])
+    else if (ammo<weaponinfo[w].ammopershot)
       hud_weapstr[i++] = '0'+CR_BROWN;
     else if (fullammo && ((ammo==fullammo) ||
       (ammo_colour_behaviour == ammo_colour_behaviour_no &&
@@ -2133,7 +2133,7 @@ void HU_widget_build_ammo_big(void)
     // set the display color from the percentage of total ammo held
     if (!sts_always_red)
       w_ammo_big.cm = HU_GetAmmoColor(ammo, fullammo, CR_BLUE2,
-        ammopershot[plr->readyweapon], plr->backpack);
+        weaponinfo[plr->readyweapon].ammopershot, plr->backpack);
 
     // transfer the init string to the widget
     s = ammostr;

--- a/prboom2/src/mbf21.md
+++ b/prboom2/src/mbf21.md
@@ -46,6 +46,12 @@ This is proof-of-concept implemented in dsda-doom.
 #### Fix generalized crusher walkover lines
 - [commit](https://github.com/kraflab/dsda-doom/commit/76776f721b5d1d8a1a0ae95daab525cf8183ce44)
 
+#### Fix negative ammo counts
+- [PR](https://github.com/kraflab/dsda-doom/pull/24)
+
+#### Fix weapon autoswitch not taking DEHACKED ammotype changes into account
+- [PR](https://github.com/kraflab/dsda-doom/pull/24)
+
 #### New comp flags
 - comp_ledgeblock: [commit](https://github.com/kraflab/dsda-doom/commit/4423cbcf8580e4d3839ddf4403b1fb4a0f993507)
 
@@ -135,6 +141,20 @@ In this example:
 | MF2_E4M8BOSS       | MF2_E4M8BOSS       | E4M8 boss (mastermind)                                                                         |
 | MF2_RIP (TODO)     | MF3_RIP (TODO)     | Ripper projectile (does not disappear on impact)                                               |
 | MF2_NEUTRAL_SPLASH | ?                  | Splash damage from this thing is not affected by splash groups (barrel)                        |
+
+#### New DEHACKED "Ammo per shot" Weapon field
+- [PR](https://github.com/kraflab/dsda-doom/pull/24)
+- Add `Ammo per shot = X` in the Weapon definition.
+- Value must be a nonnegative integer.
+- Tools should assume this value is undefined for all vanilla weapons (i.e. always write it to the patch if the user specifies any valid value)
+- Weapons WITH this field set will use the ammo-per-shot value when:
+  - Checking if there is enough ammo before firing
+  - Determining if the weapon has ammo during weapon auto-switch
+  - Deciding how much ammo to subtract in native Doom weapon attack pointers
+    - Exceptions: A_Saw and A_Punch will never attempt to subtract ammo.
+  - The `amount` param is zero for certain new MBF21 DEHACKED codepointers (see below).
+- Weapons WITHOUT this field set will use vanilla Doom semantics for all above behaviors.
+- For backwards-compatibility, setting the `BFG cells/shot` misc field will also set the BFG weapon's `Ammo per shot` field (but not vice-versa).
 
 #### New DEHACKED Codepointers
 - [PR](https://github.com/kraflab/dsda-doom/pull/20)

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -303,17 +303,17 @@ int P_SwitchWeapon(player_t *player)
   int currentweapon, newweapon;
   int i;
 
-  prefer = weapon_preferences[demo_compatibility != 0]; // killough 3/22/98
-  currentweapon = player->readyweapon;
-  newweapon = currentweapon;
-  i = NUMWEAPONS + 1;   // killough 5/2/98
-
   // [XA] use fixed behavior for mbf21. no need
   // for a discrete compat option for this, as
   // it doesn't impact demo playback (weapon
   // switches are saved in the demo itself)
   if (mbf21)
     return P_SwitchWeaponMBF21(player);
+
+  prefer = weapon_preferences[demo_compatibility != 0]; // killough 3/22/98
+  currentweapon = player->readyweapon;
+  newweapon = currentweapon;
+  i = NUMWEAPONS + 1;   // killough 5/2/98
 
   // killough 2/8/98: follow preferences and fix BFG/SSG bugs
 

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -227,13 +227,16 @@ int weapon_attack_alignment=0;
 
 static int P_SwitchWeaponMBF21(player_t *player)
 {
-  int *prefer = weapon_preferences[0];
-  int currentweapon = player->readyweapon;
-  int newweapon = currentweapon;
-  int i = NUMWEAPONS+1;
-
+  int *prefer;
+  int currentweapon, newweapon;
+  int i;
   weapontype_t checkweapon;
   ammotype_t ammotype;
+
+  prefer = weapon_preferences[0];
+  currentweapon = player->readyweapon;
+  newweapon = currentweapon;
+  i = NUMWEAPONS + 1;
 
   do
   {
@@ -284,7 +287,7 @@ static int P_SwitchWeaponMBF21(player_t *player)
         newweapon = checkweapon;
     }
   }
-  while (newweapon==currentweapon && --i);
+  while (newweapon == currentweapon && --i);
   return newweapon;
 }
 
@@ -296,10 +299,14 @@ static int P_SwitchWeaponMBF21(player_t *player)
 
 int P_SwitchWeapon(player_t *player)
 {
-  int *prefer = weapon_preferences[demo_compatibility!=0]; // killough 3/22/98
-  int currentweapon = player->readyweapon;
-  int newweapon = currentweapon;
-  int i = NUMWEAPONS+1;   // killough 5/2/98
+  int *prefer;
+  int currentweapon, newweapon;
+  int i;
+
+  prefer = weapon_preferences[demo_compatibility != 0]; // killough 3/22/98
+  currentweapon = player->readyweapon;
+  newweapon = currentweapon;
+  i = NUMWEAPONS + 1;   // killough 5/2/98
 
   // [XA] use fixed behavior for mbf21. no need
   // for a discrete compat option for this, as
@@ -356,7 +363,7 @@ int P_SwitchWeapon(player_t *player)
           newweapon = wp_supershotgun;
         break;
       }
-  while (newweapon==currentweapon && --i);          // killough 5/2/98
+  while (newweapon == currentweapon && --i);          // killough 5/2/98
   return newweapon;
 }
 
@@ -398,7 +405,7 @@ dboolean P_CheckAmmo(player_t *player)
     else
       if (player->readyweapon == wp_supershotgun)        // Double barrel.
         count = 2;
-	  else
+      else
         count = 1;
 
   // Some do not need ammunition anyway.
@@ -437,7 +444,7 @@ dboolean P_CheckAmmo(player_t *player)
 // have to worry about any compatibility shenanigans.
 //
 
-void P_SubtractAmmo(struct player_s *player, int compat_amt)
+void P_SubtractAmmo(struct player_s *player, int vanilla_amount)
 {
   int amount;
   ammotype_t ammotype = weaponinfo[player->readyweapon].ammo;
@@ -448,7 +455,7 @@ void P_SubtractAmmo(struct player_s *player, int compat_amt)
   if (mbf21 && (weaponinfo[player->readyweapon].intflags & WIF_ENABLEAPS))
     amount = weaponinfo[player->readyweapon].ammopershot;
   else
-    amount = compat_amt;
+    amount = vanilla_amount;
 
   if (!mbf21 || player->ammo[ammotype] >= amount)
     player->ammo[ammotype] -= amount;
@@ -2293,19 +2300,19 @@ void P_UpdateBeak(player_t * player, pspdef_t * psp)
 dboolean Heretic_P_CheckAmmo(player_t * player)
 {
     ammotype_t ammo;
-    weaponinfo_t *weaponinfo;
+    weaponinfo_t *checkweaponinfo;
     int count;
 
     ammo = wpnlev1info[player->readyweapon].ammo;
     if (player->powers[pw_weaponlevel2] && !deathmatch)
     {
-      weaponinfo = wpnlev2info;
+      checkweaponinfo = wpnlev2info;
     }
     else
     {
-      weaponinfo = wpnlev1info;
+      checkweaponinfo = wpnlev1info;
     }
-    count = weaponinfo[player->readyweapon].ammopershot;
+    count = checkweaponinfo[player->readyweapon].ammopershot;
     if (ammo == am_noammo || player->ammo[ammo] >= count)
     {
         return (true);
@@ -2314,26 +2321,26 @@ dboolean Heretic_P_CheckAmmo(player_t * player)
     do
     {
         if (player->weaponowned[wp_skullrod]
-            && player->ammo[am_skullrod] > weaponinfo[wp_skullrod].ammopershot)
+            && player->ammo[am_skullrod] > checkweaponinfo[wp_skullrod].ammopershot)
         {
             player->pendingweapon = wp_skullrod;
         }
         else if (player->weaponowned[wp_blaster]
-                 && player->ammo[am_blaster] > weaponinfo[wp_blaster].ammopershot)
+                 && player->ammo[am_blaster] > checkweaponinfo[wp_blaster].ammopershot)
         {
             player->pendingweapon = wp_blaster;
         }
         else if (player->weaponowned[wp_crossbow]
-                 && player->ammo[am_crossbow] > weaponinfo[wp_crossbow].ammopershot)
+                 && player->ammo[am_crossbow] > checkweaponinfo[wp_crossbow].ammopershot)
         {
             player->pendingweapon = wp_crossbow;
         }
         else if (player->weaponowned[wp_mace]
-                 && player->ammo[am_mace] > weaponinfo[wp_mace].ammopershot)
+                 && player->ammo[am_mace] > checkweaponinfo[wp_mace].ammopershot)
         {
             player->pendingweapon = wp_mace;
         }
-        else if (player->ammo[am_goldwand] > weaponinfo[wp_goldwand].ammopershot)
+        else if (player->ammo[am_goldwand] > checkweaponinfo[wp_goldwand].ammopershot)
         {
             player->pendingweapon = wp_goldwand;
         }
@@ -2342,7 +2349,7 @@ dboolean Heretic_P_CheckAmmo(player_t * player)
             player->pendingweapon = wp_gauntlets;
         }
         else if (player->weaponowned[wp_phoenixrod]
-                 && player->ammo[am_phoenixrod] > weaponinfo[wp_phoenixrod].ammopershot)
+                 && player->ammo[am_phoenixrod] > checkweaponinfo[wp_phoenixrod].ammopershot)
         {
             player->pendingweapon = wp_phoenixrod;
         }

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -440,13 +440,18 @@ dboolean P_CheckAmmo(player_t *player)
 void P_SubtractAmmo(struct player_s *player, int compat_amt)
 {
   int amount;
+  ammotype_t ammotype = weaponinfo[player->readyweapon].ammo;
+
+  if (mbf21 && ammotype == am_noammo)
+    return; // [XA] hmm... I guess vanilla/boom will go out of bounds then?
 
   if (mbf21 && (weaponinfo[player->readyweapon].intflags & WIF_ENABLEAPS))
     amount = weaponinfo[player->readyweapon].ammopershot;
   else
     amount = compat_amt;
 
-  player->ammo[weaponinfo[player->readyweapon].ammo] -= amount;
+  if (!mbf21 || player->ammo[ammotype] >= amount)
+    player->ammo[ammotype] -= amount;
 }
 
 //

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -457,8 +457,10 @@ void P_SubtractAmmo(struct player_s *player, int vanilla_amount)
   else
     amount = vanilla_amount;
 
-  if (!mbf21 || player->ammo[ammotype] >= amount)
-    player->ammo[ammotype] -= amount;
+  player->ammo[ammotype] -= amount;
+
+  if (mbf21 && player->ammo[ammotype] < 0)
+    player->ammo[ammotype] = 0;
 }
 
 //

--- a/prboom2/src/p_pspr.h
+++ b/prboom2/src/p_pspr.h
@@ -97,8 +97,8 @@ int P_WeaponPreferred(int w1, int w2);
 
 struct player_s;
 int P_SwitchWeapon(struct player_s *player);
-int P_GetAmmoPerShot(struct player_s *player);
 dboolean P_CheckAmmo(struct player_s *player);
+void P_SubtractAmmo(struct player_s *player, int compat_amt);
 void P_SetupPsprites(struct player_s *curplayer);
 void P_MovePsprites(struct player_s *curplayer);
 void P_DropWeapon(struct player_s *player);


### PR DESCRIPTION
Adds a new `Ammo per shot` field to DEHACKED. Implementation mirrors Eternity's, for forward-compat n' whatnot.

A summary of sorts:
- Weapons now use this field to determine if the player has enough ammo to fire, instead of hardcoding the value for each weapon.
- Weapon autoswitch has been fixed in general to check the correct ammotype & ammo use for each weapon, rather than assume the vanilla ammotypes (this is an ooooold bug from ever since DEHACKED was introduced).
- The new `A_ConsumeAmmo` and `A_CheckAmmo` MBF21 DEHACKED codepointers will use the ready weapon's `Ammo per shot` field if the `amount` arg is set to zero.
- Vanilla doom weapon fire codepointer behavior varies on whether or not the `Ammo per shot` field is explicitly set on a weapon.
  - If set, the ready weapon's `Ammo per shot` field is subtracted from the weapon's ammo type.
  - If not set, the amount of ammo subtracted depends on the weapon codepointer being used (e.g. A_FireShotgun2 will subtract 2, A_FireBFG will subtract BFGCELLS -- this mirrors vanilla Doom behavior)
- For general sanity, the "BFG Cells/Shot" field will also set the BFG weapon's `Ammo per shot` field.

There's a little bit of refactoring of things that touches a bit of Heretic (namely, all the various ammo-per-shot arrays for the doom/heretic weapons were replaced with the new weaponinfo_t ammopershot field ), though this feature is not yet fully implemented for Heretic 'cause it doesn't do DEH. ;) -- I tested Heretic to make sure it all works as intended still (and the spec passes), so all should be well there.

[Will update mbf21.md here in a bit; need to make the PR first. ;]