### PR TITLE
Refactor line flags

### DIFF
--- a/prboom2/src/doomdata.h
+++ b/prboom2/src/doomdata.h
@@ -118,13 +118,13 @@ typedef struct {
 //
 
 // Solid, is an obstacle.
-#define ML_BLOCKING             1
+#define ML_BLOCKING      0x0001
 
 // Blocks monsters only.
-#define ML_BLOCKMONSTERS        2
+#define ML_BLOCKMONSTERS 0x0002
 
 // Backside will not be drawn if not two sided.
-#define ML_TWOSIDED             4
+#define ML_TWOSIDED      0x0004
 
 // If a texture is pegged, the texture will have
 // the end exposed to air held constant at the
@@ -136,31 +136,30 @@ typedef struct {
 // top and bottom textures (use next to windows).
 
 // upper texture unpegged
-#define ML_DONTPEGTOP           8
+#define ML_DONTPEGTOP    0x0008
 
 // lower texture unpegged
-#define ML_DONTPEGBOTTOM        16
+#define ML_DONTPEGBOTTOM 0x0010
 
 // In AutoMap: don't map as two sided: IT'S A SECRET!
-#define ML_SECRET               32
+#define ML_SECRET        0x0020
 
 // Sound rendering: don't let sound cross two of these.
-#define ML_SOUNDBLOCK           64
+#define ML_SOUNDBLOCK    0x0040
 
 // Don't draw on the automap at all.
-#define ML_DONTDRAW             128
+#define ML_DONTDRAW      0x0080
 
 // Set if already seen, thus drawn in automap.
-#define ML_MAPPED               256
+#define ML_MAPPED        0x0100
 
 //jff 3/21/98 Set if line absorbs use by player
 //allow multiple push/switch triggers to be used on one push
-#define ML_PASSUSE      512
-
+#define ML_PASSUSE 0x0200
 
 // Reserved by EE
 // SoM 9/02/02: 3D Middletexture flag!
-#define ML_3DMIDTEX             1024
+#define ML_3DMIDTEX 0x0400
 
 // haleyjd 05/02/06: Although it was believed until now that a reserved line
 // flag was unnecessary, a problem with Ultimate DOOM E2M7 has disproven this
@@ -168,11 +167,26 @@ typedef struct {
 // making the next line flag reserved and using it to toggle off ALL extended
 // flags will preserve compatibility for such maps. I have been told this map
 // is one of the first ever created, so it may have something to do with that.
-#define ML_RESERVED             2048
+#define ML_RESERVED 0x0800
 
 // mbf21
-#define ML_BLOCKLANDMONSTERS 4096
-#define ML_BLOCKPLAYERS 8192
+#define ML_BLOCKLANDMONSTERS 0x1000
+#define ML_BLOCKPLAYERS      0x2000
+
+// extensions
+#define ML_MONSTERSCANACTIVATE 0x4000 // zdoom
+#define ML_BLOCKEVERYTHING     0x8000 // zdoom
+
+#define ML_REPEATSPECIAL       0x00010000 // hexen
+
+#define ML_SPAC_CROSS          0x00020000 // hexen activation
+#define ML_SPAC_USE            0x00040000 // hexen activation
+#define ML_SPAC_MCROSS         0x00080000 // hexen activation
+#define ML_SPAC_IMPACT         0x00100000 // hexen activation
+#define ML_SPAC_PUSH           0x00200000 // hexen activation
+#define ML_SPAC_PCROSS         0x00400000 // hexen activation
+
+#define ML_SPAC_MASK (ML_SPAC_CROSS|ML_SPAC_USE|ML_SPAC_MCROSS|ML_SPAC_IMPACT|ML_SPAC_PUSH|ML_SPAC_PCROSS)
 
 // Sector definition, from editing.
 typedef struct {
@@ -294,42 +308,15 @@ typedef struct {
 } PACKEDATTR doom_mapthing_t;
 
 // hexen
+#define HML_REPEATSPECIAL 0x0200  // special is repeatable
+#define HML_SPAC_SHIFT 10
+#define HML_SPAC_MASK 0x1c00
+#define GET_SPAC(flags) ((flags&HML_SPAC_MASK)>>HML_SPAC_SHIFT)
 
-#define ML_REPEAT_SPECIAL 0x0200  // special is repeatable
-#define ML_SPAC_SHIFT 10
-#define ML_SPAC_MASK 0x1c00
-#define GET_SPAC(flags) ((flags&ML_SPAC_MASK)>>ML_SPAC_SHIFT)
-
-// Special activation types
-#define SPAC_CROSS  0       // when player crosses line
-#define SPAC_USE    1       // when player uses line
-#define SPAC_MCROSS 2       // when monster crosses line
-#define SPAC_IMPACT 3       // when projectile hits line
-#define SPAC_PUSH   4       // when player/monster pushes line
-#define SPAC_PCROSS 5       // when projectile crosses line
-
-// extensions
-
-// ZML map values are converted to ML internal values
+// zdoom
 #define ZML_MONSTERSCANACTIVATE 0x2000 // Monsters and players can activate
 #define ZML_BLOCKPLAYERS        0x4000 // Blocks players
 #define ZML_BLOCKEVERYTHING     0x8000 // Blocks everything
-
-// ML_BLOCKPLAYERS is above
-#define ML_MONSTERSCANACTIVATE 0x4000
-#define ML_BLOCKEVERYTHING     0x8000
-
-#define SPAC_USETHROUGH 6
-#define SPAC_PTOUCH     7
-
-#define SPACF_CROSS      0x01
-#define SPACF_USE        0x02
-#define SPACF_MCROSS     0x04
-#define SPACF_IMPACT     0x08
-#define SPACF_PUSH       0x10
-#define SPACF_PCROSS     0x20
-#define SPACF_USETHROUGH 0x40
-#define SPACF_PTOUCH     0x80
 
 #ifdef _MSC_VER
 #pragma pack(pop)

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -155,8 +155,8 @@ extern void P_CrossHexenSpecialLine(line_t *line, int side, mobj_t *thing, dbool
 extern void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line);
 extern void P_ShootHexenSpecialLine(mobj_t *thing, line_t *line);
 
-extern dboolean P_TestActivateZDoomLine(line_t *line, mobj_t *mo, int side, int activationType);
-extern dboolean P_TestActivateHexenLine(line_t *line, mobj_t *mo, int side, int activationType);
+extern dboolean P_TestActivateZDoomLine(line_t *line, mobj_t *mo, int side, unsigned int activationType);
+extern dboolean P_TestActivateHexenLine(line_t *line, mobj_t *mo, int side, unsigned int activationType);
 
 extern void P_PostProcessCompatibleLineSpecial(line_t *ld);
 extern void P_PostProcessHereticLineSpecial(line_t *ld);
@@ -177,6 +177,9 @@ extern void P_CheckCompatibleImpact(mobj_t *);
 extern void P_CheckHereticImpact(mobj_t *);
 extern void P_CheckZDoomImpact(mobj_t *);
 
+extern void P_TranslateHexenLineFlags(unsigned int *);
+extern void P_TranslateZDoomLineFlags(unsigned int *);
+
 static const map_format_t zdoom_in_hexen_map_format = {
   .zdoom = true,
   .hexen = true,
@@ -192,7 +195,7 @@ static const map_format_t zdoom_in_hexen_map_format = {
   .friction_mask = ZDOOM_FRICTION_MASK,
   .push_mask = ZDOOM_PUSH_MASK,
   .generalized_mask = ~0xff,
-  .switch_activation = SPACF_USE | SPACF_IMPACT | SPACF_PUSH,
+  .switch_activation = ML_SPAC_USE | ML_SPAC_IMPACT | ML_SPAC_PUSH,
   .init_sector_special = P_SpawnZDoomSectorSpecial,
   .player_in_special_sector = P_PlayerInZDoomSector,
   .spawn_scroller = P_SpawnZDoomScroller,
@@ -206,6 +209,7 @@ static const map_format_t zdoom_in_hexen_map_format = {
   .post_process_sidedef_special = P_PostProcessZDoomSidedefSpecial,
   .animate_surfaces = P_AnimateZDoomSurfaces,
   .check_impact = P_CheckZDoomImpact,
+  .translate_line_flags = P_TranslateZDoomLineFlags,
   .mapthing_size = sizeof(mapthing_t),
   .maplinedef_size = sizeof(hexen_maplinedef_t),
 };
@@ -225,7 +229,7 @@ static const map_format_t hexen_map_format = {
   .friction_mask = 0, // not used
   .push_mask = 0, // not used
   .generalized_mask = 0, // not used
-  .switch_activation = SPACF_USE | SPACF_IMPACT,
+  .switch_activation = ML_SPAC_USE | ML_SPAC_IMPACT,
   .init_sector_special = NULL, // not used
   .player_in_special_sector = P_PlayerInHexenSector,
   .spawn_scroller = NULL, // not used
@@ -239,6 +243,7 @@ static const map_format_t hexen_map_format = {
   .post_process_sidedef_special = P_PostProcessHexenSidedefSpecial,
   .animate_surfaces = P_AnimateHexenSurfaces,
   .check_impact = NULL, // not used
+  .translate_line_flags = P_TranslateHexenLineFlags,
   .mapthing_size = sizeof(mapthing_t),
   .maplinedef_size = sizeof(hexen_maplinedef_t),
 };

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -36,7 +36,7 @@ typedef struct {
   short friction_mask;
   short push_mask;
   short generalized_mask;
-  byte switch_activation;
+  unsigned int switch_activation;
   void (*init_sector_special)(sector_t*, int);
   void (*player_in_special_sector)(player_t*, sector_t*);
   void (*spawn_scroller)(line_t*, int);
@@ -45,11 +45,12 @@ typedef struct {
   void (*spawn_extra)(line_t*, int);
   void (*cross_special_line)(line_t *, int, mobj_t *, dboolean);
   void (*shoot_special_line)(mobj_t *, line_t *);
-  dboolean (*test_activate_line)(line_t *, mobj_t *, int, int);
+  dboolean (*test_activate_line)(line_t *, mobj_t *, int, unsigned int);
   void (*post_process_line_special)(line_t *);
   void (*post_process_sidedef_special)(side_t *, const mapsidedef_t *, sector_t *, int);
   void (*animate_surfaces)(void);
   void (*check_impact)(mobj_t *);
+  void (*translate_line_flags)(unsigned int *);
   size_t mapthing_size;
   size_t maplinedef_size;
 } map_format_t;

--- a/prboom2/src/dsda/map_format_todo.md
+++ b/prboom2/src/dsda/map_format_todo.md
@@ -1,6 +1,5 @@
 ### Lines
 - ML_BLOCKEVERYTHING
-- SPAC_UseThrough
 - P_ExecuteLineSpecial ~170 specials
 
 ### Sectors

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -1342,7 +1342,7 @@ static void ArchiveWorld(void)
     }
     for (i = 0, li = lines; i < numlines; i++, li++)
     {
-        SV_WriteWord(li->flags);
+        SV_WriteLong(li->flags);
         SV_WriteByte(li->special);
         SV_WriteByte(li->arg1);
         SV_WriteByte(li->arg2);
@@ -1390,7 +1390,7 @@ static void UnarchiveWorld(void)
     }
     for (i = 0, li = lines; i < numlines; i++, li++)
     {
-        li->flags = SV_ReadWord();
+        li->flags = SV_ReadLong();
         li->special = SV_ReadByte();
         li->arg1 = SV_ReadByte();
         li->arg2 = SV_ReadByte();

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -3494,11 +3494,11 @@ static void CheckForPushSpecial(line_t * line, int side, mobj_t * mobj)
     {
         if (mobj->flags2 & MF2_PUSHWALL)
         {
-            P_ActivateLine(line, mobj, side, SPAC_PUSH);
+            P_ActivateLine(line, mobj, side, ML_SPAC_PUSH);
         }
         else if (mobj->flags2 & MF2_IMPACT)
         {
-            P_ActivateLine(line, mobj, side, SPAC_IMPACT);
+            P_ActivateLine(line, mobj, side, ML_SPAC_IMPACT);
         }
     }
 }
@@ -3622,15 +3622,15 @@ static dboolean Hexen_P_TryMove(mobj_t* thing, fixed_t x, fixed_t y)
                 {
                     if (thing->player)
                     {
-                        P_ActivateLine(ld, thing, oldside, SPAC_CROSS);
+                        P_ActivateLine(ld, thing, oldside, ML_SPAC_CROSS);
                     }
                     else if (thing->flags2 & MF2_MCROSS)
                     {
-                        P_ActivateLine(ld, thing, oldside, SPAC_MCROSS);
+                        P_ActivateLine(ld, thing, oldside, ML_SPAC_MCROSS);
                     }
                     else if (thing->flags2 & MF2_PCROSS)
                     {
-                        P_ActivateLine(ld, thing, oldside, SPAC_PCROSS);
+                        P_ActivateLine(ld, thing, oldside, ML_SPAC_PCROSS);
                     }
                 }
             }

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -508,12 +508,11 @@ dboolean PIT_CheckLine (line_t* ld)
     }
 
     // killough 8/9/98: monster-blockers don't affect friends
-    // MAP_FORMAT_TODO: clean up ML_BLOCKLANDMONSTERS check
     if (
       !(tmthing->flags & MF_FRIEND || tmthing->player) &&
       (
         ld->flags & ML_BLOCKMONSTERS ||
-        (mbf21 && !map_format.zdoom && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
+        (mbf21 && ld->flags & ML_BLOCKLANDMONSTERS && !(tmthing->flags & MF_FLOAT))
       ) &&
       (!heretic || tmthing->type != HERETIC_MT_POD)
     )

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -139,7 +139,8 @@ void P_ArchiveWorld (void)
       sizeof(sec->seqType)
     ) * numsectors +
     (
-      sizeof(short) * 3 +
+      sizeof(short) * 2 +
+      sizeof(li->flags) +
       sizeof(li->arg1) * 5
     ) * numlines +
     sizeof(musinfo.current_item);
@@ -181,7 +182,9 @@ void P_ArchiveWorld (void)
   {
     int j;
 
-    *put++ = li->flags;
+    memcpy(put, &li->flags, sizeof(li->flags));
+    put = (void *)((char *) put + sizeof(li->flags));
+
     *put++ = li->special;
     *put++ = li->tag;
 
@@ -260,7 +263,9 @@ void P_UnArchiveWorld (void)
   {
     int j;
 
-    li->flags = *get++;
+    memcpy(&li->flags, get, sizeof(li->flags));
+    get = (void *)((char *) get + sizeof(li->flags));
+
     li->special = *get++;
     li->tag = *get++;
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1610,15 +1610,28 @@ static void P_LoadThings (int lump)
 //
 // killough 5/3/98: reformatted, cleaned up
 
-static void P_TranslateLineFlags(unsigned short *flags)
+void P_TranslateZDoomLineFlags(unsigned int *flags)
 {
-  unsigned short result;
+  unsigned int result;
+  static unsigned int spac_to_flags[8] = {
+    ML_SPAC_CROSS,
+    ML_SPAC_USE,
+    ML_SPAC_MCROSS,
+    ML_SPAC_IMPACT,
+    ML_SPAC_PUSH,
+    ML_SPAC_PCROSS,
+    ML_SPAC_USE | ML_PASSUSE,
+    ML_SPAC_IMPACT | ML_SPAC_PCROSS
+  };
 
-  if (!map_format.zdoom) return;
-
-  result = *flags & 0x1fff;
+  result = *flags & 0x1ff;
 
   // from zdoom-in-hexen to dsda-doom
+
+  result |= spac_to_flags[GET_SPAC(*flags)];
+
+  if (*flags & HML_REPEATSPECIAL)
+    result |= ML_REPEATSPECIAL;
 
   if (*flags & ZML_BLOCKPLAYERS)
     result |= ML_BLOCKPLAYERS;
@@ -1628,6 +1641,32 @@ static void P_TranslateLineFlags(unsigned short *flags)
 
   if (*flags & ZML_BLOCKEVERYTHING)
     result |= ML_BLOCKEVERYTHING;
+
+  *flags = result;
+}
+
+void P_TranslateHexenLineFlags(unsigned int *flags)
+{
+  unsigned int result;
+  static unsigned int spac_to_flags[8] = {
+    ML_SPAC_CROSS,
+    ML_SPAC_USE,
+    ML_SPAC_MCROSS,
+    ML_SPAC_IMPACT,
+    ML_SPAC_PUSH,
+    ML_SPAC_PCROSS,
+    0,
+    0
+  };
+
+  result = *flags & 0x1ff;
+
+  // from hexen to dsda-doom
+
+  result |= spac_to_flags[GET_SPAC(*flags)];
+
+  if (*flags & HML_REPEATSPECIAL)
+    result |= ML_REPEATSPECIAL;
 
   *flags = result;
 }
@@ -1651,7 +1690,7 @@ static void P_LoadLineDefs (int lump)
         const hexen_maplinedef_t *mld = (const hexen_maplinedef_t *) data + i;
 
         ld->flags = (unsigned short)LittleShort(mld->flags);
-        P_TranslateLineFlags(&ld->flags);
+        map_format.translate_line_flags(&ld->flags);
         ld->special = mld->special; // just a byte in hexen
         ld->tag = 0;
         ld->arg1 = mld->arg1;

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -1347,7 +1347,7 @@ void Hexen_EV_StopPlat(line_t * line, byte * args);
 
 //
 
-dboolean P_ActivateLine(line_t * line, mobj_t * mo, int side, int activationType);
+dboolean P_ActivateLine(line_t * line, mobj_t * mo, int side, unsigned int activationType);
 dboolean P_ExecuteLineSpecial(int special, byte * args, line_t * line, int side, mobj_t * mo);
 void P_PlayerOnSpecialFlat(player_t * player, int floorType);
 line_t *P_FindLine(int lineTag, int *searchPosition);

--- a/prboom2/src/p_switch.c
+++ b/prboom2/src/p_switch.c
@@ -323,7 +323,7 @@ P_UseSpecialLine
     if (side) //jff 6/1/98 fix inadvertent deletion of side test
       return false;
 
-  if (map_format.hexen) return P_ActivateLine(line, thing, side, SPAC_USE);
+  if (map_format.hexen) return P_ActivateLine(line, thing, side, ML_SPAC_USE);
   if (heretic) return Heretic_P_UseSpecialLine(thing, line, side, bossaction);
 
   //jff 02/04/98 add check here for generalized floor/ceil mover

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -223,6 +223,14 @@ typedef enum
   ST_NEGATIVE
 } slopetype_t;
 
+typedef byte r_flags_t;
+#define RF_TOP_TILE 0x01 // Upper texture needs tiling
+#define RF_MID_TILE 0x02 // Mid texture needs tiling
+#define RF_BOT_TILE 0x04 // Lower texture needs tiling
+#define RF_IGNORE   0x08 // Renderer can skip this line
+#define RF_CLOSED   0x10 // Line blocks view
+#define RF_ISOLATED 0x20 // Isolated line
+
 typedef struct line_s
 {
   int iLineID;           // proff 04/05/2000: needed for OpenGL
@@ -245,14 +253,7 @@ typedef struct line_s
   int tranlump;          // killough 4/11/98: translucency filter, -1 == none
   int firsttag,nexttag;  // killough 4/17/98: improves searches for tags.
   int r_validcount;      // cph: if == gametic, r_flags already done
-  enum {                 // cph:
-    RF_TOP_TILE  = 1,     // Upper texture needs tiling
-    RF_MID_TILE = 2,     // Mid texture needs tiling
-    RF_BOT_TILE = 4,     // Lower texture needs tiling
-    RF_IGNORE   = 8,     // Renderer can skip this line
-    RF_CLOSED   =16,     // Line blocks view
-    RF_ISOLATED =32,     // Isolated line
-  } r_flags;
+  r_flags_t r_flags;     // cph
   degenmobj_t soundorg;  // sound origin for switches/buttons
 
   // hexen

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -231,7 +231,7 @@ typedef struct line_s
 #ifdef GL_DOOM
   float texel_length;
 #endif
-  unsigned short flags;           // Animation related.
+  unsigned int flags;           // Animation related.
   short special;
   short tag;
   unsigned short sidenum[2];        // Visual appearance: SideDefs.


### PR DESCRIPTION
Hexen's line flags overlap with boom's, and mbf21's overlap with zdoom's. Also, hexen's single-valued spac mask becomes multivalued in zdoom.

This PR migrates line flags from short to int so that there is room for everything, and adds translation when reading the map data so there is a consistent internal representation without collision.

The r_flags line field, which only needs 6 bits, was cut down from an int to a byte as well, so the size of a line actually went down in this refactor.