### PR TITLE
Fix A_SpawnObject not transferring pointers as intended if called in a missile's death state

### DIFF
--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3062,7 +3062,7 @@ void A_SpawnObject(mobj_t *actor)
   if (mo->flags & (MF_MISSILE | MF_BOUNCES))
   {
     // if spawner is also a missile, copy 'em
-    if (actor->flags & (MF_MISSILE | MF_BOUNCES))
+    if (actor->info->flags & (MF_MISSILE | MF_BOUNCES))
     {
       P_SetTarget(&mo->target, actor->target);
       P_SetTarget(&mo->tracer, actor->tracer);

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3059,7 +3059,7 @@ void A_SpawnObject(mobj_t *actor)
   mo->momz = vel_z;
 
   // if spawned object is a missile, set target+tracer
-  if (mo->flags & (MF_MISSILE | MF_BOUNCES))
+  if (mo->info->flags & (MF_MISSILE | MF_BOUNCES))
   {
     // if spawner is also a missile, copy 'em
     if (actor->info->flags & (MF_MISSILE | MF_BOUNCES))


### PR DESCRIPTION
An "oops" on my part with A_SpawnObject: the pointer transfer code at the end is intended to allow this function to be safely used to have a missile spawn sub-missiles and have all the tracer+target stuff copy over... except silly ol' me didn't realize that MF_MISSILE gets un-set when the projectile dies, which means the pointer transfer wouldn't work correctly if used in the projectile's death state (which is gonna be like 90% of the use-case for this sub-feature :P )

Just a one-liner fix here that makes the function work as it's supposed to.

[EDIT] Well, it's a two-liner now. ;)