### PR TITLE
Uncap music

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -49,6 +49,8 @@ set(COMMON_SRC
     dsda/memory.h
     dsda/msecnode.c
     dsda/msecnode.h
+    dsda/music.c
+    dsda/music.h
     dsda/options.c
     dsda/options.h
     dsda/palette.c

--- a/prboom2/src/d_deh.h
+++ b/prboom2/src/d_deh.h
@@ -1120,7 +1120,6 @@ extern const char* startup5;
 // from g_game.c, prefix for savegame name like "boomsav"
 extern const char* savegamename;
 
-void D_BuildBEXTables(void);
 void deh_changeCompTranslucency(void);
 void deh_applyCompatibility(void);
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1738,8 +1738,6 @@ static void D_DoomMainSetup(void)
 
   dsda_InitGlobal();
 
-  D_BuildBEXTables(); // haleyjd
-
   // e6y: DEH files preloaded in wrong order
   // http://sourceforge.net/tracker/index.php?func=detail&aid=1418158&group_id=148658&atid=772943
   // The dachaked stuff has been moved below an autoload

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -32,6 +32,7 @@
 
 #include "global.h"
 
+#include "dsda/music.h"
 #include "dsda/sfx.h"
 #include "dsda/sprite.h"
 #include "dsda/state.h"
@@ -47,9 +48,6 @@ mobjinfo_t* mobjinfo;
 int num_mobj_types;
 int mobj_types_zero;
 int mobj_types_max;
-
-musicinfo_t* S_music;
-int num_music;
 
 weaponinfo_t* weaponinfo;
 
@@ -164,11 +162,6 @@ static void dsda_AllocateMobjInfo(int zero, int max, int count) {
   memset(mobjinfo, 0, sizeof(mobjinfo_t) * num_mobj_types);
 }
 
-static void dsda_SetMusic(musicinfo_t* music_list, int count) {
-  S_music = music_list;
-  num_music = count;
-}
-
 static void dsda_InitDoom(void) {
   int i;
   doom_mobjinfo_t* mobjinfo_p;
@@ -177,7 +170,7 @@ static void dsda_InitDoom(void) {
   dsda_InitializeStates(doom_states, DOOM_NUMSTATES);
   dsda_InitializeSprites(doom_sprnames, DOOM_NUMSPRITES);
   dsda_InitializeSFX(doom_S_sfx, DOOM_NUMSFX);
-  dsda_SetMusic(doom_S_music, DOOM_NUMMUSIC);
+  dsda_InitializeMusic(doom_S_music, DOOM_NUMMUSIC);
 
   demostates = doom_demostates;
 
@@ -324,7 +317,7 @@ static void dsda_InitHeretic(void) {
   dsda_InitializeStates(heretic_states, HERETIC_NUMSTATES);
   dsda_InitializeSprites(heretic_sprnames, HERETIC_NUMSPRITES);
   dsda_InitializeSFX(heretic_S_sfx, HERETIC_NUMSFX);
-  dsda_SetMusic(heretic_S_music, HERETIC_NUMMUSIC);
+  dsda_InitializeMusic(heretic_S_music, HERETIC_NUMMUSIC);
 
   demostates = heretic_demostates;
 
@@ -489,7 +482,7 @@ static void dsda_InitHexen(void) {
   dsda_InitializeStates(hexen_states, HEXEN_NUMSTATES);
   dsda_InitializeSprites(hexen_sprnames, HEXEN_NUMSPRITES);
   dsda_InitializeSFX(hexen_S_sfx, HEXEN_NUMSFX);
-  dsda_SetMusic(hexen_S_music, HEXEN_NUMMUSIC);
+  dsda_InitializeMusic(hexen_S_music, HEXEN_NUMMUSIC);
 
   demostates = hexen_demostates;
 

--- a/prboom2/src/dsda/music.c
+++ b/prboom2/src/dsda/music.c
@@ -1,0 +1,108 @@
+//
+// Copyright(C) 2021 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Music
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "doomtype.h"
+
+#include "music.h"
+
+musicinfo_t* S_music;
+int num_music;
+static char** deh_musicnames;
+static byte* music_state;
+
+static void dsda_EnsureCapacity(int limit) {
+  while (limit >= num_music) {
+    int old_num_music = num_music;
+
+    num_music *= 2;
+
+    S_music = realloc(S_music, num_music * sizeof(*S_music));
+    memset(S_music + old_num_music, 0, (num_music - old_num_music) * sizeof(*S_music));
+
+    music_state = realloc(music_state, num_music * sizeof(*music_state));
+    memset(music_state + old_num_music, 0,
+      (num_music - old_num_music) * sizeof(*music_state));
+  }
+}
+
+int dsda_GetDehMusicIndex(const char* key, size_t length) {
+  int i;
+
+  for (i = 1; i < num_music; ++i)
+    if (
+      S_music[i].name &&
+      strlen(S_music[i].name) == length &&
+      !strnicmp(S_music[i].name, key, length) &&
+      !music_state[i]
+    ) {
+      music_state[i] = true; // music has been edited
+      return i;
+    }
+
+  return -1;
+}
+
+int dsda_GetOriginalMusicIndex(const char* key) {
+  int i;
+  const char* c;
+
+  for (i = 1; deh_musicnames[i]; ++i)
+    if (!strncasecmp(deh_musicnames[i], key, 6))
+      return i;
+
+  // is it a number?
+  for (c = key; *c; c++)
+    if (!isdigit(*c))
+      return -1;
+
+  i = atoi(key);
+  dsda_EnsureCapacity(i);
+
+  return i;
+}
+
+void dsda_InitializeMusic(const musicinfo_t* source, int count) {
+  int i;
+  extern int raven;
+
+  num_music = count;
+
+  S_music = malloc(num_music * sizeof(*S_music));
+  memcpy(S_music, source, num_music * sizeof(*S_music));
+
+  if (raven) return;
+
+  deh_musicnames = malloc((num_music + 1) * sizeof(*deh_musicnames));
+  for (i = 1; i < num_music; i++)
+    if (S_music[i].name != NULL)
+      deh_musicnames[i] = strdup(S_music[i].name);
+    else
+      deh_musicnames[i] = NULL;
+  deh_musicnames[0] = NULL;
+  deh_musicnames[num_music] = NULL;
+
+  music_state = calloc(num_music, sizeof(*music_state));
+}
+
+void dsda_FreeDehMusic(void) {
+  free(deh_musicnames);
+  free(music_state);
+}

--- a/prboom2/src/dsda/music.c
+++ b/prboom2/src/dsda/music.c
@@ -69,26 +69,30 @@ int dsda_GetOriginalMusicIndex(const char* key) {
     if (!strncasecmp(deh_musicnames[i], key, 6))
       return i;
 
+  return -1;
+
   // is it a number?
-  for (c = key; *c; c++)
-    if (!isdigit(*c))
-      return -1;
-
-  i = atoi(key);
-  dsda_EnsureCapacity(i);
-
-  return i;
+  // for (c = key; *c; c++)
+  //   if (!isdigit(*c))
+  //     return -1;
+  //
+  // i = atoi(key);
+  // dsda_EnsureCapacity(i);
+  //
+  // return i;
 }
 
-void dsda_InitializeMusic(const musicinfo_t* source, int count) {
+void dsda_InitializeMusic(musicinfo_t* source, int count) {
   int i;
   extern int raven;
 
   num_music = count;
   mus_musinfo = num_music;
 
-  S_music = malloc(num_music * sizeof(*S_music));
-  memcpy(S_music, source, num_music * sizeof(*S_music));
+  S_music = source;
+
+  // S_music = malloc(num_music * sizeof(*S_music));
+  // memcpy(S_music, source, num_music * sizeof(*S_music));
 
   if (raven) return;
 

--- a/prboom2/src/dsda/music.c
+++ b/prboom2/src/dsda/music.c
@@ -25,6 +25,7 @@
 
 musicinfo_t* S_music;
 int num_music;
+int mus_musinfo;
 static char** deh_musicnames;
 static byte* music_state;
 
@@ -84,6 +85,7 @@ void dsda_InitializeMusic(const musicinfo_t* source, int count) {
   extern int raven;
 
   num_music = count;
+  mus_musinfo = num_music;
 
   S_music = malloc(num_music * sizeof(*S_music));
   memcpy(S_music, source, num_music * sizeof(*S_music));

--- a/prboom2/src/dsda/music.h
+++ b/prboom2/src/dsda/music.h
@@ -1,0 +1,28 @@
+//
+// Copyright(C) 2021 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Music
+//
+
+#ifndef __DSDA_MUSIC__
+#define __DSDA_MUSIC__
+
+#include "sounds.h"
+
+int dsda_GetDehMusicIndex(const char* key, size_t length);
+int dsda_GetOriginalMusicIndex(const char* key);
+void dsda_InitializeMusic(const musicinfo_t* source, int count);
+void dsda_FreeDehMusic(void);
+
+#endif

--- a/prboom2/src/dsda/music.h
+++ b/prboom2/src/dsda/music.h
@@ -22,7 +22,7 @@
 
 int dsda_GetDehMusicIndex(const char* key, size_t length);
 int dsda_GetOriginalMusicIndex(const char* key);
-void dsda_InitializeMusic(const musicinfo_t* source, int count);
+void dsda_InitializeMusic(musicinfo_t* source, int count);
 void dsda_FreeDehMusic(void);
 
 #endif

--- a/prboom2/src/heretic/sounds.c
+++ b/prboom2/src/heretic/sounds.c
@@ -77,7 +77,7 @@ musicinfo_t heretic_S_music[] = {
     { "MUS_INTR", 0 },
     { "MUS_CPTD", 0 },
 
-    { 0 } // for S_music[num_music].lumpnum = -1; ?
+    { 0 } // for S_music[mus_musinfo].lumpnum = -1; ?
 };
 
 sfxinfo_t heretic_S_sfx[] = {

--- a/prboom2/src/s_advsound.c
+++ b/prboom2/src/s_advsound.c
@@ -71,14 +71,14 @@ void S_ParseMusInfo(const char *mapid)
 
     /* don't restart music that is already playing */
     if (mus_playing &&
-        mus_playing->lumpnum == S_music[num_music].lumpnum) {
-        load_muslump = S_music[num_music].lumpnum;
+        mus_playing->lumpnum == S_music[mus_musinfo].lumpnum) {
+        load_muslump = S_music[mus_musinfo].lumpnum;
     }
 
     memset(&musinfo, 0, sizeof(musinfo));
     musinfo.items[0] = itemzero;
     musinfo.current_item = load_muslump;
-    S_music[num_music].lumpnum = load_muslump;
+    S_music[mus_musinfo].lumpnum = load_muslump;
 
     SC_OpenLump("MUSINFO");
 

--- a/prboom2/src/s_advsound.h
+++ b/prboom2/src/s_advsound.h
@@ -45,7 +45,7 @@
 //MUSINFO lump
 //
 
-#define MAX_MUS_ENTRIES 64
+#define MAX_MUS_ENTRIES 65
 
 typedef struct musinfo_s
 {

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -596,7 +596,7 @@ void S_ChangeMusic(int musicnum, int looping)
   // current music which should play
   musicnum_current = musicnum;
   musinfo.current_item = -1;
-  S_music[num_music].lumpnum = -1;
+  S_music[mus_musinfo].lumpnum = -1;
 
   //jff 1/22/98 return if music is not enabled
   if (!mus_card || nomusicparm)
@@ -655,7 +655,7 @@ void S_ChangeMusic(int musicnum, int looping)
   if (musinfo.items[0] == -1)
   {
      musinfo.items[0] = music->lumpnum;
-     S_music[num_music].lumpnum = -1;
+     S_music[mus_musinfo].lumpnum = -1;
   }
 }
 
@@ -691,7 +691,7 @@ void S_ChangeMusInfoMusic(int lumpnum, int looping)
   if (mus_playing && mus_playing->lumpnum == lumpnum)
     return;
 
-  music = &S_music[num_music];
+  music = &S_music[mus_musinfo];
 
   if (music->lumpnum == lumpnum)
     return;

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -101,6 +101,8 @@ typedef struct {
 // Identifiers for all music in game.
 //
 
+extern int mus_musinfo;
+
 typedef enum {
   mus_None,
   mus_e1m1,
@@ -170,6 +172,7 @@ typedef enum {
   mus_read_m,
   mus_dm2ttl,
   mus_dm2int,
+  DOOM_MUSINFO,
   DOOM_NUMMUSIC,
 
   // heretic
@@ -230,6 +233,7 @@ typedef enum {
   heretic_mus_titl,
   heretic_mus_intr,
   heretic_mus_cptd,
+  HERETIC_MUSINFO,
   HERETIC_NUMMUSIC,
 
   // hexen
@@ -239,7 +243,7 @@ typedef enum {
   hexen_mus_hall,
   hexen_mus_orb,
   hexen_mus_chess,
-
+  HEXEN_MUSINFO,
   HEXEN_NUMMUSIC
 } musicenum_t;
 


### PR DESCRIPTION
There's no way to actually use more music in doom / dehacked right now, so this refactor is mainly for consistency with the sfx code and leaves the actual uncapping commented out for future reference.

While doing this I fixed a bug in musinfo handling, where we ignored the 64th entry for unknown reasons.