### PR TITLE
MBF21 Melee Range property

### DIFF
--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -135,6 +135,8 @@ In this example:
 #### Melee range
 - [PR](https://github.com/kraflab/dsda-doom/pull/46)
 - Sets the range at which a monster will initiate a melee attack.
+- Also affects the range for vanilla melee attack codepointers, e.g. A_SargAttack, A_TroopAttack, etc.
+  - Similarly, adjusting the player mobj's melee range will adjust the range of A_Punch and A_Saw
 - Add `Melee range = X` in the Thing definition.
 - `X` is in fixed point, like the Radius and Height fields
 

--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -132,6 +132,12 @@ In this example:
 - Add `Fast speed = X` in the Thing definition.
 - `X` has the same units as the normal `Speed` field.
 
+#### Melee range
+- [PR](https://github.com/kraflab/dsda-doom/pull/46)
+- Sets the range at which a monster will initiate a melee attack.
+- Add `Melee range = X` in the Thing definition.
+- `X` is in fixed point, like the Radius and Height fields
+
 ## Weapons
 
 #### Weapon Flags

--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -273,7 +273,7 @@ MBF21 defaults:
     - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
     - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 8
     - `sound (uint)`: Sound to play if attack hits
-    - `range (fixed)`: Attack range; if not set, defaults to monster's meleerange property (or 64.0 if that's not set either)
+    - `range (fixed)`: Attack range; if not set, defaults to calling actor's melee range property
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
 
@@ -423,7 +423,7 @@ MBF21 defaults:
     - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 10
     - `zerkfactor (fixed)`: Berserk damage multiplier; if not set, defaults to 1.0
     - `sound (uint)`: Sound to play if attack hits
-    - `range (fixed)`: Attack range; if not set, defaults to 64.0
+    - `range (fixed)`: Attack range; if not set, defaults to player mobj's melee range property
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`; this is then multiplied by `zerkfactor` if the player has Berserk.
 

--- a/prboom2/doc/mbf21.md
+++ b/prboom2/doc/mbf21.md
@@ -265,7 +265,7 @@ MBF21 defaults:
     - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
     - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 8
     - `sound (uint)`: Sound to play if attack hits
-    - `range (fixed)`: Attack range; if not set, defaults to 64.0
+    - `range (fixed)`: Attack range; if not set, defaults to monster's meleerange property (or 64.0 if that's not set either)
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
 

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1065,7 +1065,7 @@ typedef struct
 // killough 8/9/98: make DEH_BLOCKMAX self-adjusting
 #define DEH_BLOCKMAX (sizeof(deh_blocks) / sizeof(*deh_blocks))  // size of array
 #define DEH_MAXKEYLEN 32 // as much of any key as we'll look at
-#define DEH_MOBJINFOMAX 31 // number of mobjinfo configuration keys
+#define DEH_MOBJINFOMAX 32 // number of mobjinfo configuration keys
 
 // Put all the block header values, and the function to be called when that
 // one is encountered, in this array:
@@ -1139,6 +1139,7 @@ static const char *deh_mobjinfo[DEH_MOBJINFOMAX] =
   "MBF21 Bits",          // .flags2
   "Rip sound",           // .ripsound
   "Fast speed",          // .altspeed
+  "Melee range",         // .meleerange
 };
 
 // Strings that are used to indicate flags ("Bits" in mobjinfo)
@@ -1981,6 +1982,7 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint_64_t value) {
       return;
     case 29: mi->ripsound = (int)value; return;
     case 30: mi->altspeed = (int)value; return;
+    case 31: mi->meleerange = (int)value; return;
 
     default: return;
   }

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1490,7 +1490,7 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_SpawnObject,         "A_SpawnObject", 8},
   {A_MonsterProjectile,   "A_MonsterProjectile", 5},
   {A_MonsterBulletAttack, "A_MonsterBulletAttack", 5, {0, 0, 1, 3, 5}},
-  {A_MonsterMeleeAttack,  "A_MonsterMeleeAttack", 4, {3, 8, 0, MELEERANGE}},
+  {A_MonsterMeleeAttack,  "A_MonsterMeleeAttack", 4, {3, 8, 0, 0}},
   {A_RadiusDamage,        "A_RadiusDamage", 2},
   {A_NoiseAlert,          "A_NoiseAlert", 0},
   {A_HealChase,           "A_HealChase", 2},

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1507,7 +1507,7 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_RemoveFlags,         "A_RemoveFlags", 2},
   {A_WeaponProjectile,    "A_WeaponProjectile", 5},
   {A_WeaponBulletAttack,  "A_WeaponBulletAttack", 5, {0, 0, 1, 5, 3}},
-  {A_WeaponMeleeAttack,   "A_WeaponMeleeAttack", 5, {2, 10, 1 * FRACUNIT, 0, MELEERANGE}},
+  {A_WeaponMeleeAttack,   "A_WeaponMeleeAttack", 5, {2, 10, 1 * FRACUNIT, 0, 0}},
   {A_WeaponSound,         "A_WeaponSound", 2},
   {A_WeaponAlert,         "A_WeaponAlert", 0},
   {A_WeaponJump,          "A_WeaponJump", 2},

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -260,7 +260,7 @@ static void dsda_InitDoom(void) {
     mobjinfo[i].splash_group = SG_DEFAULT;
     mobjinfo[i].ripsound = sfx_None;
     mobjinfo[i].altspeed = NO_ALTSPEED;
-    mobjinfo[i].meleerange = NO_MELEERANGE; // don't set directly to MELEERANGE, since default behavior has a compatibility fallback
+    mobjinfo[i].meleerange = MELEERANGE;
   }
 
   // don't want to reorganize info.c structure for a few tweaks...
@@ -404,7 +404,7 @@ static void dsda_InitHeretic(void) {
     mobjinfo[j].splash_group = SG_DEFAULT;
     mobjinfo[j].ripsound = heretic_sfx_None;
     mobjinfo[j].altspeed = NO_ALTSPEED;
-    mobjinfo[i].meleerange = NO_MELEERANGE; // don't set directly to MELEERANGE, since default behavior has a compatibility fallback
+    mobjinfo[j].meleerange = MELEERANGE;
   }
 
   // don't want to reorganize info.c structure for a few tweaks...

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -260,6 +260,7 @@ static void dsda_InitDoom(void) {
     mobjinfo[i].splash_group = SG_DEFAULT;
     mobjinfo[i].ripsound = sfx_None;
     mobjinfo[i].altspeed = NO_ALTSPEED;
+    mobjinfo[i].meleerange = NO_MELEERANGE; // don't set directly to MELEERANGE, since default behavior has a compatibility fallback
   }
 
   // don't want to reorganize info.c structure for a few tweaks...
@@ -403,6 +404,7 @@ static void dsda_InitHeretic(void) {
     mobjinfo[j].splash_group = SG_DEFAULT;
     mobjinfo[j].ripsound = heretic_sfx_None;
     mobjinfo[j].altspeed = NO_ALTSPEED;
+    mobjinfo[i].meleerange = NO_MELEERANGE; // don't set directly to MELEERANGE, since default behavior has a compatibility fallback
   }
 
   // don't want to reorganize info.c structure for a few tweaks...

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -23,6 +23,7 @@
 #include "d_items.h"
 #include "p_inter.h"
 #include "p_spec.h"
+#include "p_map.h"
 #include "sounds.h"
 #include "d_main.h"
 #include "v_video.h"

--- a/prboom2/src/info.h
+++ b/prboom2/src/info.h
@@ -3091,7 +3091,6 @@ typedef struct
 } mobjinfo_t;
 
 #define NO_ALTSPEED -1
-#define NO_MELEERANGE -1
 
 typedef struct
 {

--- a/prboom2/src/info.h
+++ b/prboom2/src/info.h
@@ -3087,9 +3087,11 @@ typedef struct
   int splash_group;
   int ripsound;
   int altspeed;
+  int meleerange;
 } mobjinfo_t;
 
 #define NO_ALTSPEED -1
+#define NO_MELEERANGE -1
 
 typedef struct
 {

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -166,12 +166,16 @@ static dboolean P_CheckRange(mobj_t *actor, fixed_t range)
 
 static dboolean P_CheckMeleeRange(mobj_t *actor)
 {
-  return P_CheckRange(
-    actor,
-    compatibility_level == doom_12_compatibility ?
-     MELEERANGE :
-     MELEERANGE - 20*FRACUNIT + actor->target->info->radius
-  );
+  int range;
+
+  if (mbf21 && actor->info->meleerange != NO_MELEERANGE)
+    range = actor->info->meleerange;
+  else if (compatibility_level == doom_12_compatibility)
+    range = MELEERANGE;
+  else
+    range = MELEERANGE - 20 * FRACUNIT + actor->target->info->radius;
+
+  return P_CheckRange(actor, range);
 }
 
 //

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3175,7 +3175,7 @@ void A_MonsterBulletAttack(mobj_t *actor)
 //   args[0]: Base damage of attack (e.g. for 3d8, customize the 3); if not set, defaults to 3
 //   args[1]: Attack damage modulus (e.g. for 3d8, customize the 8); if not set, defaults to 8
 //   args[2]: Sound to play if attack hits
-//   args[3]: Range (fixed point); if not set, defaults to MELEERANGE (64.0)
+//   args[3]: Range (fixed point); if not set, defaults to monster's meleerange property (or MELEERANGE (64.0) if that's unset too)
 //
 void A_MonsterMeleeAttack(mobj_t *actor)
 {
@@ -3189,6 +3189,9 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   damagemod  = actor->state->args[1];
   hitsound   = actor->state->args[2];
   range      = actor->state->args[3];
+
+  if (range == 0)
+    range = (actor->info->meleerange == NO_MELEERANGE) ? MELEERANGE : actor->info->meleerange;
 
   A_FaceTarget(actor);
   if (!P_CheckRange(actor, range + actor->target->info->radius))

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -171,7 +171,7 @@ static dboolean P_CheckMeleeRange(mobj_t *actor)
   range = actor->info->meleerange;
 
   if (compatibility_level != doom_12_compatibility)
-    range -= 20 * FRACUNIT + actor->target->info->radius;
+    range += actor->target->info->radius - 20 * FRACUNIT;
 
   return P_CheckRange(actor, range);
 }
@@ -3191,7 +3191,7 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   if (range == 0)
     range = actor->info->meleerange;
 
-  range -= 20 * FRACUNIT + actor->target->info->radius;
+  range += actor->target->info->radius - 20 * FRACUNIT;
 
   A_FaceTarget(actor);
   if (!P_CheckRange(actor, range))

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -168,12 +168,10 @@ static dboolean P_CheckMeleeRange(mobj_t *actor)
 {
   int range;
 
-  if (mbf21 && actor->info->meleerange != NO_MELEERANGE)
-    range = actor->info->meleerange;
-  else if (compatibility_level == doom_12_compatibility)
-    range = MELEERANGE;
-  else
-    range = MELEERANGE - 20 * FRACUNIT + actor->target->info->radius;
+  range = actor->info->meleerange;
+
+  if (compatibility_level != doom_12_compatibility)
+    range -= 20 * FRACUNIT + actor->target->info->radius;
 
   return P_CheckRange(actor, range);
 }
@@ -3175,7 +3173,7 @@ void A_MonsterBulletAttack(mobj_t *actor)
 //   args[0]: Base damage of attack (e.g. for 3d8, customize the 3); if not set, defaults to 3
 //   args[1]: Attack damage modulus (e.g. for 3d8, customize the 8); if not set, defaults to 8
 //   args[2]: Sound to play if attack hits
-//   args[3]: Range (fixed point); if not set, defaults to monster's meleerange property (or MELEERANGE (64.0) if that's unset too)
+//   args[3]: Range (fixed point); if not set, defaults to monster's melee range
 //
 void A_MonsterMeleeAttack(mobj_t *actor)
 {
@@ -3191,10 +3189,12 @@ void A_MonsterMeleeAttack(mobj_t *actor)
   range      = actor->state->args[3];
 
   if (range == 0)
-    range = (actor->info->meleerange == NO_MELEERANGE) ? MELEERANGE : actor->info->meleerange;
+    range = actor->info->meleerange;
+
+  range -= 20 * FRACUNIT + actor->target->info->radius;
 
   A_FaceTarget(actor);
-  if (!P_CheckRange(actor, range + actor->target->info->radius))
+  if (!P_CheckRange(actor, range))
     return;
 
   S_StartSound(actor, hitsound);

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -756,7 +756,7 @@ static dboolean P_IsVisible(mobj_t *actor, mobj_t *mo, dboolean allaround)
       angle_t an = R_PointToAngle2(actor->x, actor->y,
            mo->x, mo->y) - actor->angle;
       if (an > ANG90 && an < ANG270 &&
-    P_AproxDistance(mo->x-actor->x, mo->y-actor->y) > MELEERANGE)
+    P_AproxDistance(mo->x-actor->x, mo->y-actor->y) > WAKEUPRANGE)
   return false;
     }
   return P_CheckSight(actor, mo);
@@ -4865,14 +4865,14 @@ dboolean Heretic_P_LookForPlayers(mobj_t * actor, dboolean allaround)
                 dist = P_AproxDistance(player->mo->x - actor->x,
                                        player->mo->y - actor->y);
                 // if real close, react anyway
-                if (dist > MELEERANGE)
+                if (dist > WAKEUPRANGE)
                     continue;   // behind back
             }
         }
         if (player->mo->flags & MF_SHADOW)
         {                       // Player is invisible
             if ((P_AproxDistance(player->mo->x - actor->x,
-                                 player->mo->y - actor->y) > 2 * MELEERANGE)
+                                 player->mo->y - actor->y) > SNEAKRANGE)
                 && P_AproxDistance(player->mo->momx, player->mo->momy)
                 < 5 * FRACUNIT)
             {                   // Player is sneaking - can't detect

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -719,9 +719,9 @@ static void P_NewChaseDir(mobj_t *actor)
           actor->info->missilestate &&
           actor->type != MT_SKULL &&
           (
-            (!target->info->missilestate && dist < MELEERANGE*2) ||
+            (!target->info->missilestate && dist < target->info->meleerange*2) ||
             (
-              target->player && dist < MELEERANGE*3 &&
+              target->player && dist < target->player->mo->info->meleerange*3 &&
               weaponinfo[target->player->readyweapon].flags & WPF_FLEEMELEE
             )
           )

--- a/prboom2/src/p_map.h
+++ b/prboom2/src/p_map.h
@@ -41,6 +41,10 @@
 #define MELEERANGE      (64*FRACUNIT)
 #define MISSILERANGE    (32*64*FRACUNIT)
 
+// a couple of explicit constants for non-melee things that used to use MELEERANGE
+#define WAKEUPRANGE     (64*FRACUNIT)
+#define SNEAKRANGE      (128*FRACUNIT)
+
 // MAXRADIUS is for precalculated sector block boxes the spider demon
 // is larger, but we do not have any moving sectors nearby
 #define MAXRADIUS       (32*FRACUNIT)


### PR DESCRIPTION
Adds a "Melee range" thing property which allows you to specify the distance at which a monster will initiate a melee attack. 

Also adjusts A_MonsterMeleeAttack to use this value if its "range" arg is zero, for convenience n' whatnot.

mbf21.md updates coming shortly...

[EDIT] mbf21 updated. this was a pretty quick one. :P