### PR TITLE
MBF21 Melee Codepointers

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -44,6 +44,7 @@
 #include "m_cheat.h"
 #include "p_inter.h"
 #include "p_enemy.h"
+#include "p_map.h"
 #include "g_game.h"
 #include "d_think.h"
 #include "w_wad.h"
@@ -1459,9 +1460,11 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_SpawnObject,         "A_SpawnObject", 8},
   {A_MonsterProjectile,   "A_MonsterProjectile", 5},
   {A_MonsterBulletAttack, "A_MonsterBulletAttack", 5, {0, 0, 1, 3, 5}},
+  {A_MonsterMeleeAttack,  "A_MonsterMeleeAttack", 4, {3, 8, 0, MELEERANGE}},
   {A_RadiusDamage,        "A_RadiusDamage", 2},
   {A_WeaponProjectile,    "A_WeaponProjectile", 5},
   {A_WeaponBulletAttack,  "A_WeaponBulletAttack", 5, {0, 0, 1, 5, 3}},
+  {A_WeaponMeleeAttack,   "A_WeaponMeleeAttack", 5, {2, 10, 1 * FRACUNIT, 0, MELEERANGE}},
   {A_WeaponSound,         "A_WeaponSound", 2},
   {A_WeaponJump,          "A_WeaponJump", 2},
   {A_ConsumeAmmo,         "A_ConsumeAmmo", 1},

--- a/prboom2/src/mbf21.md
+++ b/prboom2/src/mbf21.md
@@ -261,6 +261,16 @@ MBF21 defaults:
     - Damage arg defaults are identical to Doom's usual monster bullet attack values.
     - Entering a negative value for `numbullets`, `damagebase`, and `damagedice` is undefined behavior (for now).
 
+- **A_MonsterMeleeAttack(damagebase, damagedice, sound, range)**
+  - Generic monster melee attack.
+  - Args:
+    - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
+    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 8
+    - `sound (uint)`: Sound to play if attack hits
+    - `range (fixed)`: Attack range; if not set, defaults to 64.0
+  - Notes:
+    - Damage formula is: `damage = (damagebase * random(1, damagedice))`
+
 - **A_RadiusDamage(damage, radius)**
   - Generic A_Explode (hell yeah).
   - Args:
@@ -294,6 +304,17 @@ MBF21 defaults:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
     - Damage arg defaults are identical to Doom's usual monster bullet attack values.
       - Note that these defaults are different for weapons and monsters (5d3 vs 3d5) -- yup, Doom did it this way. :P
+
+- **A_WeaponMeleeAttack(damagebase, damagedice, zerkfactor, sound, range)**
+  - Generic weapon melee attack.
+  - Args:
+    - `damagebase (int)`: Base damage of attack; if not set, defaults to 2
+    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 10
+    - `zerkfactor (fixed)`: Berserk damage multiplier; if not set, defaults to 1.0
+    - `sound (uint)`: Sound to play if attack hits
+    - `range (fixed)`: Attack range; if not set, defaults to 64.0
+  - Notes:
+    - Damage formula is: `damage = (damagebase * random(1, damagedice))`; this is then multiplied by `zerkfactor` if the player has Berserk.
 
 - **A_WeaponSound(sound, fullvol)**
   - Generic playsound for weapons.

--- a/prboom2/src/mbf21.md
+++ b/prboom2/src/mbf21.md
@@ -209,7 +209,7 @@ MBF21 defaults:
 - For future-proofing, if more nonzero args are defined on a state than its action pointer expects (e.g. defining Args3 on a state that uses A_WeaponSound), an error will be thrown on startup.
 
 #### New DEHACKED Codepointers
-- [PR](https://github.com/kraflab/dsda-doom/pull/20), [PR](https://github.com/kraflab/dsda-doom/pull/38)
+- [PR](https://github.com/kraflab/dsda-doom/pull/20), [PR](https://github.com/kraflab/dsda-doom/pull/38), [PR](https://github.com/kraflab/dsda-doom/pull/40)
 - All new MBF21 pointers use the new "Args" fields for params, rather than misc1/misc2 fields
 - Arg fields are listed in order in the docs below, e.g. for `A_SpawnObject`, `type` is Args1, `angle` is Args2, etc.
 - Although all args are integers internally, there are effectively the following types of args:

--- a/prboom2/src/p_enemy.h
+++ b/prboom2/src/p_enemy.h
@@ -125,6 +125,7 @@ void A_SkullPop(mobj_t *);
 void A_SpawnObject(mobj_t *);
 void A_MonsterProjectile(mobj_t *);
 void A_MonsterBulletAttack(mobj_t *);
+void A_MonsterMeleeAttack(mobj_t *);
 void A_RadiusDamage(mobj_t *);
 
 // heretic

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -1256,11 +1256,9 @@ void A_WeaponMeleeAttack(player_t *player, pspdef_t *psp)
   t = P_Random(pr_mbf21);
   angle += (t - P_Random(pr_mbf21))<<18;
 
-  /* killough 8/2/98: make autoaiming prefer enemies */
-  // [XA] ain't touchin' this.
-  if (!mbf_features ||
-      (slope = P_AimLineAttack(player->mo, angle, range, MF_FRIEND),
-       !linetarget))
+  // make autoaim prefer enemies
+  slope = P_AimLineAttack(player->mo, angle, range, MF_FRIEND);
+  if (!linetarget)
     slope = P_AimLineAttack(player->mo, angle, range, 0);
 
   // attack, dammit!

--- a/prboom2/src/p_pspr.h
+++ b/prboom2/src/p_pspr.h
@@ -132,6 +132,7 @@ void A_FireOldBFG();
 
 void A_WeaponProjectile();
 void A_WeaponBulletAttack();
+void A_WeaponMeleeAttack();
 void A_WeaponSound();
 void A_WeaponJump();
 void A_ConsumeAmmo();


### PR DESCRIPTION
Adds two new MBF21 codepointers:
- A_MonsterMeleeAttack(damagebase, damagedice, sound, range)
- A_WeaponMeleeAttack(damagebase, damagedice, zerkfactor, sound, range)

Details in `mbf21.md` -- pretty straightforward now that `args` are a thing. :D