### PR TITLE
determine heretic/hexen mode from the executable name

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1016,6 +1016,16 @@ static char *FindIWADFile(void)
 {
   int   i;
   char  * iwad  = NULL;
+  char *dash;
+
+  if ((dash = strrchr(myargv[0], '-')))
+  {
+    dash++;
+    if (!strnicmp(dash, "heretic", 7))
+      return I_FindFile("heretic.wad", ".wad");
+    else if (!strnicmp(dash, "hexen", 5))
+      return I_FindFile("hexen.wad", ".wad");
+  }
 
   i = M_CheckParm("-iwad");
   if (i && (++i < myargc)) {

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -655,10 +655,6 @@ static void dsda_InitHexen(void) {
 static dboolean dsda_AutoDetectHeretic(void)
 {
   int i, length;
-  char *dash;
-  if ((dash = strrchr(myargv[0], '-')))
-    if (!strnicmp(++dash, "heretic", 7))
-      return true;
   i = M_CheckParm("-iwad");
   if (i && (++i < myargc)) {
     length = strlen(myargv[i]);
@@ -672,10 +668,6 @@ static dboolean dsda_AutoDetectHeretic(void)
 static dboolean dsda_AutoDetectHexen(void)
 {
   int i, length;
-  char *dash;
-  if ((dash = strrchr(myargv[0], '-')))
-    if (!strnicmp(++dash, "hexen", 5))
-      return true;
   i = M_CheckParm("-iwad");
   if (i && (++i < myargc)) {
     length = strlen(myargv[i]);

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -655,6 +655,10 @@ static void dsda_InitHexen(void) {
 static dboolean dsda_AutoDetectHeretic(void)
 {
   int i, length;
+  char *dash;
+  if ((dash = strrchr(myargv[0], '-')))
+    if (!strnicmp(++dash, "heretic", 7))
+      return true;
   i = M_CheckParm("-iwad");
   if (i && (++i < myargc)) {
     length = strlen(myargv[i]);
@@ -668,6 +672,10 @@ static dboolean dsda_AutoDetectHeretic(void)
 static dboolean dsda_AutoDetectHexen(void)
 {
   int i, length;
+  char *dash;
+  if ((dash = strrchr(myargv[0], '-')))
+    if (!strnicmp(++dash, "hexen", 5))
+      return true;
   i = M_CheckParm("-iwad");
   if (i && (++i < myargc)) {
     length = strlen(myargv[i]);


### PR DESCRIPTION
I'd like to install two additional executables into the Debian
package, dsda-heretic and dsda-hexen, which are mere symlinks to
dsda-doom. So, I have separate executables for each game without the
need to explicitly specify a command line parameter. The executables
will recognize the desired game from their own file name.

In other words, make it work just like
chocolate-doom/-heretic/-hexen. :wink: