### PR TITLE
Changed the IWAD directory for MacOS

### DIFF
--- a/prboom2/src/MAC/LauncherApp.m
+++ b/prboom2/src/MAC/LauncherApp.m
@@ -14,7 +14,7 @@ static LauncherApp *LApp;
 
 - (NSString *)wadPath
 {
-	return [@"~/Library/Application Support/PrBoom-Plus" stringByExpandingTildeInPath];
+	return [@"~/.dsda-doom" stringByExpandingTildeInPath];
 }
 
 - (void)awakeFromNib


### PR DESCRIPTION
(MacOS only) The launcher uses one folder to find the IWADs (/Library/Application Support/PrBoom-Plus) and another folder to load them from (/.dsda-doom). This change makes the launcher use the same folder for both finding and loading the IWAD.