### PR TITLE
Add save organization option

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -37,6 +37,8 @@ set(COMMON_SRC
     dsda/options.h
     dsda/palette.c
     dsda/palette.h
+    dsda/save.c
+    dsda/save.h
     dsda/settings.c
     dsda/settings.h
     dsda/time.c

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -95,6 +95,7 @@
 #endif
 
 #include "dsda/global.h"
+#include "dsda/save.h"
 #include "dsda/settings.h"
 
 #include "heretic/mn_menu.h"
@@ -138,8 +139,6 @@ FILE    *debugfile;
 int ffmap;
 
 dboolean advancedemo;
-
-char    *basesavegame;             // killough 2/16/98: savegame directory
 
 //jff 4/19/98 list of standard IWAD names
 const char *const standard_iwads[]=
@@ -970,29 +969,6 @@ void AddIWAD(const char *iwad)
   D_AddFile(iwad,source_iwad);
 }
 
-// NormalizeSlashes
-//
-// Remove trailing slashes, translate backslashes to slashes
-// The string to normalize is passed and returned in str
-//
-// jff 4/19/98 Make killoughs slash fixer a subroutine
-//
-static void NormalizeSlashes(char *str)
-{
-  size_t l;
-
-  // killough 1/18/98: Neater / \ handling.
-  // Remove trailing / or \ to prevent // /\ \/ \\, and change \ to /
-
-  if (!str || !(l = strlen(str)))
-    return;
-  if (str[--l]=='/' || str[l]=='\\')     // killough 1/18/98
-    str[l]=0;
-  while (l--)
-    if (str[l]=='\\')
-      str[l]='/';
-}
-
 /*
  * FindIWADFIle
  *
@@ -1038,35 +1014,9 @@ static char *FindIWADFile(void)
 
 static void IdentifyVersion (void)
 {
-  int         i;    //jff 3/24/98 index of args on commandline
-  struct stat sbuf; //jff 3/24/98 used to test save path for existence
   char *iwad;
 
-  // set save path to -save parm or current dir
-
-  //jff 3/27/98 default to current dir
-  //V.Aguilar (5/30/99): In LiNUX, default to $HOME/.lxdoom
-  {
-    // CPhipps - use DOOMSAVEDIR if defined
-    const char *p = getenv("DOOMSAVEDIR");
-
-    if (p == NULL)
-      p = I_DoomExeDir();
-
-    free(basesavegame);
-    basesavegame = strdup(p);
-  }
-  if ((i=M_CheckParm("-save")) && i<myargc-1) //jff 3/24/98 if -save present
-  {
-    if (!stat(myargv[i+1],&sbuf) && S_ISDIR(sbuf.st_mode)) // and is a dir
-    {
-      free(basesavegame);
-      basesavegame = strdup(myargv[i+1]);//jff 3/24/98 use that for savegame
-      NormalizeSlashes(basesavegame);    //jff 9/22/98 fix c:\ not working
-    }
-    //jff 9/3/98 use logical output routine
-    else lprintf(LO_ERROR,"Error: -save path does not exist, using %s\n", basesavegame);
-  }
+  dsda_InitSaveDir(); // why is this here?
 
   // locate the IWAD and determine game mode from it
 

--- a/prboom2/src/d_main.h
+++ b/prboom2/src/d_main.h
@@ -44,8 +44,6 @@
 
 /* CPhipps - removed wadfiles[] stuff to w_wad.h */
 
-extern char *basesavegame;      // killough 2/16/98: savegame path
-
 //jff 1/24/98 make command line copies of play modes available
 extern dboolean clnomonsters; // checkparm of -nomonsters
 extern dboolean clrespawnparm;  // checkparm of -respawn

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "doomtype.h"
 #include "m_argv.h"

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -1,0 +1,215 @@
+//
+// Copyright(C) 2020 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Save
+//
+
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "doomtype.h"
+#include "m_argv.h"
+#include "lprintf.h"
+#include "w_wad.h"
+#include "i_system.h"
+#include "z_zone.h"
+
+#include "save.h"
+
+int dsda_organized_saves;
+static char* dsda_base_save_dir;
+static char* dsda_wad_save_dir;
+
+// Remove trailing slashes, translate backslashes to slashes
+// The string to normalize is passed and returned in str
+//
+// jff 4/19/98 Make killoughs slash fixer a subroutine
+//
+static void dsda_NormalizeSlashes(char *str)
+{
+  size_t l;
+
+  // killough 1/18/98: Neater / \ handling.
+  // Remove trailing / or \ to prevent // /\ \/ \\, and change \ to /
+
+  if (!str || !(l = strlen(str)))
+    return;
+  if (str[--l] == '/' || str[l] == '\\')     // killough 1/18/98
+    str[l] = 0;
+  while (l--)
+    if (str[l] == '\\')
+      str[l] = '/';
+}
+
+void dsda_InitSaveDir(void) {
+  int         i;    //jff 3/24/98 index of args on commandline
+  struct stat sbuf; //jff 3/24/98 used to test save path for existence
+
+  // set save path to -save parm or current dir
+
+  //jff 3/27/98 default to current dir
+  //V.Aguilar (5/30/99): In LiNUX, default to $HOME/.lxdoom
+  {
+    // CPhipps - use DOOMSAVEDIR if defined
+    const char *p = getenv("DOOMSAVEDIR");
+
+    if (p == NULL)
+      p = I_DoomExeDir();
+
+    free(dsda_base_save_dir);
+    dsda_base_save_dir = strdup(p);
+  }
+
+  if ((i = M_CheckParm("-save")) && i < myargc - 1) //jff 3/24/98 if -save present
+  {
+    if (!stat(myargv[i + 1], &sbuf) && S_ISDIR(sbuf.st_mode)) // and is a dir
+    {
+      free(dsda_base_save_dir);
+      dsda_base_save_dir = strdup(myargv[i + 1]);//jff 3/24/98 use that for savegame
+    }
+    //jff 9/3/98 use logical output routine
+    else lprintf(LO_ERROR, "Error: -save path does not exist, using %s\n", dsda_base_save_dir);
+  }
+
+  dsda_NormalizeSlashes(dsda_base_save_dir);
+}
+
+#define SAVE_DIR_LIMIT 9
+static const char* dsda_save_root = "save_files";
+static char* dsda_save_dir_strings[SAVE_DIR_LIMIT];
+
+static void dsda_CreateSaveDir(void) {
+  int error = 0;
+
+  error =
+#if defined(_MSC_VER)
+    _mkdir(dsda_wad_save_dir);
+#else
+  #if defined(_WIN32)
+    mkdir(dsda_wad_save_dir);
+  #else
+    mkdir(dsda_wad_save_dir, 0x733);
+  #endif
+#endif
+
+  if (error)
+    I_Error(
+      "dsda_CreateSaveDir: unable to create save file directory %s (%d)",
+      dsda_wad_save_dir, error
+    );
+}
+
+static void dsda_InitWadSaveDir(void) {
+  int i;
+  int length = 0;
+  const int iwad_index = 1;
+  int pwad_index = 2;
+  struct stat sbuf;
+
+  dsda_save_dir_strings[0] = strdup(dsda_save_root);
+
+  for (i = 0; i < numwadfiles; ++i) {
+    char* start;
+
+    start = strrchr(wadfiles[i].name, '/');
+    if (start && strlen(start) > 1) {
+      start++; // move past '/'
+      length = strlen(start) - 4;
+
+      if (length > 0 && !strcasecmp(start + length, ".wad")) {
+        int dir_index;
+
+        if (wadfiles[i].src == 0)
+          dir_index = iwad_index;
+        else if (wadfiles[i].src == 3)
+          dir_index = pwad_index;
+        else
+          dir_index = -1;
+
+        if (dir_index >= 0 && dir_index < SAVE_DIR_LIMIT) {
+          dsda_save_dir_strings[dir_index] = malloc(length + 1);
+          strncpy(dsda_save_dir_strings[dir_index], start, length);
+          dsda_save_dir_strings[dir_index][length] = '\0';
+
+          for (start = dsda_save_dir_strings[dir_index]; *start; ++start)
+            *start = tolower(*start);
+
+          if (dir_index == pwad_index)
+            pwad_index++;
+        }
+      }
+    }
+  }
+
+  length = strlen(dsda_base_save_dir);
+  for (i = 0; i < SAVE_DIR_LIMIT; ++i) {
+    if (dsda_save_dir_strings[i])
+      length += strlen(dsda_save_dir_strings[i]) + 1; // "/"
+  }
+
+  dsda_wad_save_dir = calloc(length + 1, 1); // "\0"
+
+  strcat(dsda_wad_save_dir, dsda_base_save_dir);
+
+  for (i = 0; i < SAVE_DIR_LIMIT; ++i) {
+    if (dsda_save_dir_strings[i]) {
+      strcat(dsda_wad_save_dir, "/");
+      strcat(dsda_wad_save_dir, dsda_save_dir_strings[i]);
+
+      if (!stat(dsda_wad_save_dir, &sbuf) && S_ISDIR(sbuf.st_mode))
+        continue;
+      else
+        dsda_CreateSaveDir();
+    }
+  }
+
+  lprintf(LO_INFO, "Using save file directory: %s\n", dsda_wad_save_dir);
+}
+
+static char* dsda_SaveDir(void) {
+  if (dsda_organized_saves) {
+    if (!dsda_wad_save_dir)
+      dsda_InitWadSaveDir();
+
+    return dsda_wad_save_dir;
+  }
+
+  return dsda_base_save_dir;
+}
+
+extern const char* savegamename;
+
+char* dsda_SaveGameName(int slot, int demo_save) {
+  int length;
+  char* name;
+  const char* save_dir;
+  const char* save_type;
+
+  if (slot > 9999 || slot < 0)
+    I_Error("dsda_SaveGameName: bad save slot %d", slot);
+
+  save_dir = dsda_SaveDir();
+
+  save_type = demo_save ? "demosav" : savegamename;
+
+  length = strlen(save_type) + strlen(save_dir) + 10; // "/" + "9999.dsg\0"
+
+  name = malloc(length);
+
+  snprintf(name, length, "%s/%s%d.dsg", save_dir, save_type, slot);
+
+  return name;
+}

--- a/prboom2/src/dsda/save.h
+++ b/prboom2/src/dsda/save.h
@@ -1,0 +1,24 @@
+//
+// Copyright(C) 2020 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Save
+//
+
+#ifndef __DSDA_SAVE__
+#define __DSDA_SAVE__
+
+void dsda_InitSaveDir(void);
+char* dsda_SaveGameName(int slot, int demo_save);
+
+#endif

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -29,6 +29,7 @@ extern int dsda_track_attempts;
 extern int dsda_wipe_at_full_speed;
 extern int dsda_fine_sensitivity;
 extern int dsda_hide_horns;
+extern int dsda_organized_saves;
 
 void dsda_InitSettings(void);
 int dsda_CompatibilityLevel(void);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -88,6 +88,7 @@
 #include "dsda.h"
 #include "dsda/demo.h"
 #include "dsda/key_frame.h"
+#include "dsda/save.h"
 #include "dsda/settings.h"
 #include "dsda/input.h"
 #include "dsda/options.h"
@@ -2219,9 +2220,7 @@ void G_DoLoadGame(void)
   char maplump[8];
   int time, ttime;
 
-  length = G_SaveGameName(NULL, 0, savegameslot, demoplayback);
-  name = malloc(length+1);
-  G_SaveGameName(name, length+1, savegameslot, demoplayback);
+  name = dsda_SaveGameName(savegameslot, demoplayback);
 
   gameaction = ga_nothing;
 
@@ -2418,22 +2417,11 @@ void (CheckSaveGame)(size_t size, const char* file, int line)
            savegamesize += (size+1023) & ~1023)) + pos;
 }
 
-/* killough 3/22/98: form savegame name in one location
- * (previously code was scattered around in multiple places)
- * cph - Avoid possible buffer overflow problems by passing
- * size to this function and using snprintf */
-
-int G_SaveGameName(char *name, size_t size, int slot, dboolean demoplayback)
-{
-  const char* sgn = demoplayback ? "demosav" : savegamename;
-  return doom_snprintf (name, size, "%s/%s%d.dsg", basesavegame, sgn, slot);
-}
-
 static void G_DoSaveGame (dboolean menu)
 {
   char *name;
   char *description;
-  int  length, i;
+  int  i;
   //e6y: numeric version number of package
   unsigned int packageversion = GetPackageVersion();
   char maplump[8];
@@ -2442,9 +2430,7 @@ static void G_DoSaveGame (dboolean menu)
   gameaction = ga_nothing; // cph - cancel savegame at top of this function,
     // in case later problems cause a premature exit
 
-  length = G_SaveGameName(NULL, 0, savegameslot, demoplayback && !menu);
-  name = malloc(length+1);
-  G_SaveGameName(name, length+1, savegameslot, demoplayback && !menu);
+  name = dsda_SaveGameName(savegameslot, demoplayback && !menu);
 
   description = savedescription;
 

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -62,7 +62,6 @@ void G_EndGame(void); /* cph - make m_menu.c call a G_* function for this */
 void G_Ticker(void);
 void G_ScreenShot(void);
 void G_ReloadDefaults(void);     // killough 3/1/98: loads game defaults
-int  G_SaveGameName(char *, size_t, int, dboolean); /* killough 3/22/98: sets savegame filename */
 void G_SetFastParms(int);        // killough 4/10/98: sets -fast parameters
 void G_DoNewGame(void);
 void G_DoReborn(int playernum);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -71,6 +71,7 @@
 #include "dsda/key_frame.h"
 #include "dsda/input.h"
 #include "dsda/palette.h"
+#include "dsda/save.h"
 #include "heretic/mn_menu.h"
 #ifdef _WIN32
 #include "e6y_launcher.h"
@@ -901,9 +902,7 @@ void M_ReadSaveStrings(void)
 
     /* killough 3/22/98
      * cph - add not-demoplayback parameter */
-    len = G_SaveGameName(NULL, 0, i, false);
-    name = malloc(len+1);
-    G_SaveGameName(name, len+1, i, false);
+    name = dsda_SaveGameName(i, false);
     fp = fopen(name,"rb");
     free(name);
     if (!fp) {   // Ty 03/27/98 - externalized:
@@ -3333,6 +3332,7 @@ setup_menu_t dsda_gen_settings[] = {
   { "Track Demo Attempts", S_YESNO, m_null, G_X, G_Y + 8 * 8, { "dsda_track_attempts" } },
   { "Fine Sensitivity", S_NUM, m_null, G_X, G_Y + 9 * 8, { "dsda_fine_sensitivity" } },
   { "Hide Status Bar Horns", S_YESNO, m_null, G_X, G_Y + 10 * 8, { "dsda_hide_horns" } },
+  { "Organize My Save Files", S_YESNO, m_null, G_X, G_Y + 11 * 8, { "dsda_organized_saves" } },
 
 #ifdef GL_DOOM
   { "<- PREV", S_SKIP | S_PREV, m_null, KB_PREV, KB_Y + 20 * 8, { gen_settings8 } },

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -897,7 +897,6 @@ void M_ReadSaveStrings(void)
 
   for (i = 0 ; i < load_end ; i++) {
     char *name;               // killough 3/22/98
-    int len;
     FILE *fp;  // killough 11/98: change to use stdio
 
     /* killough 3/22/98

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1015,6 +1015,7 @@ default_t defaults[] =
   { "dsda_track_attempts", { &dsda_track_attempts }, { 1 }, 0, 1, def_bool, ss_stat },
   { "dsda_fine_sensitivity", { &dsda_fine_sensitivity }, { 0 }, 0, 99, def_int, ss_stat },
   { "dsda_hide_horns", { &dsda_hide_horns }, { 0 }, 0, 1, def_bool, ss_stat },
+  { "dsda_organized_saves", { &dsda_organized_saves }, { 0 }, 0, 1, def_bool, ss_stat },
 
   // NSM
   {"Video capture encoding settings",{NULL},{0},UL,UL,def_none,ss_none},


### PR DESCRIPTION
Automatically manage directories based on loaded wads for save files.

E.g., `-iwad doom2 -file pwads/foo.wad` will use directory `base/save_files/doom2/foo`. The `base` of that path is the old value (either the exe dir or the one supplied with `-save`).