### PR TITLE
Add comp_friendlyspawn

### DIFF
--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -123,7 +123,7 @@ enum {
 
   // mbf21
   comp_ledgeblock,
-  comp_placeholder_30,
+  comp_friendlyspawn,
   comp_placeholder_31,
   comp_placeholder_32,
   // and more!

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -94,7 +94,8 @@ static const dsda_options_t default_mbf_options = {
   // .comp_ouchface = 1,
   // .comp_maxhealth = 0,
   // .comp_translucency = 0,
-  // .comp_ledgeblock = 0
+  // .comp_ledgeblock = 0,
+  // .comp_friendlyspawn = 1
 };
 
 static const dsda_options_t default_latest_options = {
@@ -139,7 +140,8 @@ static const dsda_options_t default_latest_options = {
   .comp_ouchface = 0,
   .comp_maxhealth = 0,
   .comp_translucency = 0,
-  .comp_ledgeblock = 1
+  .comp_ledgeblock = 1,
+  .comp_friendlyspawn = 1
 };
 
 static dsda_options_t mbf_options;
@@ -186,6 +188,7 @@ static dsda_option_t option_list[] = {
   { "comp_respawnfix", &mbf_options.comp_respawn, 0, 1 },
   { "comp_soul", &mbf_options.comp_soul, 0, 1 },
   { "comp_ledgeblock", &mbf_options.comp_ledgeblock, 0, 1 },
+  { "comp_friendlyspawn", &mbf_options.comp_friendlyspawn, 0, 1 },
   { 0 }
 };
 

--- a/prboom2/src/dsda/options.h
+++ b/prboom2/src/dsda/options.h
@@ -59,7 +59,7 @@ typedef struct dsda_options {
   int comp_maxhealth;
   int comp_translucency;
   int comp_ledgeblock;
-  // int comp_30;
+  int comp_friendlyspawn;
   // int comp_31;
   // int comp_32;
 } dsda_options_t;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2626,8 +2626,8 @@ void G_Compatibility(void)
     { boom_compatibility_compatibility, prboom_6_compatibility },
     // comp_ledgeblock - ground monsters are blocked by ledges
     { boom_compatibility, mbf21_compatibility },
-    // comp_placeholder_30 - Not defined yet
-    { 255, 255 },
+    // comp_friendlyspawn - A_Spawn new mobj inherits friendliness
+    { prboom_1_compatibility, mbf21_compatibility },
     // comp_placeholder_31 - Not defined yet
     { 255, 255 },
     // comp_placeholder_32 - Not defined yet
@@ -2771,6 +2771,7 @@ void G_ReloadDefaults(void)
     comp[comp_maxhealth] = options->comp_maxhealth;
     comp[comp_translucency] = options->comp_translucency;
     comp[comp_ledgeblock] = options->comp_ledgeblock;
+    comp[comp_friendlyspawn] = options->comp_friendlyspawn;
   }
 
   G_Compatibility();

--- a/prboom2/src/mbf21.md
+++ b/prboom2/src/mbf21.md
@@ -76,12 +76,6 @@ This is proof-of-concept implemented in dsda-doom.
 - [EE](https://github.com/team-eternity/eternity/blob/0fc2a38da688d9f5001fef723b40ef92c5db0956/source/p_inter.cpp#L971)
 - Why? Needs investigation.
 
-#### A_Spawn friendliness inheritance
-- Changed in pr+, but not in EE.
-- [code](https://github.com/kraflab/dsda-doom/blob/6006aa42d3fba0ad2822ea35b144a921678821bf/prboom2/src/p_enemy.c#L2894-L2897)
-- [EE](https://github.com/team-eternity/eternity/blob/0fc2a38da688d9f5001fef723b40ef92c5db0956/source/a_general.cpp#L189)
-- Why? Needs investigation.
-
 #### A_Mushroom changes
 - Changed in pr+, reverted for mbf21.
 - [commit](https://github.com/kraflab/dsda-doom/commit/a330db45dee7f255510f6b2c06006e97dc04d578)

--- a/prboom2/src/mbf21.md
+++ b/prboom2/src/mbf21.md
@@ -111,6 +111,9 @@ This is proof-of-concept implemented in dsda-doom.
 - comp_ledgeblock: [commit](https://github.com/kraflab/dsda-doom/commit/4423cbcf8580e4d3839ddf4403b1fb4a0f993507)
   - Ledges block ground enemies
   - Exception: movement due to scrolling / pushers / pullers disables comp_ledgeblock for the next xy movement: [commit](https://github.com/kraflab/dsda-doom/commit/db8c3d606ed23dfb6b2408c4ddbf0af91d33f3de)
+- comp_friendlyspawn: [PR](https://github.com/kraflab/dsda-doom/pull/34)
+  - When on: A_Spawn new thing inherits friend flag from source thing.
+  - When off: A_Spawn new thing keeps its default friend flag.
 
 Summary of comp flags since mbf in pr+ and changes:
 
@@ -126,6 +129,7 @@ Summary of comp flags since mbf in pr+ and changes:
 | comp_maxhealth-    | 26    | 0       | Max health in deh only applies to potions     |
 | comp_translucency- | 27    | 0       | Disable some predefined translucency          |
 | comp_ledgeblock    | 28    | 1       | Ledges block ground enemies                   |
+| comp_friendlyspawn | 29    | 1       | A_Spawn new thing inherits friendliness       |
 
 - Comp options marked with a `-` have been deoptionalized in mbf21 (forced to `0`). Many of these have nothing to do with demo compatibility - others are simple bug fixes.
 - Comp options marked with a `*` are already implemented in EE.

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -2893,15 +2893,17 @@ void A_Spawn(mobj_t *mo)
     return;
 
   if (mo->state->misc1)
-    {
-      mobj_t *newmobj =
-      P_SpawnMobj(mo->x, mo->y, (mo->state->misc2 << FRACBITS) + mo->z,
-      mo->state->misc1 - 1);
-      if (compatibility_level == mbf_compatibility &&
-          !prboom_comp[PC_DO_NOT_INHERIT_FRIENDLYNESS_FLAG_ON_SPAWN].state)
-      /* CPhipps - no friendlyness (yet)*/ //e6y: why not?
-   newmobj->flags = (newmobj->flags & ~MF_FRIEND) | (mo->flags & MF_FRIEND);
-    }
+  {
+    mobj_t *newmobj =
+      P_SpawnMobj(mo->x, mo->y, (mo->state->misc2 << FRACBITS) + mo->z, mo->state->misc1 - 1);
+
+    if (
+      mbf_features &&
+      comp[comp_friendlyspawn] &&
+      !prboom_comp[PC_DO_NOT_INHERIT_FRIENDLYNESS_FLAG_ON_SPAWN].state
+    )
+      newmobj->flags = (newmobj->flags & ~MF_FRIEND) | (mo->flags & MF_FRIEND);
+  }
 }
 
 void A_Turn(mobj_t *mo)


### PR DESCRIPTION
There are two friendliness inheritance behaviours in A_Spawn:
1) mbf: new thing inherits parent object friend flag
2) post-mbf: new thing keeps its mobjinfo friend flag

This comp option allows the mod author to choose the behaviour - default is mbf original style.