### PR TITLE
Add comp_voodooscroller

### DIFF
--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -121,6 +121,7 @@ enum {
   // mbf21
   comp_ledgeblock,
   comp_friendlyspawn,
+  comp_voodooscroller,
 
   MBF_COMP_TOTAL = 32  // limit in MBF format
 };

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -95,7 +95,8 @@ static const dsda_options_t default_mbf_options = {
   // .comp_maxhealth = 0,
   // .comp_translucency = 0,
   // .comp_ledgeblock = 0,
-  // .comp_friendlyspawn = 1
+  // .comp_friendlyspawn = 1,
+  // .comp_voodooscroller = 1,
 };
 
 static const dsda_options_t default_latest_options = {
@@ -141,7 +142,8 @@ static const dsda_options_t default_latest_options = {
   .comp_maxhealth = 0,
   .comp_translucency = 0,
   .comp_ledgeblock = 1,
-  .comp_friendlyspawn = 1
+  .comp_friendlyspawn = 1,
+  .comp_voodooscroller = 0,
 };
 
 static dsda_options_t mbf_options;
@@ -189,6 +191,7 @@ static dsda_option_t option_list[] = {
   { "comp_soul", &mbf_options.comp_soul, 0, 1 },
   { "comp_ledgeblock", &mbf_options.comp_ledgeblock, 0, 1 },
   { "comp_friendlyspawn", &mbf_options.comp_friendlyspawn, 0, 1 },
+  { "comp_voodooscroller", &mbf_options.comp_voodooscroller, 0, 1 },
   { 0 }
 };
 
@@ -278,7 +281,7 @@ const dsda_options_t* dsda_Options(void) {
   return dsda_MBFOptions();
 }
 
-#define MBF21_COMP_TOTAL 23
+#define MBF21_COMP_TOTAL 24
 
 static int mbf21_comp_translation[MBF21_COMP_TOTAL] = {
   comp_telefrag,
@@ -304,6 +307,7 @@ static int mbf21_comp_translation[MBF21_COMP_TOTAL] = {
   comp_soul,
   comp_ledgeblock,
   comp_friendlyspawn,
+  comp_voodooscroller,
 };
 
 // killough 5/2/98: number of bytes reserved for saving options

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -403,6 +403,10 @@ const byte *dsda_ReadOptions21(const byte *demo_p) {
   for (i = 0; i < count; i++)
     comp[mbf21_comp_translation[i]] = *demo_p++;
 
+  // comp_voodooscroller
+  if (count < 24)
+    comp[mbf21_comp_translation[23]] = 1;
+
   G_Compatibility();
 
   return demo_p;

--- a/prboom2/src/dsda/options.h
+++ b/prboom2/src/dsda/options.h
@@ -60,7 +60,7 @@ typedef struct dsda_options {
   int comp_translucency;
   int comp_ledgeblock;
   int comp_friendlyspawn;
-  // int comp_31;
+  int comp_voodooscroller;
   // int comp_32;
 } dsda_options_t;
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2773,8 +2773,8 @@ void G_Compatibility(void)
     { boom_compatibility, mbf21_compatibility },
     // comp_friendlyspawn - A_Spawn new mobj inherits friendliness
     { prboom_1_compatibility, mbf21_compatibility },
-    // comp_placeholder_31 - Not defined yet
-    { 255, 255 },
+    // comp_voodooscroller - Voodoo dolls on slow scrollers move too slowly
+    { mbf21_compatibility, mbf21_compatibility },
     // comp_placeholder_32 - Not defined yet
     { 255, 255 }
   };
@@ -2917,6 +2917,7 @@ void G_ReloadDefaults(void)
     comp[comp_translucency] = options->comp_translucency;
     comp[comp_ledgeblock] = options->comp_ledgeblock;
     comp[comp_friendlyspawn] = options->comp_friendlyspawn;
+    comp[comp_voodooscroller] = options->comp_voodooscroller;
   }
 
   G_Compatibility();

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -544,7 +544,8 @@ static void P_XYMovement (mobj_t* mo)
       !(player->cmd.forwardmove | player->cmd.sidemove) ||
       (
         player->mo != mo &&
-        compatibility_level >= lxdoom_1_compatibility
+        compatibility_level >= lxdoom_1_compatibility &&
+        (comp[comp_voodooscroller] || !(mo->intflags & MIF_SCROLLING))
       )
     )
   )


### PR DESCRIPTION
There's a bug introduced by lxdoom (cl 10) where voodoo dolls on slowly scrolling floors move too slowly. It's a side effect of a feature / fix related to stopping voodoo dolls similar to how a player is stopped.

MBF21 was designed with small adjustments in mind for these kinds of important bugs, so this PR adds a `comp_voodooscroller` option to fix this issue. The mbf21 spec must be updated before merging this.

Heads up @rfomin @fabiangreffrath