### PR TITLE
MBF21 State Args

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -59,16 +59,6 @@
 
 static dboolean bfgcells_modified = false;
 
-void CheckDehConsistency(void)
-{
-  if (
-    bfgcells_modified &&
-    weaponinfo[MT_BFG].intflags & WIF_ENABLEAPS &&
-    bfgcells != weaponinfo[MT_BFG].ammopershot
-  )
-    I_Error("Mismatch between bfgcells and bfg ammo per shot modifications! Check your dehacked.");
-}
-
 // e6y: for compatibility with BOOM deh parser
 int deh_strcasecmp(const char *str1, const char *str2)
 {
@@ -1362,6 +1352,7 @@ typedef struct {
   actionf_t cptr;  // actual pointer to the subroutine
   const char *lookup;  // mnemonic lookup string to be specified in BEX
   // CPhipps - const*
+  int argcount;  // [XA] number of mbf21 args this action uses, if any
 } deh_bexptr;
 
 static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
@@ -1456,18 +1447,18 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_Stop,            "A_Stop"},
 
   // [XA] New mbf21 codepointers
-  {A_SpawnFacing,         "A_SpawnFacing"},
-  {A_MonsterProjectile,   "A_MonsterProjectile"},
-  {A_MonsterBulletAttack, "A_MonsterBulletAttack"},
-  {A_RadiusDamage,        "A_RadiusDamage"},
-  {A_WeaponProjectile,    "A_WeaponProjectile"},
-  {A_WeaponBulletAttack,  "A_WeaponBulletAttack"},
-  {A_WeaponSound,         "A_WeaponSound"},
-  {A_WeaponJump,          "A_WeaponJump"},
-  {A_ConsumeAmmo,         "A_ConsumeAmmo"},
-  {A_CheckAmmo,           "A_CheckAmmo"},
-  {A_RefireTo,            "A_RefireTo"},
-  {A_GunFlashTo,          "A_GunFlashTo"},
+  {A_SpawnFacing,         "A_SpawnFacing", 2},
+  {A_MonsterProjectile,   "A_MonsterProjectile", 2},
+  {A_MonsterBulletAttack, "A_MonsterBulletAttack", 2},
+  {A_RadiusDamage,        "A_RadiusDamage", 2},
+  {A_WeaponProjectile,    "A_WeaponProjectile", 2},
+  {A_WeaponBulletAttack,  "A_WeaponBulletAttack", 2},
+  {A_WeaponSound,         "A_WeaponSound", 2},
+  {A_WeaponJump,          "A_WeaponJump", 2},
+  {A_ConsumeAmmo,         "A_ConsumeAmmo", 1},
+  {A_CheckAmmo,           "A_CheckAmmo", 2},
+  {A_RefireTo,            "A_RefireTo", 2},
+  {A_GunFlashTo,          "A_GunFlashTo", 2},
 
   // This NULL entry must be the last in the list
   {NULL,              "A_NULL"},  // Ty 05/16/98
@@ -3521,4 +3512,48 @@ dboolean deh_GetData(char *s, char *k, uint_64_t *l, char **strval, FILE *fpout)
   // even if pointing at the zero byte.
 
   return(okrc);
+}
+
+//
+// CheckDehConsistency
+//
+void CheckDehConsistency(void)
+{
+  int i, j, maxargs;
+  dboolean found;
+  const char *bexptr_name;
+
+  // sanity-check bfgcells and bfg ammopershot
+  if (
+    bfgcells_modified &&
+    weaponinfo[MT_BFG].intflags & WIF_ENABLEAPS &&
+    bfgcells != weaponinfo[MT_BFG].ammopershot
+  )
+    I_Error("Mismatch between bfgcells and bfg ammo per shot modifications! Check your dehacked.");
+
+  // ensure states don't use more mbf21 args than their
+  // action pointer expects, for future-proofing's sake
+  for (i = 0; i < num_states; i++)
+  {
+    bexptr_name = "(NULL)";
+    maxargs = 0;
+    found = FALSE;
+    j= -1;
+
+    do
+    {
+      ++j;
+      if (states[i].action == deh_bexptrs[j].cptr)
+      {
+        bexptr_name = deh_bexptrs[j].lookup;
+        maxargs = deh_bexptrs[j].argcount;
+        found = TRUE;
+      }
+    } while (!found && (deh_bexptrs[j].cptr != NULL));
+
+    for(j = MAXSTATEARGS - 1; j >= maxargs; j--)
+      if (states[i].args[j] != 0)
+        I_Error("Action %s on state %d expects no more than %d nonzero args (%d found). Check your dehacked.",
+          bexptr_name, i, maxargs, j+1);
+  }
 }

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -3520,7 +3520,6 @@ dboolean deh_GetData(char *s, char *k, uint_64_t *l, char **strval, FILE *fpout)
 void CheckDehConsistency(void)
 {
   int i, j, maxargs;
-  dboolean found;
   const char *bexptr_name;
 
   // sanity-check bfgcells and bfg ammopershot
@@ -3537,7 +3536,6 @@ void CheckDehConsistency(void)
   {
     bexptr_name = "(NULL)";
     maxargs = 0;
-    found = FALSE;
     j= -1;
 
     do
@@ -3547,9 +3545,9 @@ void CheckDehConsistency(void)
       {
         bexptr_name = deh_bexptrs[j].lookup;
         maxargs = deh_bexptrs[j].argcount;
-        found = TRUE;
+        break;
       }
-    } while (!found && (deh_bexptrs[j].cptr != NULL));
+    } while (deh_bexptrs[j].cptr != NULL);
 
     for(j = MAXSTATEARGS - 1; j >= maxargs; j--)
       if (states[i].args[j] != 0)

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -3536,20 +3536,16 @@ void CheckDehConsistency(void)
   {
     bexptr_name = "(NULL)";
     maxargs = 0;
-    j= -1;
 
-    do
-    {
-      ++j;
+    for (j = 0; deh_bexptrs[j].cptr != NULL; ++j)
       if (states[i].action == deh_bexptrs[j].cptr)
       {
         bexptr_name = deh_bexptrs[j].lookup;
         maxargs = deh_bexptrs[j].argcount;
         break;
       }
-    } while (deh_bexptrs[j].cptr != NULL);
 
-    for(j = MAXSTATEARGS - 1; j >= maxargs; j--)
+    for (j = MAXSTATEARGS - 1; j >= maxargs; j--)
       if (states[i].args[j] != 0)
         I_Error("Action %s on state %d expects no more than %d nonzero args (%d found). Check your dehacked.",
           bexptr_name, i, maxargs, j+1);

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1245,7 +1245,15 @@ static const char *deh_state[] = // CPhipps - static const*
   // This is set in a separate "Pointer" block from Dehacked
   "Codep Frame",      // pointer to first use of action (actionf_t)
   "Unknown 1",        // .misc1 (long)
-  "Unknown 2"         // .misc2 (long)
+  "Unknown 2",        // .misc2 (long)
+  "Args1",            // .args[0] (long)
+  "Args2",            // .args[1] (long)
+  "Args3",            // .args[2] (long)
+  "Args4",            // .args[3] (long)
+  "Args5",            // .args[4] (long)
+  "Args6",            // .args[5] (long)
+  "Args7",            // .args[6] (long)
+  "Args8",            // .args[7] (long)
 };
 
 // SFXINFO_STRUCT - Dehacked block name = "Sounds"
@@ -2204,7 +2212,55 @@ static void deh_procFrame(DEHFILE *fpin, FILE* fpout, char *line)
                       states[indexnum].misc2 = (long)value; // long
                     }
                   else
-                    if (fpout) fprintf(fpout,"Invalid frame string index for '%s'\n",key);
+                    if (!deh_strcasecmp(key,deh_state[7]))  // Args1
+                      {
+                        if (fpout) fprintf(fpout," - args[0] = %ld\n",(long)value);
+                        states[indexnum].args[0] = (long)value; // long
+                      }
+                    else
+                      if (!deh_strcasecmp(key,deh_state[8]))  // Args2
+                        {
+                          if (fpout) fprintf(fpout," - args[1] = %ld\n",(long)value);
+                          states[indexnum].args[1] = (long)value; // long
+                        }
+                      else
+                        if (!deh_strcasecmp(key,deh_state[9]))  // Args3
+                          {
+                            if (fpout) fprintf(fpout," - args[2] = %ld\n",(long)value);
+                            states[indexnum].args[2] = (long)value; // long
+                          }
+                        else
+                          if (!deh_strcasecmp(key,deh_state[10]))  // Args4
+                            {
+                              if (fpout) fprintf(fpout," - args[3] = %ld\n",(long)value);
+                              states[indexnum].args[3] = (long)value; // long
+                            }
+                          else
+                            if (!deh_strcasecmp(key,deh_state[11]))  // Args5
+                              {
+                                if (fpout) fprintf(fpout," - args[4] = %ld\n",(long)value);
+                                states[indexnum].args[4] = (long)value; // long
+                              }
+                            else
+                              if (!deh_strcasecmp(key,deh_state[12]))  // Args6
+                                {
+                                  if (fpout) fprintf(fpout," - args[5] = %ld\n",(long)value);
+                                  states[indexnum].args[5] = (long)value; // long
+                                }
+                              else
+                                if (!deh_strcasecmp(key,deh_state[13]))  // Args7
+                                  {
+                                    if (fpout) fprintf(fpout," - args[6] = %ld\n",(long)value);
+                                    states[indexnum].args[6] = (long)value; // long
+                                  }
+                                else
+                                  if (!deh_strcasecmp(key,deh_state[14]))  // Args8
+                                    {
+                                      if (fpout) fprintf(fpout," - args[7] = %ld\n",(long)value);
+                                      states[indexnum].args[7] = (long)value; // long
+                                    }
+                                  else
+                                    if (fpout) fprintf(fpout,"Invalid frame string index for '%s'\n",key);
     }
   return;
 }

--- a/prboom2/src/info.h
+++ b/prboom2/src/info.h
@@ -42,6 +42,8 @@
 
 #include "dsda/global.h"
 
+#define MAXSTATEARGS 8
+
 /********************************************************************
  * Sprite name enumeration - must match info.c                      *
  ********************************************************************/
@@ -2630,6 +2632,7 @@ typedef struct
   actionf_t   action;       /* code pointer to function for action if any  */
   statenum_t  nextstate;    /* linked list pointer to next state or zero   */
   long        misc1, misc2; /* apparently never used in DOOM               */
+  long        args[MAXSTATEARGS]; // [XA] mbf21 args
 } state_t;
 
 /********************************************************************

--- a/prboom2/src/mbf21.md
+++ b/prboom2/src/mbf21.md
@@ -183,6 +183,13 @@ MBF21 defaults:
   - player did not have enough ammo to fire the weapon before
   - player now has enough ammo to fire the weapon
 
+#### New "Args" fields for DEHACKED states
+- [PR](https://github.com/kraflab/dsda-doom/pull/30)
+- Defines 8 new integer fields in the state table for use as codepointer arguments
+- Args are defined in dehacked by adding `Args1 = X`, `Args2 = X`... up to `Args8 = X` in the State definition.
+- Default value for every arg is 0
+- For future-proofing, if more nonzero args are defined on a state than its action pointer expects (e.g. defining Args3 on a state that uses A_WeaponSound), an error will be thrown on startup.
+
 #### New DEHACKED "Ammo per shot" Weapon field
 - [PR](https://github.com/kraflab/dsda-doom/pull/24)
 - Add `Ammo per shot = X` in the Weapon definition.
@@ -199,6 +206,7 @@ MBF21 defaults:
 
 #### New DEHACKED Codepointers
 - [PR](https://github.com/kraflab/dsda-doom/pull/20)
+- All new MBF21 pointers use the new "Args" fields for params, rather than misc1/misc2 fields
 - Actor pointers:
   - **A_SpawnFacing(type, height)** -- spawns an actor of `type` at `height` z units and sets its angle to the caller's angle.
   - **A_MonsterProjectile(type, angle)** -- generic monster projectile attack; always sets `tracer` field.

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -2982,17 +2982,17 @@ void A_LineEffect(mobj_t *mo)
 // A_SpawnFacing
 // Spawns an actor facing the same direction as the caller.
 // Basically just A_Spawn with a major quality-of-life tweak.
-//   misc1: Type of actor to spawn
-//   misc2: Height to spawn at, relative to calling actor
+//   args[0]: Type of actor to spawn
+//   args[1]: Height to spawn at, relative to calling actor
 //
 void A_SpawnFacing(mobj_t *actor)
 {
   mobj_t *mo;
 
-  if (!mbf21 || !actor->state->misc1)
+  if (!mbf21 || !actor->state->args[0])
     return;
 
-  mo = P_SpawnMobj(actor->x, actor->y, (actor->state->misc2 << FRACBITS) + actor->z, actor->state->misc1 - 1);
+  mo = P_SpawnMobj(actor->x, actor->y, (actor->state->args[1] << FRACBITS) + actor->z, actor->state->args[0] - 1);
   if (mo)
     mo->angle = actor->angle;
 
@@ -3003,24 +3003,24 @@ void A_SpawnFacing(mobj_t *actor)
 //
 // A_MonsterProjectile
 // A parameterized monster projectile attack.
-//   misc1: Type of actor to spawn
-//   misc2: Angle (degrees, in fixed point), relative to calling actor's angle
+//   args[0]: Type of actor to spawn
+//   args[1]: Angle (degrees, in fixed point), relative to calling actor's angle
 //
 void A_MonsterProjectile(mobj_t *actor)
 {
   mobj_t *mo;
   int an;
 
-  if (!mbf21 || !actor->target || !actor->state->misc1)
+  if (!mbf21 || !actor->target || !actor->state->args[0])
     return;
 
   A_FaceTarget(actor);
-  mo = P_SpawnMissile(actor, actor->target, actor->state->misc1 - 1);
+  mo = P_SpawnMissile(actor, actor->target, actor->state->args[0] - 1);
   if (!mo)
     return;
 
-  // adjust the angle by misc2;
-  mo->angle += (unsigned int)(((int_64_t)actor->state->misc2 << 16) / 360);
+  // adjust the angle by args[1];
+  mo->angle += (unsigned int)(((int_64_t)actor->state->args[1] << 16) / 360);
   an = mo->angle >> ANGLETOFINESHIFT;
   mo->momx = FixedMul(mo->info->speed, finecosine[an]);
   mo->momy = FixedMul(mo->info->speed, finesine[an]);
@@ -3033,8 +3033,8 @@ void A_MonsterProjectile(mobj_t *actor)
 //
 // A_MonsterBulletAttack
 // A parameterized monster bullet attack.
-//   misc1: Damage of attack (times 1d5)
-//   misc2: Horizontal spread (degrees, in fixed point);
+//   args[0]: Damage of attack (times 1d5)
+//   args[1]: Horizontal spread (degrees, in fixed point);
 //          if negative, also use 2/3 of this value for vertical spread
 //
 void A_MonsterBulletAttack(mobj_t *actor)
@@ -3048,13 +3048,13 @@ void A_MonsterBulletAttack(mobj_t *actor)
   A_FaceTarget(actor);
   S_StartSound(actor, actor->info->attacksound);
 
-  damage = (P_Random(pr_mbf21) % 5 + 1) * actor->state->misc1;
+  damage = (P_Random(pr_mbf21) % 5 + 1) * actor->state->args[0];
 
-  angle = (int)actor->angle + P_RandomHitscanAngle(pr_mbf21, actor->state->misc2);;
+  angle = (int)actor->angle + P_RandomHitscanAngle(pr_mbf21, actor->state->args[1]);;
   slope = P_AimLineAttack(actor, angle, MISSILERANGE, 0);
 
-  if (actor->state->misc2 < 0)
-    slope += P_RandomHitscanSlope(pr_mbf21, actor->state->misc2 * 2 / 3);
+  if (actor->state->args[1] < 0)
+    slope += P_RandomHitscanSlope(pr_mbf21, actor->state->args[1] * 2 / 3);
 
   P_LineAttack(actor, angle, MISSILERANGE, slope, damage);
 }
@@ -3062,15 +3062,15 @@ void A_MonsterBulletAttack(mobj_t *actor)
 //
 // A_RadiusDamage
 // A parameterized version of A_Explode. Friggin' finally. :P
-//   misc1: Damage (int)
-//   misc2: Radius (also int; no real need for fractional precision here)
+//   args[0]: Damage (int)
+//   args[1]: Radius (also int; no real need for fractional precision here)
 //
 void A_RadiusDamage(mobj_t *actor)
 {
   if (!mbf21 || !actor->state)
     return;
 
-  P_RadiusAttack(actor, actor->target, actor->state->misc1, actor->state->misc2);
+  P_RadiusAttack(actor, actor->target, actor->state->args[0], actor->state->args[1]);
 }
 
 


### PR DESCRIPTION
Adds an `args` array to the state table, exposes it to DEHACKED, and updates the new codepointers to use args instead of misc1/misc2.  'Nuff said.

[Will update mbf21.md here in a bit; gotta get food n' do some things]