### PR TITLE
Decouple P_CreateSecNodeList

### DIFF
--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -1190,8 +1190,6 @@ dboolean P_CheckPosition (mobj_t* thing,fixed_t x,fixed_t y)
   yl = P_GetSafeBlockY(tmbbox[BOXBOTTOM] - bmaporgy);
   yh = P_GetSafeBlockY(tmbbox[BOXTOP] - bmaporgy);
 
-  // heretic - this must be incremented before iterating over the lines
-  validcount++;
   for (bx=xl ; bx<=xh ; bx++)
     for (by=yl ; by<=yh ; by++)
       if (!P_BlockLinesIterator (bx,by,PIT_CheckLine))
@@ -2997,7 +2995,7 @@ void P_CreateSecNodeList(mobj_t* thing,fixed_t x,fixed_t y)
   tmbbox[BOXRIGHT]  = x + tmthing->radius;
   tmbbox[BOXLEFT]   = x - tmthing->radius;
 
-  validcount++; // used to make sure we only process a line once
+  validcount2++; // used to make sure we only process a line once
 
   xl = P_GetSafeBlockX(tmbbox[BOXLEFT] - bmaporgx);
   xh = P_GetSafeBlockX(tmbbox[BOXRIGHT] - bmaporgx);
@@ -3006,7 +3004,7 @@ void P_CreateSecNodeList(mobj_t* thing,fixed_t x,fixed_t y)
 
   for (bx=xl ; bx<=xh ; bx++)
     for (by=yl ; by<=yh ; by++)
-      P_BlockLinesIterator(bx,by,PIT_GetSectors);
+      P_BlockLinesIterator2(bx,by,PIT_GetSectors);
 
   // Add the sector of the (x,y) point to sector_list.
 

--- a/prboom2/src/p_maputl.h
+++ b/prboom2/src/p_maputl.h
@@ -81,6 +81,7 @@ void    P_LineOpening (const line_t *linedef);
 void    P_UnsetThingPosition(mobj_t *thing);
 void    P_SetThingPosition(mobj_t *thing);
 dboolean P_BlockLinesIterator (int x, int y, dboolean func(line_t *));
+dboolean P_BlockLinesIterator2(int x, int y, dboolean func(line_t *));
 dboolean P_BlockThingsIterator(int x, int y, dboolean func(mobj_t *));
 dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
                        int flags, dboolean trav(intercept_t *));

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2717,6 +2717,7 @@ void P_InitSubsectorsLines(void)
     {
       if (!seg->linedef) continue;
       seg->linedef->validcount = 0;
+      seg->linedef->validcount2 = 0;
     }
 
     for (seg = segs + subsectors[num].firstline; seg < seg_last; seg++)
@@ -2745,6 +2746,7 @@ void P_InitSubsectorsLines(void)
     {
       if (!seg->linedef) continue;
       seg->linedef->validcount = 0;
+      seg->linedef->validcount2 = 0;
     }
 
     for (seg = segs + subsectors[num].firstline; seg < seg_last; seg++)
@@ -2776,6 +2778,7 @@ void P_InitSubsectorsLines(void)
   for (num = 0; num < numlines; num++)
   {
     lines[num].validcount = 0;
+    lines[num].validcount2 = 0;
   }
 }
 

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -237,6 +237,7 @@ typedef struct line_s
   sector_t *frontsector; // Front and back sector.
   sector_t *backsector;
   int validcount;        // if == validcount, already checked
+  int validcount2;
   void *specialdata;     // thinker_t for reversable actions
   int tranlump;          // killough 4/11/98: translucency filter, -1 == none
   int firsttag,nexttag;  // killough 4/17/98: improves searches for tags.
@@ -499,6 +500,7 @@ typedef struct polyobj_s
   int tag;                    // reference tag assigned in HereticEd
   int bbox[4];
   int validcount;
+  int validcount2;
   dboolean crush;              // should the polyobj attempt to crush mobjs?
   int seqType;
   fixed_t size;               // polyobj size (area of POLY_AREAUNIT == size of FRACUNIT)

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -84,6 +84,7 @@ int r_have_internal_hires = false;
 int viewangleoffset;
 int viewpitchoffset;
 int validcount = 1;         // increment every time a check is made
+int validcount2 = 1;
 const lighttable_t *fixedcolormap;
 int      centerx, centery;
 // e6y: wide-res

--- a/prboom2/src/r_main.h
+++ b/prboom2/src/r_main.h
@@ -76,6 +76,7 @@ extern int wide_offset2y;
 // proff 11/06/98: Added for high-res
 extern fixed_t  projectiony;
 extern int      validcount;
+extern int      validcount2;
 // e6y: Added for more precise flats drawing
 extern fixed_t viewfocratio;
 


### PR DESCRIPTION
The extra validcount++ injection into P_CheckPosition done in the scope of heretic and mbf21 fixed an issue introduced by MBF, briefly described here in a comment. Unfortunately, hexen _relies on_ buggy validcount usage. There are recursive calls to P_CheckPosition that cause the counter to become invalidated and lines to get skipped when they shouldn't. This means that a fix for the MBF change breaks hexen. The safest solution here is to completely decouple P_CreateSecNodeList from the normal validcount. This allows validcount to break correctly in hexen, and not break in heretic and mbf21. With luck, there isn't some place in mbf that relies on the count breaking via P_CreateSecNodeList...