### PR TITLE
Allow desktop-fullscreen in OpenGL mode

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1154,10 +1154,9 @@ void I_UpdateVideoMode(void)
     init_flags = SDL_WINDOW_OPENGL;
   }
 
-  // Fullscreen desktop for software renderer only - DTIED
   if (desired_fullscreen)
   {
-    if (V_IsOpenGLMode() || exclusive_fullscreen)
+    if (exclusive_fullscreen)
       init_flags |= SDL_WINDOW_FULLSCREEN;
     else
       init_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;


### PR DESCRIPTION
I noticed some odd mode-switch delay when alt-tabbing in the latest builds and tracked it to this; exclusive fullscreen was being forced in opengl mode. Made this quick change and things are working smoothly again. Borderless window mode works perfectly fine with OpenGL and is a common setting in games these days.