### PR TITLE
Add mbf21 ammo autoswitch handling

### DIFF
--- a/prboom2/src/d_items.c
+++ b/prboom2/src/d_items.c
@@ -67,7 +67,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     0,
     0,
-    WPF_FLEEMELEE
+    WPF_FLEEMELEE | WPF_AUTOSWITCHFROM
   },
   {
     // pistol
@@ -80,7 +80,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_PISTOLFLASH,
     1,
     0,
-    WPF_NOFLAG
+    WPF_NOFLAG | WPF_AUTOSWITCHFROM | WPF_AUTOSWITCHTO
   },
   {
     // shotgun
@@ -93,7 +93,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_SGUNFLASH1,
     1,
     0,
-    WPF_NOFLAG
+    WPF_NOFLAG | WPF_AUTOSWITCHTO
   },
   {
     // chaingun
@@ -106,7 +106,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_CHAINFLASH1,
     1,
     0,
-    WPF_NOFLAG
+    WPF_NOFLAG | WPF_AUTOSWITCHTO
   },
   {
     // missile launcher
@@ -119,7 +119,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_MISSILEFLASH1,
     1,
     0,
-    WPF_NOAUTOFIRE
+    WPF_NOAUTOFIRE | WPF_AUTOSWITCHTO
   },
   {
     // plasma rifle
@@ -132,7 +132,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_PLASMAFLASH1,
     1,
     0,
-    WPF_NOFLAG
+    WPF_NOFLAG | WPF_AUTOSWITCHTO
   },
   {
     // bfg 9000
@@ -145,7 +145,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_BFGFLASH1,
     40,
     0,
-    WPF_NOAUTOFIRE
+    WPF_NOAUTOFIRE | WPF_AUTOSWITCHTO
   },
   {
     // chainsaw
@@ -171,7 +171,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_DSGUNFLASH1,
     2,
     0,
-    WPF_NOFLAG
+    WPF_NOFLAG | WPF_AUTOSWITCHTO
   },
 
   // dseg03:00082D90                 weaponinfo_t <5, 46h, 45h, 43h, 47h, 0>

--- a/prboom2/src/d_items.h
+++ b/prboom2/src/d_items.h
@@ -53,7 +53,8 @@
 #define WPF_SILENT         0x00000002 // weapon is silent
 #define WPF_NOAUTOFIRE     0x00000004 // weapon won't autofire in A_WeaponReady
 #define WPF_FLEEMELEE      0x00000008 // monsters consider it a melee weapon
-#define WPF_AUTOSWITCHFROM 0x00000010 // switches away if ammo for a better weapon is picked up
+#define WPF_AUTOSWITCHFROM 0x00000010 // can be switched away from when ammo is picked up
+#define WPF_AUTOSWITCHTO   0x00000020 // can be switched to when ammo is picked up
 
 /* Weapon info: sprite frames, ammunition use. */
 typedef struct


### PR DESCRIPTION
Opens up more configuration possibilities for the "pick up ammo -> switch to better weapon" function, and accounts for ammopershot changes as well.

Current default is that all ammo weapons are enabled for switching TO, and fist / pistol for switching FROM.