### PR TITLE
Fix for "Cannot open file" issue on macOS

### DIFF
--- a/prboom2/data/rd_util.c
+++ b/prboom2/data/rd_util.c
@@ -102,6 +102,7 @@ size_t read_or_die(void **ptr, const char *file)
   }
 
   *ptr = buffer;
+  fclose(f);
   return length;
 }
 


### PR DESCRIPTION
macOS has a limit of 256 files open at the same time by default.
With the new crosshair variants introduced in 0.21.3, it needed to open 258 files to compile.

@fabiangreffrath you might want to take look, as prboom+ might end up needing to open that many files