### PR TITLE
Sound Quirks Fix

### DIFF
--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -348,7 +348,7 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume)
   // kill old sound
   for (cnum=0 ; cnum<numChannels ; cnum++)
     if (channels[cnum].sfxinfo && channels[cnum].origin == origin &&
-        (comp[comp_sound] || channels[cnum].is_pickup == is_pickup))
+        (comp[comp_sound] && channels[cnum].is_pickup == is_pickup))
       {
         S_StopChannel(cnum);
         break;


### PR DESCRIPTION
Changes an 'or' statement to an 'and' in a check for stopping sound. The 'kill old sound' code is supposed to emulate a quirk with item pickup sounds however it was applying the quirk to all sounds. Changing the `or` to an `and` fixes this.