### PR TITLE
MBF21 Seeker missile codepointers (Take 2)

### DIFF
--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -306,9 +306,11 @@ MBF21 defaults:
     - This function will no-op if the calling actor already has a tracer. To forcibly re-acquire a new tracer, call A_ClearTracer first.
     - This function uses a variant of Hexen's blockmap search algorithm (P_RoughMonsterSearch); refer to the implementation for specifics, but it's identical to Hexen's except for the rules for picking a valid target (in order of evaluation):
       - Actors without the SHOOTABLE flag are skipped
-      - Players are skipped in co-op multiplayer games
       - The projectile's owner (target) is skipped
-      - Friendly monsters will be skipped if missile is fired by a player or another friendly monster
+      - Actors on the same "team" are skipped (e.g. MF_FRIEND actors will not pick players or fellow MF_FRIENDs), with a few exceptions:
+        - If actors are infighting (i.e. candidate actor is projectile owner's target), actor will not be skipped
+        - Players will not be skipped in deathmatch
+          - This rule is to work around a weird quirk in MBF (namely, that players have MF_FRIEND set even in DM); ports with a robust "team" implementation may be able to do a smarter check here in general.
       - If the `fov` arg is nonzero, actors outside of an `fov`-degree cone, relative to the missile's angle, are skipped
       - Actors not in line-of-sight of the missile are skipped
 

--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -207,7 +207,7 @@ MBF21 defaults:
 - For future-proofing, if more nonzero args are defined on a state than its action pointer expects (e.g. defining Args3 on a state that uses A_WeaponSound), an error will be thrown on startup.
 
 #### New DEHACKED Codepointers
-- [PR](https://github.com/kraflab/dsda-doom/pull/20), [PR](https://github.com/kraflab/dsda-doom/pull/38), [PR](https://github.com/kraflab/dsda-doom/pull/40), [PR](https://github.com/kraflab/dsda-doom/pull/41), [PR](https://github.com/kraflab/dsda-doom/pull/43)
+- [PR](https://github.com/kraflab/dsda-doom/pull/20), [PR](https://github.com/kraflab/dsda-doom/pull/38), [PR](https://github.com/kraflab/dsda-doom/pull/40), [PR](https://github.com/kraflab/dsda-doom/pull/41), [PR](https://github.com/kraflab/dsda-doom/pull/45)
 - All new MBF21 pointers use the new "Args" fields for params, rather than misc1/misc2 fields
 - Arg fields are listed in order in the docs below, e.g. for `A_SpawnObject`, `type` is Args1, `angle` is Args2, etc.
 - Although all args are integers internally, there are effectively the following types of args:

--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -207,7 +207,7 @@ MBF21 defaults:
 - For future-proofing, if more nonzero args are defined on a state than its action pointer expects (e.g. defining Args3 on a state that uses A_WeaponSound), an error will be thrown on startup.
 
 #### New DEHACKED Codepointers
-- [PR](https://github.com/kraflab/dsda-doom/pull/20), [PR](https://github.com/kraflab/dsda-doom/pull/38), [PR](https://github.com/kraflab/dsda-doom/pull/40), [PR](https://github.com/kraflab/dsda-doom/pull/41)
+- [PR](https://github.com/kraflab/dsda-doom/pull/20), [PR](https://github.com/kraflab/dsda-doom/pull/38), [PR](https://github.com/kraflab/dsda-doom/pull/40), [PR](https://github.com/kraflab/dsda-doom/pull/41), [PR](https://github.com/kraflab/dsda-doom/pull/43)
 - All new MBF21 pointers use the new "Args" fields for params, rather than misc1/misc2 fields
 - Arg fields are listed in order in the docs below, e.g. for `A_SpawnObject`, `type` is Args1, `angle` is Args2, etc.
 - Although all args are integers internally, there are effectively the following types of args:
@@ -296,7 +296,7 @@ MBF21 defaults:
       - The actor's `tracer` pointer is used as the seek target, rather than Heretic's `special1` field
       - On the z-axis, the missile will seek towards the vertical centerpoint of the seek target, rather than the bottom (resulting in much friendly behavior when seeking toward enemies on high ledges). Refer to the implementation for details.
 
-- **A_FindTracer(threshold, maxturnangle)**
+- **A_FindTracer(fov, distance)**
   - Searches for a valid tracer (seek target), if the calling actor doesn't already have one. Particularly useful for player missiles.
   - Args:
     - `fov (fixed)`: Field-of-view, relative to calling actor's angle, to search for targets in. If zero, the search will occur in all directions.

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1494,6 +1494,8 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_NoiseAlert,          "A_NoiseAlert", 0},
   {A_HealChase,           "A_HealChase", 2},
   {A_Seek,                "A_Seek", 2},
+  {A_FindTracer,          "A_FindTracer", 2, {0, 10}},
+  {A_ClearTracer,         "A_ClearTracer", 0},
   {A_JumpIfHealthBelow,   "A_JumpIfHealthBelow", 2},
   {A_JumpIfTargetInSight, "A_JumpIfTargetInSight", 1},
   {A_JumpIfTargetCloser,  "A_JumpIfTargetCloser", 2},

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1493,6 +1493,7 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_RadiusDamage,        "A_RadiusDamage", 2},
   {A_NoiseAlert,          "A_NoiseAlert", 0},
   {A_HealChase,           "A_HealChase", 2},
+  {A_Seek,                "A_Seek", 2},
   {A_JumpIfHealthBelow,   "A_JumpIfHealthBelow", 2},
   {A_JumpIfTargetInSight, "A_JumpIfTargetInSight", 1},
   {A_JumpIfTargetCloser,  "A_JumpIfTargetCloser", 2},

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1499,6 +1499,8 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_JumpIfHealthBelow,   "A_JumpIfHealthBelow", 2},
   {A_JumpIfTargetInSight, "A_JumpIfTargetInSight", 1},
   {A_JumpIfTargetCloser,  "A_JumpIfTargetCloser", 2},
+  {A_JumpIfTracerInSight, "A_JumpIfTracerInSight", 1},
+  {A_JumpIfTracerCloser,  "A_JumpIfTracerCloser", 2},
   {A_JumpIfFlagsSet,      "A_JumpIfFlagsSet", 3},
   {A_AddFlags,            "A_AddFlags", 2},
   {A_RemoveFlags,         "A_RemoveFlags", 2},

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1493,7 +1493,7 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_RadiusDamage,        "A_RadiusDamage", 2},
   {A_NoiseAlert,          "A_NoiseAlert", 0},
   {A_HealChase,           "A_HealChase", 2},
-  {A_Seek,                "A_Seek", 2},
+  {A_SeekTracer,          "A_SeekTracer", 2},
   {A_FindTracer,          "A_FindTracer", 2, {0, 10}},
   {A_ClearTracer,         "A_ClearTracer", 0},
   {A_JumpIfHealthBelow,   "A_JumpIfHealthBelow", 2},

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3278,7 +3278,7 @@ void A_FindTracer(mobj_t *actor)
   fov  = FixedToAngle(actor->state->args[0]);
   dist =             (actor->state->args[1]);
 
-  actor->tracer = P_RoughMonsterSearch(actor, fov, dist);
+  actor->tracer = P_RoughTargetSearch(actor, fov, dist);
 }
 
 //

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3243,6 +3243,25 @@ void A_HealChase(mobj_t* actor)
 }
 
 //
+// A_Seek
+// A parameterized seeker missile function.
+//   args[0]: direct-homing threshold angle (degrees, in fixed point)
+//   args[1]: maximum turn angle (degrees, in fixed point)
+//
+void A_Seek(mobj_t *actor)
+{
+  angle_t threshold, maxturnangle;
+
+  if (!mbf21 || !actor)
+    return;
+
+  threshold    = FixedToAngle(actor->state->args[0]);
+  maxturnangle = FixedToAngle(actor->state->args[1]);
+
+  P_SeekerMissile(actor, threshold, maxturnangle, true);
+}
+
+//
 // A_JumpIfHealthBelow
 // Jumps to a state if caller's health is below the specified threshold.
 //   args[0]: State to jump to
@@ -3703,7 +3722,7 @@ void A_MummyAttack2(mobj_t * actor)
 
 void A_MummyFX1Seek(mobj_t * actor)
 {
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 20);
+    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 20, false);
 }
 
 void A_MummySoul(mobj_t * mummy)
@@ -4157,7 +4176,7 @@ void A_WhirlwindSeek(mobj_t * actor)
     {
         return;
     }
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30);
+    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false);
 }
 
 void A_HeadIceImpact(mobj_t * ice)

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3243,12 +3243,12 @@ void A_HealChase(mobj_t* actor)
 }
 
 //
-// A_Seek
+// A_SeekTracer
 // A parameterized seeker missile function.
 //   args[0]: direct-homing threshold angle (degrees, in fixed point)
 //   args[1]: maximum turn angle (degrees, in fixed point)
 //
-void A_Seek(mobj_t *actor)
+void A_SeekTracer(mobj_t *actor)
 {
   angle_t threshold, maxturnangle;
 

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3258,7 +3258,7 @@ void A_SeekTracer(mobj_t *actor)
   threshold    = FixedToAngle(actor->state->args[0]);
   maxturnangle = FixedToAngle(actor->state->args[1]);
 
-  P_SeekerMissile(actor, threshold, maxturnangle, true);
+  P_SeekerMissile(actor, threshold, maxturnangle, true, true);
 }
 
 //
@@ -3754,7 +3754,7 @@ void A_MummyAttack2(mobj_t * actor)
 
 void A_MummyFX1Seek(mobj_t * actor)
 {
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 20, false);
+    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 20, false, false);
 }
 
 void A_MummySoul(mobj_t * mummy)
@@ -4208,7 +4208,7 @@ void A_WhirlwindSeek(mobj_t * actor)
     {
         return;
     }
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false);
+    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false, false);
 }
 
 void A_HeadIceImpact(mobj_t * ice)

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3353,6 +3353,45 @@ void A_JumpIfTargetCloser(mobj_t* actor)
 }
 
 //
+// A_JumpIfTracerInSight
+// Jumps to a state if caller's tracer (seek target) is in line-of-sight.
+//   args[0]: State to jump to
+//
+void A_JumpIfTracerInSight(mobj_t* actor)
+{
+  int state;
+
+  if (!mbf21 || !actor || !actor->tracer)
+    return;
+
+  state = actor->state->args[0];
+
+  if (P_CheckSight(actor, actor->tracer))
+    P_SetMobjState(actor, state);
+}
+
+//
+// A_JumpIfTracerCloser
+// Jumps to a state if caller's tracer (seek target) is closer than the specified distance.
+//   args[0]: State to jump to
+//   args[1]: Distance threshold (fixed point)
+//
+void A_JumpIfTracerCloser(mobj_t* actor)
+{
+  int state, distance;
+
+  if (!mbf21 || !actor || !actor->tracer)
+    return;
+
+  state    = actor->state->args[0];
+  distance = actor->state->args[1];
+
+  if (distance > P_AproxDistance(actor->x - actor->tracer->x,
+                                 actor->y - actor->tracer->y))
+    P_SetMobjState(actor, state);
+}
+
+//
 // A_JumpIfFlagsSet
 // Jumps to a state if caller has the specified thing flags set.
 //   args[0]: State to jump to

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3262,6 +3262,38 @@ void A_Seek(mobj_t *actor)
 }
 
 //
+// A_FindTracer
+// Search for a valid tracer (seek target), if the calling actor doesn't already have one.
+//   args[0]: field-of-view to search in (degrees, in fixed point); if zero, will search in all directions
+//   args[1]: distance to search (map blocks, i.e. 128 units)
+//
+void A_FindTracer(mobj_t *actor)
+{
+  angle_t fov;
+  int dist;
+
+  if (!mbf21 || !actor || actor->tracer)
+    return;
+
+  fov  = FixedToAngle(actor->state->args[0]);
+  dist =             (actor->state->args[1]);
+
+  actor->tracer = P_RoughMonsterSearch(actor, fov, dist);
+}
+
+//
+// A_ClearTracer
+// Clear current tracer (seek target).
+//
+void A_ClearTracer(mobj_t *actor)
+{
+  if (!mbf21 || !actor)
+    return;
+
+  actor->tracer = NULL;
+}
+
+//
 // A_JumpIfHealthBelow
 // Jumps to a state if caller's health is below the specified threshold.
 //   args[0]: State to jump to

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3258,7 +3258,7 @@ void A_SeekTracer(mobj_t *actor)
   threshold    = FixedToAngle(actor->state->args[0]);
   maxturnangle = FixedToAngle(actor->state->args[1]);
 
-  P_SeekerMissile(actor, threshold, maxturnangle, true, true);
+  P_SeekerMissile(actor, &actor->tracer, threshold, maxturnangle, true);
 }
 
 //
@@ -3793,7 +3793,7 @@ void A_MummyAttack2(mobj_t * actor)
 
 void A_MummyFX1Seek(mobj_t * actor)
 {
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 20, false, false);
+    P_SeekerMissile(actor, &actor->special1.m, ANG1_X * 10, ANG1_X * 20, false);
 }
 
 void A_MummySoul(mobj_t * mummy)
@@ -4247,7 +4247,7 @@ void A_WhirlwindSeek(mobj_t * actor)
     {
         return;
     }
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false, false);
+    P_SeekerMissile(actor, &actor->special1.m, ANG1_X * 10, ANG1_X * 30, false);
 }
 
 void A_HeadIceImpact(mobj_t * ice)

--- a/prboom2/src/p_enemy.h
+++ b/prboom2/src/p_enemy.h
@@ -135,6 +135,8 @@ void A_ClearTracer(mobj_t *);
 void A_JumpIfHealthBelow(mobj_t *);
 void A_JumpIfTargetInSight(mobj_t *);
 void A_JumpIfTargetCloser(mobj_t *);
+void A_JumpIfTracerInSight(mobj_t *);
+void A_JumpIfTracerCloser(mobj_t *);
 void A_JumpIfFlagsSet(mobj_t *);
 void A_AddFlags(mobj_t *);
 void A_RemoveFlags(mobj_t *);

--- a/prboom2/src/p_enemy.h
+++ b/prboom2/src/p_enemy.h
@@ -130,6 +130,8 @@ void A_RadiusDamage(mobj_t *);
 void A_NoiseAlert(mobj_t *);
 void A_HealChase(mobj_t *);
 void A_Seek(mobj_t *);
+void A_FindTracer(mobj_t *);
+void A_ClearTracer(mobj_t *);
 void A_JumpIfHealthBelow(mobj_t *);
 void A_JumpIfTargetInSight(mobj_t *);
 void A_JumpIfTargetCloser(mobj_t *);

--- a/prboom2/src/p_enemy.h
+++ b/prboom2/src/p_enemy.h
@@ -129,7 +129,7 @@ void A_MonsterMeleeAttack(mobj_t *);
 void A_RadiusDamage(mobj_t *);
 void A_NoiseAlert(mobj_t *);
 void A_HealChase(mobj_t *);
-void A_Seek(mobj_t *);
+void A_SeekTracer(mobj_t *);
 void A_FindTracer(mobj_t *);
 void A_ClearTracer(mobj_t *);
 void A_JumpIfHealthBelow(mobj_t *);

--- a/prboom2/src/p_enemy.h
+++ b/prboom2/src/p_enemy.h
@@ -129,6 +129,7 @@ void A_MonsterMeleeAttack(mobj_t *);
 void A_RadiusDamage(mobj_t *);
 void A_NoiseAlert(mobj_t *);
 void A_HealChase(mobj_t *);
+void A_Seek(mobj_t *);
 void A_JumpIfHealthBelow(mobj_t *);
 void A_JumpIfTargetInSight(mobj_t *);
 void A_JumpIfTargetCloser(mobj_t *);

--- a/prboom2/src/p_maputl.c
+++ b/prboom2/src/p_maputl.c
@@ -725,6 +725,195 @@ dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
   return P_TraverseIntercepts(trav, FRACUNIT);
 }
 
+//
+// RoughBlockCheck
+// [XA] adapted from Hexen -- used by P_RoughMonsterSearch
+//
+
+static mobj_t *RoughBlockCheck(mobj_t *mo, int index, angle_t fov)
+{
+  mobj_t *link;
+  mobj_t *master;
+  angle_t angle, minang, maxang;
+
+  // pre-calculate fov check stuff since it
+  // won't change during the blocklinks loop
+  if (fov > 0) {
+    minang = mo->angle - fov / 2;
+    maxang = mo->angle + fov / 2;
+  }
+
+  link = blocklinks[index];
+  while (link)
+  {
+    // skip non-shootable actors
+    if (!(link->flags & MF_SHOOTABLE))
+    {
+      link = link->bnext;
+      continue;
+    }
+
+    // skip other players in co-op
+    if (netgame && !deathmatch && link->player)
+    {
+      link = link->bnext;
+      continue;
+    }
+
+    // skip the projectile's owner
+    if (link == mo->target)
+    {
+      link = link->bnext;
+      continue;
+    }
+
+    // skip friendly actors if owner is friendly (or a player)
+    if ((link->flags & MF_FRIEND) && mo->target != NULL &&
+      ((mo->target->flags & MF_FRIEND) || mo->target->player))
+    {
+      link = link->bnext;
+      continue;
+    }
+
+    // skip actors outside of specified FOV
+    // [XA] code borrowed from EE; thanks Quas :D
+    if (fov > 0)
+    {
+      angle = R_PointToAngle2(mo->x, mo->y, link->x, link->y);
+      // if the angles are backward, compare differently
+      if((minang > maxang) ? angle < minang && angle > maxang
+                           : angle < minang || angle > maxang)
+      {
+        link = link->bnext;
+        continue;
+      }
+    }
+
+    // skip actors not in line of sight
+    if (!P_CheckSight(mo, link))
+    {
+      link = link->bnext;
+      continue;
+    }
+
+    // all good! return it.
+    return link;
+  }
+
+  // couldn't find a valid target
+  return NULL;
+}
+
+//
+// P_RoughMonsterSearch
+// Searches though the surrounding mapblocks for monsters/players
+//
+// distance is in MAPBLOCKUNITS
+
+mobj_t *P_RoughMonsterSearch(mobj_t *mo, angle_t fov, int distance)
+{
+  int blockX;
+  int blockY;
+  int startX, startY;
+  int blockIndex;
+  int firstStop;
+  int secondStop;
+  int thirdStop;
+  int finalStop;
+  int count;
+  mobj_t *target;
+
+  startX = (mo->x - bmaporgx) >> MAPBLOCKSHIFT;
+  startY = (mo->y - bmaporgy) >> MAPBLOCKSHIFT;
+
+  if (startX >= 0 && startX < bmapwidth && startY >= 0 && startY < bmapheight)
+  {
+    if (target = RoughBlockCheck(mo, startY*bmapwidth + startX, fov))
+    { // found a target right away
+      return target;
+    }
+  }
+  for (count = 1; count <= distance; count++)
+  {
+    blockX = startX - count;
+    blockY = startY - count;
+
+    if (blockY < 0)
+    {
+      blockY = 0;
+    }
+    else if (blockY >= bmapheight)
+    {
+      blockY = bmapheight - 1;
+    }
+    if (blockX < 0)
+    {
+      blockX = 0;
+    }
+    else if (blockX >= bmapwidth)
+    {
+      blockX = bmapwidth - 1;
+    }
+    blockIndex = blockY * bmapwidth + blockX;
+    firstStop = startX + count;
+    if (firstStop < 0)
+    {
+      continue;
+    }
+    if (firstStop >= bmapwidth)
+    {
+      firstStop = bmapwidth - 1;
+    }
+    secondStop = startY + count;
+    if (secondStop < 0)
+    {
+      continue;
+    }
+    if (secondStop >= bmapheight)
+    {
+      secondStop = bmapheight - 1;
+    }
+    thirdStop = secondStop * bmapwidth + blockX;
+    secondStop = secondStop * bmapwidth + firstStop;
+    firstStop += blockY * bmapwidth;
+    finalStop = blockIndex;
+
+    // Trace the first block section (along the top)
+    for (; blockIndex <= firstStop; blockIndex++)
+    {
+      if (target = RoughBlockCheck(mo, blockIndex, fov))
+      {
+        return target;
+      }
+    }
+    // Trace the second block section (right edge)
+    for (blockIndex--; blockIndex <= secondStop; blockIndex += bmapwidth)
+    {
+      if (target = RoughBlockCheck(mo, blockIndex, fov))
+      {
+        return target;
+      }
+    }
+    // Trace the third block section (bottom edge)
+    for (blockIndex -= bmapwidth; blockIndex >= thirdStop; blockIndex--)
+    {
+      if (target = RoughBlockCheck(mo, blockIndex, fov))
+      {
+        return target;
+      }
+    }
+    // Trace the final block section (left edge)
+    for (blockIndex++; blockIndex > finalStop; blockIndex -= bmapwidth)
+    {
+      if (target = RoughBlockCheck(mo, blockIndex, fov))
+      {
+        return target;
+      }
+    }
+  }
+  return NULL;
+}
+
 // MAES: support 512x512 blockmaps.
 int P_GetSafeBlockX(int coord)
 {

--- a/prboom2/src/p_maputl.c
+++ b/prboom2/src/p_maputl.c
@@ -733,7 +733,6 @@ dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
 static mobj_t *RoughBlockCheck(mobj_t *mo, int index, angle_t fov)
 {
   mobj_t *link;
-  mobj_t *master;
   angle_t angle, minang, maxang;
 
   // pre-calculate fov check stuff since it
@@ -753,13 +752,6 @@ static mobj_t *RoughBlockCheck(mobj_t *mo, int index, angle_t fov)
       continue;
     }
 
-    // skip other players in co-op
-    if (netgame && !deathmatch && link->player)
-    {
-      link = link->bnext;
-      continue;
-    }
-
     // skip the projectile's owner
     if (link == mo->target)
     {
@@ -767,9 +759,11 @@ static mobj_t *RoughBlockCheck(mobj_t *mo, int index, angle_t fov)
       continue;
     }
 
-    // skip friendly actors if owner is friendly (or a player)
-    if ((link->flags & MF_FRIEND) && mo->target != NULL &&
-      ((mo->target->flags & MF_FRIEND) || mo->target->player))
+    // skip actors on the same "team", unless infighting or deathmatching
+    if (mo->target &&
+      !((link->flags ^ mo->target->flags) & MF_FRIEND) &&
+      mo->target->target != link &&
+      !(deathmatch && link->player && mo->target->player))
     {
       link = link->bnext;
       continue;

--- a/prboom2/src/p_maputl.c
+++ b/prboom2/src/p_maputl.c
@@ -727,7 +727,7 @@ dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
 
 //
 // RoughBlockCheck
-// [XA] adapted from Hexen -- used by P_RoughMonsterSearch
+// [XA] adapted from Hexen -- used by P_RoughTargetSearch
 //
 
 static mobj_t *RoughBlockCheck(mobj_t *mo, int index, angle_t fov)
@@ -805,12 +805,13 @@ static mobj_t *RoughBlockCheck(mobj_t *mo, int index, angle_t fov)
 }
 
 //
-// P_RoughMonsterSearch
+// P_RoughTargetSearch
 // Searches though the surrounding mapblocks for monsters/players
+// based on Hexen's P_RoughMonsterSearch
 //
 // distance is in MAPBLOCKUNITS
 
-mobj_t *P_RoughMonsterSearch(mobj_t *mo, angle_t fov, int distance)
+mobj_t *P_RoughTargetSearch(mobj_t *mo, angle_t fov, int distance)
 {
   int blockX;
   int blockY;

--- a/prboom2/src/p_maputl.h
+++ b/prboom2/src/p_maputl.h
@@ -86,7 +86,7 @@ dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
                        int flags, dboolean trav(intercept_t *));
 
 angle_t P_PointToAngle(fixed_t xo, fixed_t yo, fixed_t x, fixed_t y);
-mobj_t *P_RoughMonsterSearch(mobj_t *mo, angle_t fov, int distance);
+mobj_t *P_RoughTargetSearch(mobj_t *mo, angle_t fov, int distance);
 
 // MAES: support 512x512 blockmaps.
 int P_GetSafeBlockX(int coord);

--- a/prboom2/src/p_maputl.h
+++ b/prboom2/src/p_maputl.h
@@ -85,6 +85,9 @@ dboolean P_BlockThingsIterator(int x, int y, dboolean func(mobj_t *));
 dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
                        int flags, dboolean trav(intercept_t *));
 
+angle_t P_PointToAngle(fixed_t xo, fixed_t yo, fixed_t x, fixed_t y);
+mobj_t *P_RoughMonsterSearch(mobj_t *mo, angle_t fov, int distance);
+
 // MAES: support 512x512 blockmaps.
 int P_GetSafeBlockX(int coord);
 int P_GetSafeBlockY(int coord);

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2232,7 +2232,7 @@ void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move)
     mo->momy += FixedMul(move, finesine[angle]);
 }
 
-dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer, dboolean seekcenter)
+dboolean P_SeekerMissile(mobj_t * actor, mobj_t ** seekTarget, angle_t thresh, angle_t turnMax, dboolean seekcenter)
 {
     int dir;
     int dist;
@@ -2240,17 +2240,14 @@ dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboole
     angle_t angle;
     mobj_t *target;
 
-    target = (mobj_t *)(usetracer ? actor->tracer : actor->special1.m);
+    target = *seekTarget;
     if (target == NULL)
     {
         return (false);
     }
     if (!(target->flags & MF_SHOOTABLE))
     {                           // Target died
-        if (usetracer)
-            actor->tracer = NULL;
-        else
-            actor->special1.m = NULL;
+        *seekTarget = NULL;
         return (false);
     }
     dir = P_FaceMobj(actor, target, &delta);

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2232,7 +2232,7 @@ void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move)
     mo->momy += FixedMul(move, finesine[angle]);
 }
 
-dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer)
+dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer, dboolean seekcenter)
 {
     int dir;
     int dist;
@@ -2274,7 +2274,7 @@ dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboole
     actor->momx = FixedMul(actor->info->speed, finecosine[angle]);
     actor->momy = FixedMul(actor->info->speed, finesine[angle]);
     if (actor->z + actor->height < target->z ||
-        target->z + target->height < actor->z)
+        target->z + target->height < actor->z || seekcenter)
     {                           // Need to seek vertically
         dist = P_AproxDistance(target->x - actor->x, target->y - actor->y);
         dist = dist / actor->info->speed;
@@ -2282,7 +2282,7 @@ dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboole
         {
             dist = 1;
         }
-        actor->momz = (target->z - actor->z) / dist;
+        actor->momz = (target->z + (seekcenter ? target->height/2 : 0) - actor->z) / dist;
     }
     return (true);
 }

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2232,7 +2232,7 @@ void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move)
     mo->momy += FixedMul(move, finesine[angle]);
 }
 
-dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax)
+dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer)
 {
     int dir;
     int dist;
@@ -2240,14 +2240,17 @@ dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax)
     angle_t angle;
     mobj_t *target;
 
-    target = (mobj_t *) actor->special1.m;
+    target = (mobj_t *)(usetracer ? actor->tracer : actor->special1.m);
     if (target == NULL)
     {
         return (false);
     }
     if (!(target->flags & MF_SHOOTABLE))
     {                           // Target died
-        actor->special1.m = NULL;
+        if (usetracer)
+            actor->tracer = NULL;
+        else
+            actor->special1.m = NULL;
         return (false);
     }
     dir = P_FaceMobj(actor, target, &delta);

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -499,7 +499,7 @@ void P_BlasterMobjThinker(mobj_t * mobj);
 mobj_t *P_SpawnMissileAngle(mobj_t * source, mobjtype_t type, angle_t angle, fixed_t momz);
 dboolean P_SetMobjStateNF(mobj_t * mobj, statenum_t state);
 void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move);
-dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer, dboolean seekcenter);
+dboolean P_SeekerMissile(mobj_t * actor, mobj_t ** seekTarget, angle_t thresh, angle_t turnMax, dboolean seekcenter);
 mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle);
 int P_HitFloor(mobj_t * thing);
 int P_GetThingFloorType(mobj_t * thing);

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -499,7 +499,7 @@ void P_BlasterMobjThinker(mobj_t * mobj);
 mobj_t *P_SpawnMissileAngle(mobj_t * source, mobjtype_t type, angle_t angle, fixed_t momz);
 dboolean P_SetMobjStateNF(mobj_t * mobj, statenum_t state);
 void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move);
-dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax);
+dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer);
 mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle);
 int P_HitFloor(mobj_t * thing);
 int P_GetThingFloorType(mobj_t * thing);

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -499,7 +499,7 @@ void P_BlasterMobjThinker(mobj_t * mobj);
 mobj_t *P_SpawnMissileAngle(mobj_t * source, mobjtype_t type, angle_t angle, fixed_t momz);
 dboolean P_SetMobjStateNF(mobj_t * mobj, statenum_t state);
 void P_ThrustMobj(mobj_t * mo, angle_t angle, fixed_t move);
-dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer);
+dboolean P_SeekerMissile(mobj_t * actor, angle_t thresh, angle_t turnMax, dboolean usetracer, dboolean seekcenter);
 mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle);
 int P_HitFloor(mobj_t * thing);
 int P_GetThingFloorType(mobj_t * thing);

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -2024,7 +2024,7 @@ void A_FireSkullRodPL2(player_t * player, pspdef_t * psp)
 
 void A_SkullRodPL2Seek(mobj_t * actor)
 {
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30);
+    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false);
 }
 
 void A_AddPlayerRain(mobj_t * actor)
@@ -2156,7 +2156,7 @@ void A_PhoenixPuff(mobj_t * actor)
     mobj_t *puff;
     angle_t angle;
 
-    P_SeekerMissile(actor, ANG1_X * 5, ANG1_X * 10);
+    P_SeekerMissile(actor, ANG1_X * 5, ANG1_X * 10, false);
     puff = P_SpawnMobj(actor->x, actor->y, actor->z, HERETIC_MT_PHOENIXPUFF);
     angle = actor->angle + ANG90;
     angle >>= ANGLETOFINESHIFT;

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -1181,6 +1181,11 @@ void A_WeaponProjectile(player_t *player, pspdef_t *psp)
   mo->x += FixedMul(spawnofs_xy, finecosine[an]);
   mo->y += FixedMul(spawnofs_xy, finesine[an]);
   mo->z += spawnofs_z;
+
+  // set tracer to the player's autoaim target,
+  // so player seeker missiles prioritizing the
+  // baddie the player is actually aiming at. ;)
+  mo->tracer = linetarget;
 }
 
 //

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -2029,7 +2029,7 @@ void A_FireSkullRodPL2(player_t * player, pspdef_t * psp)
 
 void A_SkullRodPL2Seek(mobj_t * actor)
 {
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false);
+    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false, false);
 }
 
 void A_AddPlayerRain(mobj_t * actor)
@@ -2161,7 +2161,7 @@ void A_PhoenixPuff(mobj_t * actor)
     mobj_t *puff;
     angle_t angle;
 
-    P_SeekerMissile(actor, ANG1_X * 5, ANG1_X * 10, false);
+    P_SeekerMissile(actor, ANG1_X * 5, ANG1_X * 10, false, false);
     puff = P_SpawnMobj(actor->x, actor->y, actor->z, HERETIC_MT_PHOENIXPUFF);
     angle = actor->angle + ANG90;
     angle >>= ANGLETOFINESHIFT;

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -2029,7 +2029,7 @@ void A_FireSkullRodPL2(player_t * player, pspdef_t * psp)
 
 void A_SkullRodPL2Seek(mobj_t * actor)
 {
-    P_SeekerMissile(actor, ANG1_X * 10, ANG1_X * 30, false, false);
+    P_SeekerMissile(actor, &actor->special1.m, ANG1_X * 10, ANG1_X * 30, false);
 }
 
 void A_AddPlayerRain(mobj_t * actor)
@@ -2161,7 +2161,7 @@ void A_PhoenixPuff(mobj_t * actor)
     mobj_t *puff;
     angle_t angle;
 
-    P_SeekerMissile(actor, ANG1_X * 5, ANG1_X * 10, false, false);
+    P_SeekerMissile(actor, &actor->special1.m, ANG1_X * 5, ANG1_X * 10, false);
     puff = P_SpawnMobj(actor->x, actor->y, actor->z, HERETIC_MT_PHOENIXPUFF);
     angle = actor->angle + ANG90;
     angle >>= ANGLETOFINESHIFT;


### PR DESCRIPTION
Redoing this PR sans the funky whitespace-fuxing commit -- there were some suggested changes to the target-checking rules anyway so it's better to ditch it and redo it IMO.

Original post follows:

> Adds the following MBF21 codepointers:
> - A_SeekTracer(threshold, maxturnangle)
> - A_FindTracer(fov, distance)
> - A_ClearTracer
> - A_JumpIfTracerInSight(state)
> - A_JumpIfTracerCloser(state, distance)
> 
> More deets in mbf21.md as usual. Been a lot of fun testing this one. :P