### PR TITLE
Expand save slots

### DIFF
--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -107,6 +107,7 @@ int g_cr_blue;
 
 const char* g_menu_flat;
 patchnum_t* g_menu_font;
+int g_menu_save_page_size;
 int g_menu_font_spacing;
 int g_menu_cr_title;
 int g_menu_cr_set;
@@ -213,6 +214,7 @@ static void dsda_InitDoom(void) {
 
   g_menu_flat = "FLOOR4_6";
   g_menu_font = hu_font;
+  g_menu_save_page_size = 7;
   g_menu_font_spacing = -1;
   g_menu_cr_title = CR_GOLD;
   g_menu_cr_set = CR_GREEN;
@@ -343,6 +345,7 @@ static void dsda_InitHeretic(void) {
 
   g_menu_flat = "FLOOR30";
   g_menu_font = hu_font2;
+  g_menu_save_page_size = 5;
   g_menu_font_spacing = 0;
   g_menu_cr_title = g_cr_gold;
   g_menu_cr_set = g_cr_green;

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -34,6 +34,8 @@
 #define SFX_VOL_INDEX 1
 #define MUS_VOL_INDEX 3
 
+extern int g_menu_save_page_size;
+
 static int FontABaseLump;
 static int FontBBaseLump;
 static int SkullBaseLump;
@@ -92,11 +94,11 @@ void MN_Init(void)
 
   LoadDef.x = 70;
   LoadDef.y = 30;
-  LoadDef.numitems = 6;
+  LoadDef.numitems = g_menu_save_page_size;
 
   SaveDef.x = 70;
   SaveDef.y = 30;
-  SaveDef.numitems = 6;
+  SaveDef.numitems = g_menu_save_page_size;
 
   EpisodeMenu[0].alttext = "CITY OF THE DAMNED";
   EpisodeMenu[1].alttext = "HELL'S MAW";
@@ -323,13 +325,16 @@ extern char savegamestrings[10][SAVESTRINGSIZE];
 static void MN_DrawFileSlots(int x, int y)
 {
   int i;
+  extern char save_page_string[];
 
-  for (i = 0; i < 6; i++)
+  for (i = 0; i < g_menu_save_page_size; i++)
   {
     V_DrawNamePatch(x, y, 0, DEH_String("M_FSLOT"), CR_DEFAULT, VPT_STRETCH);
     MN_DrTextA(savegamestrings[i], x + 5, y + 5);
     y += ITEM_HEIGHT;
   }
+
+  MN_DrTextA(save_page_string, x + 5, y + 5);
 }
 
 void MN_DrawLoad(void)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -109,6 +109,7 @@ int screenblocks;    // has default
 int screenSize;      // temp for screenblocks (0-9)
 
 int quickSaveSlot;   // -1 = no quicksave slot picked!
+int quickSavePage;
 
 int messageToPrint;  // 1 = message to be printed
 
@@ -959,7 +960,10 @@ static void M_DoSave(int slot)
 
   // PICK QUICKSAVE SLOT YET?
   if (quickSaveSlot == -2)
+  {
     quickSaveSlot = slot;
+    quickSavePage = save_page;
+  }
 }
 
 //
@@ -1393,6 +1397,11 @@ void M_QuickSave(void)
     quickSaveSlot = -2; // means to pick a slot now
     return;
   }
+  else
+  {
+    save_page = quickSavePage;
+    M_ReadSaveStrings();
+  }
   sprintf(tempstring,s_QSPROMPT,savegamestrings[quickSaveSlot]); // Ty 03/27/98 - externalized
   M_StartMessage(tempstring,M_QuickSaveResponse,true);
 }
@@ -1424,6 +1433,11 @@ void M_QuickLoad(void)
   if (quickSaveSlot < 0) {
     M_StartMessage(s_QSAVESPOT,NULL,false); // Ty 03/27/98 - externalized
     return;
+  }
+  else
+  {
+    save_page = quickSavePage;
+    M_ReadSaveStrings();
   }
   sprintf(tempstring,s_QLPROMPT,savegamestrings[quickSaveSlot]); // Ty 03/27/98 - externalized
   M_StartMessage(tempstring,M_QuickLoadResponse,true);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -83,6 +83,7 @@ extern dboolean chat_on;          // in heads-up code
 
 extern const char* g_menu_flat;
 extern patchnum_t* g_menu_font;
+extern int g_menu_save_page_size;
 extern int g_menu_font_spacing;
 extern int g_menu_cr_title;
 extern int g_menu_cr_set;
@@ -744,7 +745,7 @@ static int save_page = 0;
 static const int save_page_limit = 16;
 
 #define SAVE_PAGE_STRING_SIZE 16
-static char save_page_string[SAVE_PAGE_STRING_SIZE];
+char save_page_string[SAVE_PAGE_STRING_SIZE];
 
 // The definitions of the Load Game screen
 
@@ -821,7 +822,8 @@ void M_LoadSelect(int choice)
   // CPhipps - Modified so savegame filename is worked out only internal
   //  to g_game.c, this only passes the slot.
 
-  G_LoadGame(choice + save_page * load_end, false); // killough 3/16/98, 5/15/98: add slot, cmd
+  // killough 3/16/98, 5/15/98: add slot, cmd
+  G_LoadGame(choice + save_page * g_menu_save_page_size, false);
   M_ClearMenus();
 }
 
@@ -907,7 +909,7 @@ void M_ReadSaveStrings(void)
 
     /* killough 3/22/98
      * cph - add not-demoplayback parameter */
-    name = dsda_SaveGameName(i + save_page * load_end, false);
+    name = dsda_SaveGameName(i + save_page * g_menu_save_page_size, false);
     fp = fopen(name,"rb");
     free(name);
     if (!fp) {   // Ty 03/27/98 - externalized:
@@ -955,7 +957,7 @@ void M_DrawSave(void)
 //
 static void M_DoSave(int slot)
 {
-  G_SaveGame(slot + save_page * load_end, savegamestrings[slot]);
+  G_SaveGame(slot + save_page * g_menu_save_page_size, savegamestrings[slot]);
   M_ClearMenus();
 
   // PICK QUICKSAVE SLOT YET?

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -735,10 +735,15 @@ enum
   load4,
   load5,
   load6,
-  load7, //jff 3/15/98 extend number of slots
-  load8,
+  load7,
   load_end
 } load_e;
+
+static int save_page = 0;
+static const int save_page_limit = 16;
+
+#define SAVE_PAGE_STRING_SIZE 16
+static char save_page_string[SAVE_PAGE_STRING_SIZE];
 
 // The definitions of the Load Game screen
 
@@ -783,6 +788,8 @@ void M_DrawLoad(void)
     M_DrawSaveLoadBorder(LoadDef.x,LoadDef.y+LINEHEIGHT*i);
     M_WriteText(LoadDef.x,LoadDef.y+LINEHEIGHT*i,savegamestrings[i], CR_DEFAULT);
   }
+
+  M_WriteText(LoadDef.x, LoadDef.y + LINEHEIGHT * load_end, save_page_string, CR_DEFAULT);
 }
 
 //
@@ -813,9 +820,8 @@ void M_LoadSelect(int choice)
   // CPhipps - Modified so savegame filename is worked out only internal
   //  to g_game.c, this only passes the slot.
 
-  G_LoadGame(choice, false); // killough 3/16/98, 5/15/98: add slot, cmd
-
-  M_ClearMenus ();
+  G_LoadGame(choice + save_page * load_end, false); // killough 3/16/98, 5/15/98: add slot, cmd
+  M_ClearMenus();
 }
 
 //
@@ -844,15 +850,14 @@ void M_ForcedLoadGame(const char *msg)
 
 void M_LoadGame (int choice)
 {
-  /* killough 5/26/98: exclude during demo recordings
-   * cph - unless a new demo */
-  if (demorecording && (compatibility_level < prboom_2_compatibility) && !mbf21)
-    {
+  // killough 5/26/98: exclude during demo recordings
+  if (demorecording)
+  {
     M_StartMessage("you can't load a game\n"
-       "while recording a demo in this complevel!\n\n"PRESSKEY,
+       "while recording a demo!\n\n"PRESSKEY,
        NULL, false); // killough 5/26/98: not externalized
     return;
-    }
+  }
 
   M_SetupNextMenu(&LoadDef);
   M_ReadSaveStrings();
@@ -901,7 +906,7 @@ void M_ReadSaveStrings(void)
 
     /* killough 3/22/98
      * cph - add not-demoplayback parameter */
-    name = dsda_SaveGameName(i, false);
+    name = dsda_SaveGameName(i + save_page * load_end, false);
     fp = fopen(name,"rb");
     free(name);
     if (!fp) {   // Ty 03/27/98 - externalized:
@@ -913,6 +918,8 @@ void M_ReadSaveStrings(void)
     fclose(fp);
     LoadMenue[i].status = 1;
   }
+
+  snprintf(save_page_string, SAVE_PAGE_STRING_SIZE, "PAGE %d/%d", save_page + 1, save_page_limit);
 }
 
 //
@@ -933,6 +940,8 @@ void M_DrawSave(void)
     M_WriteText(LoadDef.x,LoadDef.y+LINEHEIGHT*i,savegamestrings[i], CR_DEFAULT);
     }
 
+  M_WriteText(LoadDef.x, LoadDef.y + LINEHEIGHT * load_end, save_page_string, CR_DEFAULT);
+
   if (saveStringEnter)
     {
     i = M_StringWidth(savegamestrings[saveSlot]);
@@ -945,8 +954,8 @@ void M_DrawSave(void)
 //
 static void M_DoSave(int slot)
 {
-  G_SaveGame (slot,savegamestrings[slot]);
-  M_ClearMenus ();
+  G_SaveGame(slot + save_page * load_end, savegamestrings[slot]);
+  M_ClearMenus();
 
   // PICK QUICKSAVE SLOT YET?
   if (quickSaveSlot == -2)
@@ -4440,6 +4449,27 @@ dboolean M_Responder (event_t* ev) {
       }
     }
     return true;
+  }
+
+  if ((currentMenu == &LoadDef || currentMenu == &SaveDef) && !saveStringEnter)
+  {
+    int diff = 0;
+
+    if (action == MENU_LEFT)
+      diff = -1;
+    else if (action == MENU_RIGHT)
+      diff = 1;
+
+    if (diff)
+    {
+      save_page += diff;
+      if (save_page < 0)
+        save_page = save_page_limit - 1;
+      else if (save_page >= save_page_limit)
+        save_page = 0;
+
+      M_ReadSaveStrings();
+    }
   }
 
   // Take care of any messages that need input


### PR DESCRIPTION
Save slots were previously bound by the tick command limitations, due to a desire to store load commands in demos. That feature has been dropped and the save limit increased from 8 to 112. All the demo + save file stuff will be replaced by more open-ended key frame things later on.