### PR TITLE
Widescreen assets

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -572,10 +572,7 @@ static void D_PageDrawer(void)
 {
   if (heretic)
   {
-    const byte* lump = W_CacheLumpName(pagename);
-    V_DrawRawScreen(lump);
-    W_UnlockLumpName(pagename);
-
+    V_DrawRawScreen(pagename);
     return;
   }
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -584,9 +584,9 @@ static void D_PageDrawer(void)
   // proff - added M_DrawCredits
   if (pagename)
   {
-    V_DrawNamePatch(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
     // e6y: wide-res
     V_FillBorder(-1, 0);
+    V_DrawNamePatch(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
   }
   else
     M_DrawCredits();

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -631,17 +631,44 @@ void F_BunnyScroll (void)
   char        name[10];
   int         stage;
   static int  laststage;
+  static int  p1offset, p2width;
+
+  if (finalecount == 0)
+  {
+    const rpatch_t *p1, *p2;
+    p1 = R_CachePatchName(pfub1);
+    p2 = R_CachePatchName(pfub2);
+
+    p2width = p2->width;
+    if (p1->width == 320)
+    {
+      // Unity or original PFUBs.
+      p1offset = (p2width - 320) / 2;
+    }
+    else
+    {
+      // Widescreen mod PFUBs.
+      p1offset = 0;
+    }
+
+    W_UnlockLumpName(pfub2);
+    W_UnlockLumpName(pfub1);
+  }
 
   {
     int scrolled = 320 - (finalecount-230)/2;
     if (scrolled <= 0) {
       V_DrawNamePatch(0, 0, 0, pfub2, CR_DEFAULT, VPT_STRETCH);
     } else if (scrolled >= 320) {
-      V_DrawNamePatch(0, 0, 0, pfub1, CR_DEFAULT, VPT_STRETCH);
+      V_DrawNamePatch(p1offset, 0, 0, pfub1, CR_DEFAULT, VPT_STRETCH);
+      if (p1offset > 0)
+        V_DrawNamePatch(-320, 0, 0, pfub2, CR_DEFAULT, VPT_STRETCH);
     } else {
-      V_DrawNamePatch(320-scrolled, 0, 0, pfub1, CR_DEFAULT, VPT_STRETCH);
+      V_DrawNamePatch(p1offset + 320 - scrolled, 0, 0, pfub1, CR_DEFAULT, VPT_STRETCH);
       V_DrawNamePatch(-scrolled, 0, 0, pfub2, CR_DEFAULT, VPT_STRETCH);
     }
+    if (p2width == 320)
+      V_FillBorder(-1, 0);
   }
 
   if (finalecount < 1130)

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -306,8 +306,8 @@ void F_TextWrite (void)
   if (gamemapinfo && W_CheckNumForName(finaleflat) != -1 &&
       (W_CheckNumForName)(finaleflat, ns_flats) == -1)
   {
-    V_DrawNamePatch(0, 0, 0, finaleflat, CR_DEFAULT, VPT_STRETCH);
     V_FillBorder(-1, 0);
+    V_DrawNamePatch(0, 0, 0, finaleflat, CR_DEFAULT, VPT_STRETCH);
   }
   else
     V_DrawBackground(finaleflat, 0);
@@ -601,11 +601,11 @@ void F_CastDrawer (void)
   int                 lump;
   dboolean             flip;
 
+  // e6y: wide-res
+  V_FillBorder(-1, 0);
   // erase the entire screen to a background
   // CPhipps - patch drawing updated
   V_DrawNamePatch(0,0,0, bgcastcall, CR_DEFAULT, VPT_STRETCH); // Ty 03/30/98 bg texture extern
-  // e6y: wide-res
-  V_FillBorder(-1, 0);
 
   F_CastPrint (*(castorder[castnum].name));
 
@@ -692,6 +692,9 @@ void F_Drawer (void)
     F_TextWrite ();
   else
   {
+    // e6y: wide-res
+    V_FillBorder(-1, 0);
+
     switch (gameepisode)
     {
       // CPhipps - patch drawing updated
@@ -711,7 +714,5 @@ void F_Drawer (void)
            V_DrawNamePatch(0, 0, 0, "ENDPIC", CR_DEFAULT, VPT_STRETCH);
            break;
     }
-    // e6y: wide-res
-    V_FillBorder(-1, 0);
   }
 }

--- a/prboom2/src/f_finale2.c
+++ b/prboom2/src/f_finale2.c
@@ -171,8 +171,8 @@ void FMI_Drawer(void)
 	}
 	else
 	{
-		V_DrawNamePatch(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);
 		// e6y: wide-res
 		V_FillBorder(-1, 0);
+		V_DrawNamePatch(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);
 	}
 }

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -668,6 +668,10 @@ void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translati
     topoffset = gltexture->topoffset;
   }
 
+  // [FG] automatically center wide patches without horizontal offset
+  if (gltexture->width > 320 && leftoffset == 0)
+    x -= (float)(gltexture->width - 320) / 2;
+
   if (flags & VPT_STRETCH_MASK)
   {
     stretch_param_t *params = &stretch_params[flags & VPT_ALIGN_MASK];

--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -138,13 +138,13 @@ void Heretic_F_TextWrite(void)
   int lump;
   int width;
 
+  // e6y: wide-res
+  V_FillBorder(-1, 0);
+
   //
   // erase the entire screen to a tiled background
   //
   V_DrawBackground(finaleflat, 0);
-
-  // e6y: wide-res
-  V_FillBorder(-1, 0);
 
   //
   // draw some of the text onto the screen

--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -194,7 +194,6 @@ void Heretic_F_TextWrite(void)
 
 void F_DemonScroll(void)
 {
-  const byte *p1, *p2;
   static int yval = 0;
   static int nextscroll = 0;
 
@@ -203,28 +202,22 @@ void F_DemonScroll(void)
     return;
   }
 
-  p1 = W_CacheLumpName(DEH_String("FINAL1"));
-  p2 = W_CacheLumpName(DEH_String("FINAL2"));
-
   if (finalecount < 70)
   {
-    V_DrawRawScreen(p1);
+    V_DrawRawScreen(DEH_String("FINAL1"));
     nextscroll = finalecount;
   }
   else if (yval < 200)
   {
-    V_DrawRawScreenSection(p2 + (200 - yval) * 320, 0, yval);
-    V_DrawRawScreenSection(p1, yval, 200 - yval);
+    V_DrawRawScreenSection(DEH_String("FINAL2"), (200 - yval) * 320, 0, yval);
+    V_DrawRawScreenSection(DEH_String("FINAL1"), 0, yval, 200 - yval);
     yval++;
     nextscroll = finalecount + 3;
   }
   else
   {                           //else, we'll just sit here and wait, for now
-    V_DrawRawScreen(p2);
+    V_DrawRawScreen(DEH_String("FINAL2"));
   }
-
-  W_UnlockLumpName(DEH_String("FINAL1"));
-  W_UnlockLumpName(DEH_String("FINAL2"));
 }
 
 /*
@@ -241,14 +234,12 @@ void F_DrawUnderwater(void)
   {
     case 1:
       V_SetPlayPal(playpal_heretic_e2end);
-      V_DrawRawScreen(W_CacheLumpName(DEH_String("E2END")));
-      W_UnlockLumpName(DEH_String("E2END"));
+      V_DrawRawScreen(DEH_String("E2END"));
       V_SetPlayPal(playpal_default);
 
       break;
     case 2:
-      V_DrawRawScreen(W_CacheLumpName(DEH_String("TITLE")));
-      W_UnlockLumpName(DEH_String("TITLE"));
+      V_DrawRawScreen(DEH_String("TITLE"));
   }
 }
 
@@ -272,13 +263,11 @@ void Heretic_F_Drawer(void)
       case 1:
         if (gamemode == shareware)
         {
-          V_DrawRawScreen(W_CacheLumpName("ORDER"));
-          W_UnlockLumpName("ORDER");
+          V_DrawRawScreen("ORDER");
         }
         else
         {
-          V_DrawRawScreen(W_CacheLumpName("CREDIT"));
-          W_UnlockLumpName("CREDIT");
+          V_DrawRawScreen("CREDIT");
         }
         break;
       case 2:
@@ -289,8 +278,7 @@ void Heretic_F_Drawer(void)
         break;
       case 4:            // Just show credits screen for extended episodes
       case 5:
-        V_DrawRawScreen(W_CacheLumpName("CREDIT"));
-        W_UnlockLumpName("CREDIT");
+        V_DrawRawScreen("CREDIT");
         break;
     }
   }

--- a/prboom2/src/heretic/in_lude.c
+++ b/prboom2/src/heretic/in_lude.c
@@ -167,10 +167,9 @@ static void IN_DrawInterpic(void)
 
   snprintf(name, 9, "MAPE%d", gameepisode);
 
-  V_DrawNamePatch(0, 0, 0, DEH_String(name), CR_DEFAULT, VPT_STRETCH);
-
   // e6y: wide-res
   V_FillBorder(-1, 0);
+  V_DrawNamePatch(0, 0, 0, DEH_String(name), CR_DEFAULT, VPT_STRETCH);
 }
 
 static void IN_DrawBeenThere(int i)
@@ -573,10 +572,9 @@ void IN_Drawer(void)
 
 void IN_DrawStatBack(void)
 {
-    V_DrawBackground(DEH_String("FLOOR16"), 0);
-
     // e6y: wide-res
     V_FillBorder(-1, 0);
+    V_DrawBackground(DEH_String("FLOOR16"), 0);
 }
 
 //========================================================================

--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -22,6 +22,7 @@
 #include "v_video.h"
 #include "r_main.h"
 #include "w_wad.h"
+#include "st_stuff.h"
 
 #include "dsda/settings.h"
 
@@ -111,6 +112,7 @@ void SB_Init(void)
 {
     int i;
     int startLump;
+    extern patchnum_t stbarbg;
     extern patchnum_t grnrock;
     extern patchnum_t brdr_t, brdr_b, brdr_l, brdr_r;
     extern patchnum_t brdr_tl, brdr_tr, brdr_bl, brdr_br;
@@ -125,6 +127,7 @@ void SB_Init(void)
     R_SetPatchNum(&brdr_tr, DEH_String("bordtr"));
     R_SetPatchNum(&brdr_bl, DEH_String("bordbl"));
     R_SetPatchNum(&brdr_br, DEH_String("bordbr"));
+    R_SetPatchNum(&stbarbg, DEH_String("BARBACK"));
 
     for (i = 0; i < 11; ++i)
     {
@@ -176,6 +179,9 @@ void SB_Init(void)
     }
     spinbooklump = W_GetNumForName(DEH_String("SPINBK0"));
     spinflylump = W_GetNumForName(DEH_String("SPFLY0"));
+
+    // [FG] support widescreen status bar backgrounds
+    ST_SetScaledWidth();
 }
 
 //---------------------------------------------------------------------------

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4222,12 +4222,7 @@ void M_DrawCredits(void)     // killough 10/98: credit screen
 
   if (heretic)
   {
-    const byte* lump = W_CacheLumpNum(creditlump);
-
-    V_DrawRawScreen(lump);
-
-    W_UnlockLumpNum(creditlump);
-
+    V_DrawRawScreen("CREDIT");
     return;
   }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -472,9 +472,9 @@ void M_DrawReadThis1(void)
   inhelpscreens = true;
   if (gamemode == shareware)
   {
-    V_DrawNamePatch(0, 0, 0, "HELP2", CR_DEFAULT, VPT_STRETCH);
     // e6y: wide-res
     V_FillBorder(-1, 0);
+    V_DrawNamePatch(0, 0, 0, "HELP2", CR_DEFAULT, VPT_STRETCH);
   }
   else
     M_DrawCredits();
@@ -4161,8 +4161,8 @@ void M_DrawHelp (void)
 
   if (helplump >= 0 && lumpinfo[helplump].source != source_iwad)
   {
-    V_DrawNumPatch(0, 0, 0, helplump, CR_DEFAULT, VPT_STRETCH);
     V_FillBorder(-1, 0);
+    V_DrawNumPatch(0, 0, 0, helplump, CR_DEFAULT, VPT_STRETCH);
   }
   else
   {
@@ -4234,8 +4234,8 @@ void M_DrawCredits(void)     // killough 10/98: credit screen
   inhelpscreens = true;
   if (creditlump >= 0 && lumpinfo[creditlump].source != source_iwad)
   {
-    V_DrawNumPatch(0, 0, 0, creditlump, CR_DEFAULT, VPT_STRETCH);
     V_FillBorder(-1, 0);
+    V_DrawNumPatch(0, 0, 0, creditlump, CR_DEFAULT, VPT_STRETCH);
   }
   else
   {

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -765,21 +765,21 @@ void R_FillBackScreen (void)
       only_stbar = screenblocks >= 10;
     }
 
-    if (only_stbar)
+    if (only_stbar && ST_SCALED_OFFSETX > 0)
     {
       int stbar_top = SCREENHEIGHT - ST_SCALED_HEIGHT;
 
       V_FillFlat(grnrock.lumpnum, 1,
-        0, stbar_top, wide_offsetx, ST_SCALED_HEIGHT, VPT_NONE);
+        0, stbar_top, ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_NONE);
       V_FillFlat(grnrock.lumpnum, 1,
-        SCREENWIDTH - wide_offsetx, stbar_top, wide_offsetx, ST_SCALED_HEIGHT, VPT_NONE);
+        SCREENWIDTH - ST_SCALED_OFFSETX, stbar_top, ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_NONE);
 
       // heretic_note: I think this looks bad, so I'm skipping it...
       if (heretic) return;
 
       // line between view and status bar
-      V_FillPatch(brdr_b.lumpnum, 1, 0, stbar_top, wide_offsetx, brdr_b.height, VPT_NONE);
-      V_FillPatch(brdr_b.lumpnum, 1, SCREENWIDTH - wide_offsetx, stbar_top, wide_offsetx, brdr_b.height, VPT_NONE);
+      V_FillPatch(brdr_b.lumpnum, 1, 0, stbar_top, ST_SCALED_OFFSETX, brdr_b.height, VPT_NONE);
+      V_FillPatch(brdr_b.lumpnum, 1, SCREENWIDTH - ST_SCALED_OFFSETX, stbar_top, ST_SCALED_OFFSETX, brdr_b.height, VPT_NONE);
 
       return;
     }
@@ -850,13 +850,13 @@ void R_DrawViewBorder(void)
   {
     for (i = (SCREENHEIGHT - ST_SCALED_HEIGHT); i < SCREENHEIGHT; i++)
     {
-      R_VideoErase (0, i, wide_offsetx);
-      R_VideoErase (SCREENWIDTH - wide_offsetx, i, wide_offsetx);
+      R_VideoErase (0, i, ST_SCALED_OFFSETX);
+      R_VideoErase (SCREENWIDTH - ST_SCALED_OFFSETX, i, ST_SCALED_OFFSETX);
     }
   }
 
   if ( viewheight >= ( SCREENHEIGHT - ST_SCALED_HEIGHT ))
-    return; // if high-res, don�t go any further!
+    return; // if high-res, don't go any further!
 
   top = ((SCREENHEIGHT-ST_SCALED_HEIGHT)-viewheight)/2;
   side = (SCREENWIDTH-scaledviewwidth)/2;

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -60,6 +60,7 @@
 int ST_SCALED_HEIGHT;
 int ST_SCALED_WIDTH;
 int ST_SCALED_Y;
+int ST_SCALED_OFFSETX;
 
 // Palette indices.
 // For damage/bonus red-/gold-shifts
@@ -315,7 +316,7 @@ static patchnum_t faces[ST_NUMFACES];
 static patchnum_t faceback; // CPhipps - single background, translated for different players
 
 //e6y: status bar background
-static patchnum_t stbarbg;
+patchnum_t stbarbg;
 patchnum_t grnrock;
 patchnum_t brdr_t, brdr_b, brdr_l, brdr_r;
 patchnum_t brdr_tl, brdr_tr, brdr_bl, brdr_br;
@@ -402,6 +403,36 @@ extern char     *mapnames[];
 
 static void ST_Stop(void);
 
+// [FG] support widescreen status bar backgrounds
+
+void ST_SetScaledWidth(void)
+{
+  int width = stbarbg.width;
+
+  if (width == 0)
+      width = ST_WIDTH;
+
+  switch (render_stretch_hud)
+  {
+    case patch_stretch_16x10:
+      ST_SCALED_WIDTH  = width * patches_scalex;
+      break;
+    case patch_stretch_4x3:
+      ST_SCALED_WIDTH  = width * WIDE_SCREENWIDTH / 320;
+      break;
+    case patch_stretch_full:
+      ST_SCALED_WIDTH  = width * SCREENWIDTH / 320;
+      break;
+  }
+
+  ST_SCALED_WIDTH = (ST_SCALED_WIDTH + 3) & (int)~3;
+
+  if (ST_SCALED_WIDTH > SCREENWIDTH)
+      ST_SCALED_WIDTH = SCREENWIDTH;
+
+  ST_SCALED_OFFSETX = (SCREENWIDTH - ST_SCALED_WIDTH) / 2;
+}
+
 static void ST_refreshBackground(void)
 {
   int y = ST_Y;
@@ -424,7 +455,7 @@ static void ST_refreshBackground(void)
            displayplayer ? CR_LIMIT+displayplayer : CR_DEFAULT,
            displayplayer ? (VPT_TRANS | VPT_ALIGN_BOTTOM) : flags);
       }
-      V_CopyRect(BG, FG, ST_X + wide_offsetx, SCREENHEIGHT - ST_SCALED_HEIGHT, ST_SCALED_WIDTH, ST_SCALED_HEIGHT, VPT_NONE);
+      V_CopyRect(BG, FG, ST_X + ST_SCALED_OFFSETX, SCREENHEIGHT - ST_SCALED_HEIGHT, ST_SCALED_WIDTH, ST_SCALED_HEIGHT, VPT_NONE);
     }
 }
 
@@ -1018,6 +1049,9 @@ static void ST_loadGraphics(dboolean doload)
     }
   R_SetPatchNum(&faces[facenum++], "STFGOD0");
   R_SetPatchNum(&faces[facenum++], "STFDEAD0");
+
+  // [FG] support widescreen status bar backgrounds
+  ST_SetScaledWidth();
 }
 
 static void ST_loadData(void)

--- a/prboom2/src/st_stuff.h
+++ b/prboom2/src/st_stuff.h
@@ -52,6 +52,9 @@
 extern int ST_SCALED_HEIGHT;
 extern int ST_SCALED_WIDTH;
 extern int ST_SCALED_Y;
+extern int ST_SCALED_OFFSETX;
+
+void ST_SetScaledWidth(void);
 
 //
 // STATUS BAR

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1672,6 +1672,9 @@ void V_DrawRawScreenSection(const byte *raw, int dest_y_offset, int dest_y_limit
   float x_factor, y_factor;
   int x_offset;
 
+  // e6y: wide-res
+  V_FillBorder(-1, 0);
+
   x_factor = (float)SCREENWIDTH / 320;
   y_factor = (float)SCREENHEIGHT / 200;
 
@@ -1692,9 +1695,6 @@ void V_DrawRawScreenSection(const byte *raw, int dest_y_offset, int dest_y_limit
 
       V_FillRect(0, x_offset + x, y, width, height, *raw);
     }
-
-  // e6y: wide-res
-  V_FillBorder(-1, 0);
 }
 
 void V_DrawShadowedNumPatch(int x, int y, int lump)

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1522,7 +1522,6 @@ void SetRatio(int width, int height)
     patches_scaley = MIN(render_patches_scaley, patches_scaley);
   }
 
-  ST_SCALED_WIDTH = ST_WIDTH * patches_scalex;
   ST_SCALED_HEIGHT = g_st_height * patches_scaley;
 
   if (SCREENWIDTH < 320 || WIDE_SCREENWIDTH < 320 ||
@@ -1546,7 +1545,6 @@ void SetRatio(int width, int height)
     break;
   case patch_stretch_4x3:
     ST_SCALED_HEIGHT = g_st_height * WIDE_SCREENHEIGHT / 200;
-    ST_SCALED_WIDTH  = WIDE_SCREENWIDTH;
 
     ST_SCALED_Y = SCREENHEIGHT - ST_SCALED_HEIGHT;
 
@@ -1555,7 +1553,6 @@ void SetRatio(int width, int height)
     break;
   case patch_stretch_full:
     ST_SCALED_HEIGHT = g_st_height * SCREENHEIGHT / 200;
-    ST_SCALED_WIDTH  = SCREENWIDTH;
 
     ST_SCALED_Y = SCREENHEIGHT - ST_SCALED_HEIGHT;
     wide_offset2x = 0;
@@ -1569,6 +1566,9 @@ void SetRatio(int width, int height)
   SCREEN_320x200 =
     (SCREENWIDTH == 320) && (SCREENHEIGHT == 200) &&
     (WIDE_SCREENWIDTH == 320) && (WIDE_SCREENHEIGHT == 200);
+
+  // [FG] support widescreen status bar backgrounds
+  ST_SetScaledWidth();
 }
 
 void V_GetWideRect(int *x, int *y, int *w, int *h, enum patch_translation_e flags)

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -422,6 +422,10 @@ static void V_DrawMemPatch(int x, int y, int scrn, const rpatch_t *patch,
   if (!trans)
     flags &= ~VPT_TRANS;
 
+  // [FG] automatically center wide patches without horizontal offset
+  if (patch->width > 320 && patch->leftoffset == 0)
+    x -= (patch->width - 320) / 2;
+
   if (V_GetMode() == VID_MODE8 && !(flags & VPT_STRETCH_MASK)) {
     int             col;
     byte           *desttop = screens[scrn].data+y*screens[scrn].byte_pitch+x*V_GetPixelDepth();

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1694,7 +1694,7 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
     }
   }
 
-  raw = W_CacheLumpName(lump_name) + source_offset;
+  raw = (const byte *) W_CacheLumpName(lump_name) + source_offset;
 
   x_factor = (float)SCREENWIDTH / 320;
   y_factor = (float)SCREENHEIGHT / 200;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -558,7 +558,7 @@ static void V_DrawMemPatch(int x, int y, int scrn, const rpatch_t *patch,
       top =  (y < 0 || y > 200 ? (y * params->video->height) / 200 : params->video->y1lookup[y]);
 
       if (x + patch->width < 0 || x + patch->width > 320)
-        right = ( ((x + patch->width - 1) * params->video->width) / 320 );
+        right = ( ((x + patch->width) * params->video->width - 1) / 320 );
       else
         right = params->video->x2lookup[x + patch->width - 1];
 

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1664,20 +1664,37 @@ void V_ChangeScreenResolution(void)
 
 // heretic
 
+#define HERETIC_RAW_SCREEN_SIZE 64000
+
 // heretic_note: is something already implemented to handle this?
-void V_DrawRawScreen(const byte *raw)
+void V_DrawRawScreen(const char *lump_name)
 {
-  V_DrawRawScreenSection(raw, 0, 200);
+  V_DrawRawScreenSection(lump_name, 0, 0, 200);
 }
 
-void V_DrawRawScreenSection(const byte *raw, int dest_y_offset, int dest_y_limit)
+void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y_offset, int dest_y_limit)
 {
   int i, j;
   float x_factor, y_factor;
   int x_offset;
+  const byte* raw;
 
   // e6y: wide-res
   V_FillBorder(-1, 0);
+
+  // custom widescreen assets are a different format
+  {
+    int lump;
+
+    lump = W_CheckNumForName(lump_name);
+    if (W_LumpLength(lump) != HERETIC_RAW_SCREEN_SIZE)
+    {
+      V_DrawNamePatch(0, 0, 0, lump_name, CR_DEFAULT, VPT_STRETCH);
+      return;
+    }
+  }
+
+  raw = W_CacheLumpName(lump_name) + source_offset;
 
   x_factor = (float)SCREENWIDTH / 320;
   y_factor = (float)SCREENHEIGHT / 200;
@@ -1699,6 +1716,8 @@ void V_DrawRawScreenSection(const byte *raw, int dest_y_offset, int dest_y_limit
 
       V_FillRect(0, x_offset + x, y, width, height, *raw);
     }
+
+  W_UnlockLumpName(lump_name);
 }
 
 void V_DrawShadowedNumPatch(int x, int y, int lump)

--- a/prboom2/src/v_video.h
+++ b/prboom2/src/v_video.h
@@ -302,8 +302,8 @@ int V_BestColor(const unsigned char *palette, int r, int g, int b);
 
 // heretic
 
-void V_DrawRawScreen(const byte *raw);
-void V_DrawRawScreenSection(const byte *raw, int dest_y_offset, int dest_y_limit);
+void V_DrawRawScreen(const char *lump_name);
+void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y_offset, int dest_y_limit);
 void V_DrawShadowedNumPatch(int x, int y, int lump);
 void V_DrawShadowedNamePatch(int x, int y, const char* name);
 void V_DrawTLNumPatch(int x, int y, int lump);

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -425,11 +425,11 @@ static void WI_slamBackground(void)
   else
     sprintf(name, "WIMAP%d", wbs->epsd);
 
-  // background
-  V_DrawNamePatch(0, 0, FB, name, CR_DEFAULT, VPT_STRETCH);
-
   // e6y: wide-res
   V_FillBorder(-1, 0);
+
+  // background
+  V_DrawNamePatch(0, 0, FB, name, CR_DEFAULT, VPT_STRETCH);
 }
 
 


### PR DESCRIPTION
Implementation from https://github.com/coelckers/prboom-plus/pull/278 with heretic support added. Heretic side is a bit messier because the widescreen assets for heretic are in a different format than the vanilla ones. The e3 end pic doesn't scroll, otherwise it looks like things are working more or less (hard to test every res / case, will just fix if there are reports).