### PR TITLE
Protect type checks

### DIFF
--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -1324,19 +1324,19 @@ void A_Chase(mobj_t *actor)
   // make active sound
   if (actor->info->activesound && P_Random(pr_see) < 3)
   {
-    if (actor->type == HERETIC_MT_WIZARD && P_Random(pr_heretic) < 128)
+    if (heretic && actor->type == HERETIC_MT_WIZARD && P_Random(pr_heretic) < 128)
     {
       S_StartSound(actor, actor->info->seesound);
     }
-    else if (actor->type == HERETIC_MT_SORCERER2)
+    else if (heretic && actor->type == HERETIC_MT_SORCERER2)
     {
       S_StartSound(NULL, actor->info->activesound);
     }
-    else if (actor->type == HEXEN_MT_BISHOP && P_Random(pr_hexen) < 128)
+    else if (hexen && actor->type == HEXEN_MT_BISHOP && P_Random(pr_hexen) < 128)
     {
       S_StartSound(actor, actor->info->seesound);
     }
-    else if (actor->type == HEXEN_MT_PIG)
+    else if (hexen && actor->type == HEXEN_MT_PIG)
     {
       S_StartSound(actor, hexen_sfx_pig_active1 + (P_Random(pr_hexen) & 1));
     }
@@ -2383,80 +2383,84 @@ void A_Explode(mobj_t *thingy)
   damage = 128;
   distance = 128;
   damageSelf = true;
-  switch (thingy->type)
+
+  if (raven)
   {
-    case HERETIC_MT_FIREBOMB:      // Time Bombs
-    case HEXEN_MT_FIREBOMB:        // Time Bombs
-      thingy->z += 32 * FRACUNIT;
-      thingy->flags &= ~MF_SHADOW;
-      break;
-    case HERETIC_MT_MNTRFX2:       // Minotaur floor fire
-      damage = 24;
-      distance = damage;
-      break;
-    case HERETIC_MT_SOR2FX1:       // D'Sparil missile
-      damage = 80 + (P_Random(pr_heretic) & 31);
-      distance = damage;
-      break;
-    case HEXEN_MT_MNTRFX2:       // Minotaur floor fire
-      damage = 24;
-      break;
-    case HEXEN_MT_BISHOP:        // Bishop radius death
-      damage = 25 + (P_Random(pr_hexen) & 15);
-      break;
-    case HEXEN_MT_HAMMER_MISSILE:        // Fighter Hammer
-      damage = 128;
-      damageSelf = false;
-      break;
-    case HEXEN_MT_FSWORD_MISSILE:        // Fighter Runesword
-      damage = 64;
-      damageSelf = false;
-      break;
-    case HEXEN_MT_CIRCLEFLAME:   // Cleric Flame secondary flames
-      damage = 20;
-      damageSelf = false;
-      break;
-    case HEXEN_MT_SORCBALL1:     // Sorcerer balls
-    case HEXEN_MT_SORCBALL2:
-    case HEXEN_MT_SORCBALL3:
-      distance = 255;
-      damage = 255;
-      thingy->args[0] = 1; // don't play bounce
-      break;
-    case HEXEN_MT_SORCFX1:       // Sorcerer spell 1
-      damage = 30;
-      break;
-    case HEXEN_MT_SORCFX4:       // Sorcerer spell 4
-      damage = 20;
-      break;
-    case HEXEN_MT_TREEDESTRUCTIBLE:
-      damage = 10;
-      break;
-    case HEXEN_MT_DRAGON_FX2:
-      damage = 80;
-      damageSelf = false;
-      break;
-    case HEXEN_MT_MSTAFF_FX:
-      damage = 64;
-      distance = 192;
-      damageSelf = false;
-      break;
-    case HEXEN_MT_MSTAFF_FX2:
-      damage = 80;
-      distance = 192;
-      damageSelf = false;
-      break;
-    case HEXEN_MT_POISONCLOUD:
-      damage = 4;
-      distance = 40;
-      break;
-    case HEXEN_MT_ZXMAS_TREE:
-    case HEXEN_MT_ZSHRUB2:
-      damage = 30;
-      distance = 64;
-      break;
-    default:
-      break;
+    switch (thingy->type)
+    {
+      case HERETIC_MT_FIREBOMB:      // Time Bombs
+      case HEXEN_MT_FIREBOMB:        // Time Bombs
+        thingy->z += 32 * FRACUNIT;
+        thingy->flags &= ~MF_SHADOW;
+        break;
+      case HERETIC_MT_MNTRFX2:       // Minotaur floor fire
+        damage = 24;
+        distance = damage;
+        break;
+      case HERETIC_MT_SOR2FX1:       // D'Sparil missile
+        damage = 80 + (P_Random(pr_heretic) & 31);
+        distance = damage;
+        break;
+      case HEXEN_MT_MNTRFX2:       // Minotaur floor fire
+        damage = 24;
+        break;
+      case HEXEN_MT_BISHOP:        // Bishop radius death
+        damage = 25 + (P_Random(pr_hexen) & 15);
+        break;
+      case HEXEN_MT_HAMMER_MISSILE:        // Fighter Hammer
+        damage = 128;
+        damageSelf = false;
+        break;
+      case HEXEN_MT_FSWORD_MISSILE:        // Fighter Runesword
+        damage = 64;
+        damageSelf = false;
+        break;
+      case HEXEN_MT_CIRCLEFLAME:   // Cleric Flame secondary flames
+        damage = 20;
+        damageSelf = false;
+        break;
+      case HEXEN_MT_SORCBALL1:     // Sorcerer balls
+      case HEXEN_MT_SORCBALL2:
+      case HEXEN_MT_SORCBALL3:
+        distance = 255;
+        damage = 255;
+        thingy->args[0] = 1; // don't play bounce
+        break;
+      case HEXEN_MT_SORCFX1:       // Sorcerer spell 1
+        damage = 30;
+        break;
+      case HEXEN_MT_SORCFX4:       // Sorcerer spell 4
+        damage = 20;
+        break;
+      case HEXEN_MT_TREEDESTRUCTIBLE:
+        damage = 10;
+        break;
+      case HEXEN_MT_DRAGON_FX2:
+        damage = 80;
+        damageSelf = false;
+        break;
+      case HEXEN_MT_MSTAFF_FX:
+        damage = 64;
+        distance = 192;
+        damageSelf = false;
+        break;
+      case HEXEN_MT_MSTAFF_FX2:
+        damage = 80;
+        distance = 192;
+        damageSelf = false;
+        break;
+      case HEXEN_MT_POISONCLOUD:
+        damage = 4;
+        distance = 40;
+        break;
+      case HEXEN_MT_ZXMAS_TREE:
+      case HEXEN_MT_ZSHRUB2:
+        damage = 30;
+        distance = 64;
+        break;
+      default:
+        break;
+    }
   }
 
   P_RadiusAttack(thingy, thingy->target, damage, distance, damageSelf);

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -1209,7 +1209,7 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
 
   if (target->flags & MF_SKULLFLY)
   {
-    if (target->type == HERETIC_MT_MINOTAUR) return;
+    if (heretic && target->type == HERETIC_MT_MINOTAUR) return;
     target->momx = target->momy = target->momz = 0;
   }
 
@@ -1651,8 +1651,8 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
   if (P_Random (pr_painchance) < target->info->painchance &&
       !(target->flags & MF_SKULLFLY)) //killough 11/98: see below
   {
-    if (inflictor && (inflictor->type >= HEXEN_MT_LIGHTNING_FLOOR
-                      && inflictor->type <= HEXEN_MT_LIGHTNING_ZAP))
+    if (hexen && inflictor && inflictor->type >= HEXEN_MT_LIGHTNING_FLOOR &&
+                              inflictor->type <= HEXEN_MT_LIGHTNING_ZAP)
     {
       if (P_Random(pr_hexen) < 96)
       {
@@ -1683,7 +1683,7 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
 
       P_SetMobjState(target, target->info->painstate);
 
-      if (inflictor && inflictor->type == HEXEN_MT_POISONCLOUD)
+      if (hexen && inflictor && inflictor->type == HEXEN_MT_POISONCLOUD)
       {
         if (target->flags & MF_COUNTKILL && P_Random(pr_hexen) < 128
             && !S_GetSoundPlayingInfo(target, hexen_sfx_puppybeat))

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -501,7 +501,7 @@ dboolean PIT_CheckLine (line_t* ld)
         ld->flags & ML_BLOCKMONSTERS ||
         (mbf21 && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
       ) &&
-      tmthing->type != HERETIC_MT_POD
+      (!heretic || tmthing->type != HERETIC_MT_POD)
     )
     {
       if (tmthing->flags2 & MF2_BLASTED)
@@ -659,67 +659,70 @@ static dboolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
     int new_state;
     int damage;
 
-    if (tmthing->type == HEXEN_MT_MINOTAUR)
+    if (hexen)
     {
-      // Slamming minotaurs shouldn't move non-creatures
-      if (!(thing->flags & MF_COUNTKILL))
+      if (tmthing->type == HEXEN_MT_MINOTAUR)
       {
-        return (false);
+        // Slamming minotaurs shouldn't move non-creatures
+        if (!(thing->flags & MF_COUNTKILL))
+        {
+          return (false);
+        }
       }
-    }
-    else if (tmthing->type == HEXEN_MT_HOLY_FX)
-    {
-      if (thing->flags & MF_SHOOTABLE && thing != tmthing->target)
+      else if (tmthing->type == HEXEN_MT_HOLY_FX)
       {
-        if (netgame && !deathmatch && thing->player)
-        {               // don't attack other co-op players
-          return true;
-        }
-        if (thing->flags2 & MF2_REFLECTIVE
-            && (thing->player || thing->flags2 & MF2_BOSS))
+        if (thing->flags & MF_SHOOTABLE && thing != tmthing->target)
         {
-          P_SetTarget(&tmthing->special1.m, tmthing->target);
-          P_SetTarget(&tmthing->target, thing);
-          return true;
-        }
-        if (thing->flags & MF_COUNTKILL || thing->player)
-        {
-          P_SetTarget(&tmthing->special1.m, thing);
-        }
-        if (P_Random(pr_hexen) < 96)
-        {
-          damage = 12;
-          if (thing->player || thing->flags2 & MF2_BOSS)
-          {
-            damage = 3;
-            // ghost burns out faster when attacking players/bosses
-            tmthing->health -= 6;
+          if (netgame && !deathmatch && thing->player)
+          {               // don't attack other co-op players
+            return true;
           }
-          P_DamageMobj(thing, tmthing, tmthing->target, damage);
-          if (P_Random(pr_hexen) < 128)
+          if (thing->flags2 & MF2_REFLECTIVE
+              && (thing->player || thing->flags2 & MF2_BOSS))
           {
-            P_SpawnMobj(tmthing->x, tmthing->y, tmthing->z,
-                        HEXEN_MT_HOLY_PUFF);
-            S_StartSound(tmthing, hexen_sfx_spirit_attack);
-            if (thing->flags & MF_COUNTKILL && P_Random(pr_hexen) < 128
-                && !S_GetSoundPlayingInfo(thing, hexen_sfx_puppybeat))
+            P_SetTarget(&tmthing->special1.m, tmthing->target);
+            P_SetTarget(&tmthing->target, thing);
+            return true;
+          }
+          if (thing->flags & MF_COUNTKILL || thing->player)
+          {
+            P_SetTarget(&tmthing->special1.m, thing);
+          }
+          if (P_Random(pr_hexen) < 96)
+          {
+            damage = 12;
+            if (thing->player || thing->flags2 & MF2_BOSS)
             {
-              if ((thing->type == HEXEN_MT_CENTAUR) ||
-                  (thing->type == HEXEN_MT_CENTAURLEADER) ||
-                  (thing->type == HEXEN_MT_ETTIN))
+              damage = 3;
+              // ghost burns out faster when attacking players/bosses
+              tmthing->health -= 6;
+            }
+            P_DamageMobj(thing, tmthing, tmthing->target, damage);
+            if (P_Random(pr_hexen) < 128)
+            {
+              P_SpawnMobj(tmthing->x, tmthing->y, tmthing->z,
+                          HEXEN_MT_HOLY_PUFF);
+              S_StartSound(tmthing, hexen_sfx_spirit_attack);
+              if (thing->flags & MF_COUNTKILL && P_Random(pr_hexen) < 128
+                  && !S_GetSoundPlayingInfo(thing, hexen_sfx_puppybeat))
               {
-                S_StartSound(thing, hexen_sfx_puppybeat);
+                if ((thing->type == HEXEN_MT_CENTAUR) ||
+                    (thing->type == HEXEN_MT_CENTAURLEADER) ||
+                    (thing->type == HEXEN_MT_ETTIN))
+                {
+                  S_StartSound(thing, hexen_sfx_puppybeat);
+                }
               }
             }
           }
+          if (thing->health <= 0)
+          {
+            tmthing->special1.i = 0;
+            P_SetTarget(&tmthing->special1.m, NULL);
+          }
         }
-        if (thing->health <= 0)
-        {
-          tmthing->special1.i = 0;
-          P_SetTarget(&tmthing->special1.m, NULL);
-        }
+        return true;
       }
-      return true;
     }
 
     damage = ((P_Random(pr_skullfly) % 8) + 1) * tmthing->info->damage;
@@ -783,118 +786,121 @@ static dboolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
     if (tmthing->z + tmthing->height < thing->z)
       return true;    // underneath
 
-    if (hexen && tmthing->flags2 & MF2_FLOORBOUNCE)
+    if (hexen)
     {
-      if (tmthing->target == thing || !(thing->flags & MF_SOLID))
+      if (tmthing->flags2 & MF2_FLOORBOUNCE)
       {
-        return true;
-      }
-      else
-      {
-        return false;
-      }
-    }
-
-    if (tmthing->type == HEXEN_MT_LIGHTNING_FLOOR
-        || tmthing->type == HEXEN_MT_LIGHTNING_CEILING)
-    {
-      if (thing->flags & MF_SHOOTABLE && thing != tmthing->target)
-      {
-        if (thing->info->mass != INT_MAX)
+        if (tmthing->target == thing || !(thing->flags & MF_SOLID))
         {
-          thing->momx += tmthing->momx >> 4;
-          thing->momy += tmthing->momy >> 4;
+          return true;
         }
-        if ((!thing->player && !(thing->flags2 & MF2_BOSS))
-            || !(leveltime & 1))
-        {
-          if (thing->type == HEXEN_MT_CENTAUR
-              || thing->type == HEXEN_MT_CENTAURLEADER)
-          {           // Lightning does more damage to centaurs
-            P_DamageMobj(thing, tmthing, tmthing->target, 9);
-          }
-          else
-          {
-            P_DamageMobj(thing, tmthing, tmthing->target, 3);
-          }
-          if (!(S_GetSoundPlayingInfo(tmthing,
-                                      hexen_sfx_mage_lightning_zap)))
-          {
-            S_StartSound(tmthing, hexen_sfx_mage_lightning_zap);
-          }
-          if (thing->flags & MF_COUNTKILL && P_Random(pr_hexen) < 64
-              && !S_GetSoundPlayingInfo(thing, hexen_sfx_puppybeat))
-          {
-            if ((thing->type == HEXEN_MT_CENTAUR) ||
-                (thing->type == HEXEN_MT_CENTAURLEADER) ||
-                (thing->type == HEXEN_MT_ETTIN))
-            {
-              S_StartSound(thing, hexen_sfx_puppybeat);
-            }
-          }
-        }
-        tmthing->health--;
-        if (tmthing->health <= 0 || thing->health <= 0)
+        else
         {
           return false;
         }
-        if (tmthing->type == HEXEN_MT_LIGHTNING_FLOOR)
-        {
-          if (tmthing->special2.m
-              && !tmthing->special2.m->special1.m)
-          {
-            P_SetTarget(&tmthing->special2.m->special1.m, thing);
-          }
-        }
-        else if (!tmthing->special1.m)
-        {
-          P_SetTarget(&tmthing->special1.m, thing);
-        }
       }
-      return true;        // lightning zaps through all sprites
-    }
-    else if (tmthing->type == HEXEN_MT_LIGHTNING_ZAP)
-    {
-      mobj_t *lmo;
 
-      if (thing->flags & MF_SHOOTABLE && thing != tmthing->target)
+      if (tmthing->type == HEXEN_MT_LIGHTNING_FLOOR
+          || tmthing->type == HEXEN_MT_LIGHTNING_CEILING)
       {
-        lmo = tmthing->special2.m;
-        if (lmo)
+        if (thing->flags & MF_SHOOTABLE && thing != tmthing->target)
         {
-          if (lmo->type == HEXEN_MT_LIGHTNING_FLOOR)
+          if (thing->info->mass != INT_MAX)
           {
-            if (lmo->special2.m
-                && !lmo->special2.m->special1.m)
+            thing->momx += tmthing->momx >> 4;
+            thing->momy += tmthing->momy >> 4;
+          }
+          if ((!thing->player && !(thing->flags2 & MF2_BOSS))
+              || !(leveltime & 1))
+          {
+            if (thing->type == HEXEN_MT_CENTAUR
+                || thing->type == HEXEN_MT_CENTAURLEADER)
+            {           // Lightning does more damage to centaurs
+              P_DamageMobj(thing, tmthing, tmthing->target, 9);
+            }
+            else
             {
-              P_SetTarget(&lmo->special2.m->special1.m, thing);
+              P_DamageMobj(thing, tmthing, tmthing->target, 3);
+            }
+            if (!(S_GetSoundPlayingInfo(tmthing,
+                                        hexen_sfx_mage_lightning_zap)))
+            {
+              S_StartSound(tmthing, hexen_sfx_mage_lightning_zap);
+            }
+            if (thing->flags & MF_COUNTKILL && P_Random(pr_hexen) < 64
+                && !S_GetSoundPlayingInfo(thing, hexen_sfx_puppybeat))
+            {
+              if ((thing->type == HEXEN_MT_CENTAUR) ||
+                  (thing->type == HEXEN_MT_CENTAURLEADER) ||
+                  (thing->type == HEXEN_MT_ETTIN))
+              {
+                S_StartSound(thing, hexen_sfx_puppybeat);
+              }
             }
           }
-          else if (!lmo->special1.m)
+          tmthing->health--;
+          if (tmthing->health <= 0 || thing->health <= 0)
           {
-            P_SetTarget(&lmo->special1.m, thing);
+            return false;
           }
-          if (!(leveltime & 3))
+          if (tmthing->type == HEXEN_MT_LIGHTNING_FLOOR)
           {
-            lmo->health--;
+            if (tmthing->special2.m
+                && !tmthing->special2.m->special1.m)
+            {
+              P_SetTarget(&tmthing->special2.m->special1.m, thing);
+            }
+          }
+          else if (!tmthing->special1.m)
+          {
+            P_SetTarget(&tmthing->special1.m, thing);
+          }
+        }
+        return true;        // lightning zaps through all sprites
+      }
+      else if (tmthing->type == HEXEN_MT_LIGHTNING_ZAP)
+      {
+        mobj_t *lmo;
+
+        if (thing->flags & MF_SHOOTABLE && thing != tmthing->target)
+        {
+          lmo = tmthing->special2.m;
+          if (lmo)
+          {
+            if (lmo->type == HEXEN_MT_LIGHTNING_FLOOR)
+            {
+              if (lmo->special2.m
+                  && !lmo->special2.m->special1.m)
+              {
+                P_SetTarget(&lmo->special2.m->special1.m, thing);
+              }
+            }
+            else if (!lmo->special1.m)
+            {
+              P_SetTarget(&lmo->special1.m, thing);
+            }
+            if (!(leveltime & 3))
+            {
+              lmo->health--;
+            }
           }
         }
       }
-    }
-    else if (tmthing->type == HEXEN_MT_MSTAFF_FX2 && thing != tmthing->target)
-    {
-      if (!thing->player && !(thing->flags2 & MF2_BOSS))
+      else if (tmthing->type == HEXEN_MT_MSTAFF_FX2 && thing != tmthing->target)
       {
-        switch (thing->type)
+        if (!thing->player && !(thing->flags2 & MF2_BOSS))
         {
-          case HEXEN_MT_FIGHTER_BOSS:      // these not flagged boss
-          case HEXEN_MT_CLERIC_BOSS:       // so they can be blasted
-          case HEXEN_MT_MAGE_BOSS:
-            break;
-          default:
-            P_DamageMobj(thing, tmthing, tmthing->target, 10);
-            return true;
-            break;
+          switch (thing->type)
+          {
+            case HEXEN_MT_FIGHTER_BOSS:      // these not flagged boss
+            case HEXEN_MT_CLERIC_BOSS:       // so they can be blasted
+            case HEXEN_MT_MAGE_BOSS:
+              break;
+            default:
+              P_DamageMobj(thing, tmthing, tmthing->target, 10);
+              return true;
+              break;
+          }
         }
       }
     }
@@ -1286,7 +1292,7 @@ dboolean P_TryMove(mobj_t* thing,fixed_t x,fixed_t y,
 
     if (
       !(thing->flags & MF_TELEPORT) &&
-      thing->type != HERETIC_MT_MNTRFX2 &&
+      (!heretic || thing->type != HERETIC_MT_MNTRFX2) &&
       tmfloorz - thing->z > 24*FRACUNIT
     )
     {
@@ -1971,7 +1977,7 @@ dboolean PTR_AimTraverse (intercept_t* in)
   if (!(th->flags&MF_SHOOTABLE))
     return true;    // corpse or something
 
-  if (th->type == HERETIC_MT_POD)
+  if (heretic && th->type == HERETIC_MT_POD)
     return true;    // Can't auto-aim at pods
 
   if (hexen && th->player && netgame && !deathmatch)
@@ -2165,7 +2171,7 @@ dboolean PTR_ShootTraverse (intercept_t* in)
       }
     }
 
-    if (PuffType == HEXEN_MT_FLAMEPUFF2)
+    if (hexen && PuffType == HEXEN_MT_FLAMEPUFF2)
     {                       // Cleric FlameStrike does fire damage
       extern mobj_t LavaInflictor;
 
@@ -2250,21 +2256,24 @@ void P_LineAttack(mobj_t* t1, angle_t angle, fixed_t distance, fixed_t slope,
 
   if (P_PathTraverse(t1->x,t1->y,x2,y2,PT_ADDLINES|PT_ADDTHINGS,PTR_ShootTraverse))
   {
-    switch (PuffType)
+    if (hexen)
     {
-      case HEXEN_MT_PUNCHPUFF:
-        S_StartSound(t1, hexen_sfx_fighter_punch_miss);
-        break;
-      case HEXEN_MT_HAMMERPUFF:
-      case HEXEN_MT_AXEPUFF:
-      case HEXEN_MT_AXEPUFF_GLOW:
-        S_StartSound(t1, hexen_sfx_fighter_hammer_miss);
-        break;
-      case HEXEN_MT_FLAMEPUFF:
-        P_SpawnPuff(x2, y2, shootz + FixedMul(slope, distance));
-        break;
-      default:
-        break;
+      switch (PuffType)
+      {
+        case HEXEN_MT_PUNCHPUFF:
+          S_StartSound(t1, hexen_sfx_fighter_punch_miss);
+          break;
+        case HEXEN_MT_HAMMERPUFF:
+        case HEXEN_MT_AXEPUFF:
+        case HEXEN_MT_AXEPUFF_GLOW:
+          S_StartSound(t1, hexen_sfx_fighter_hammer_miss);
+          break;
+        case HEXEN_MT_FLAMEPUFF:
+          P_SpawnPuff(x2, y2, shootz + FixedMul(slope, distance));
+          break;
+        default:
+          break;
+      }
     }
   }
 }
@@ -2549,7 +2558,7 @@ void P_RadiusAttack(mobj_t* spot,mobj_t* source, int damage, int distance, dbool
   xh = P_GetSafeBlockX(spot->x + dist - bmaporgx);
   xl = P_GetSafeBlockX(spot->x - dist - bmaporgx);
   bombspot = spot;
-  if (spot->type == HERETIC_MT_POD && spot->target)
+  if (heretic && spot->type == HERETIC_MT_POD && spot->target)
   {
     bombsource = spot->target;
   }

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -1341,7 +1341,7 @@ void P_TrueUnArchiveThinkers(void) {
           mobj->thinker.function = P_MobjThinker;
           P_AddThinker (&mobj->thinker);
 
-          if (mobj->type == HERETIC_MT_BLASTERFX1)
+          if (heretic && mobj->type == HERETIC_MT_BLASTERFX1)
             mobj->thinker.function = P_BlasterMobjThinker;
 
           if (!((mobj->flags ^ MF_COUNTKILL) & (MF_FRIEND | MF_COUNTKILL | MF_CORPSE)))

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -404,7 +404,7 @@ void P_DeathThink (player_t* player)
   // fall to the ground
 
   onground = (player->mo->z <= player->mo->floorz);
-  if (player->mo->type == g_skullpop_mt || player->mo->type == HEXEN_MT_ICECHUNK)
+  if (player->mo->type == g_skullpop_mt || (hexen && player->mo->type == HEXEN_MT_ICECHUNK))
   {
     // Flying bloody skull
     player->viewheight = 6*FRACUNIT;


### PR DESCRIPTION
Uncapping thing types will lead to situations where dehacked types overrun into the existing heretic and hexen definitions. The code base is currently set up under the assumption that such a case is impossible. This PR adds necessary checks to prevent raven logic from leaking into doom. This separates doom from raven, but heretic and hexen still operate under the assumption there is no overlap.

Best viewed with `?w=1`