### PR TITLE
Generalize crush

### DIFF
--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -302,6 +302,14 @@ void SpechitOverrun(spechit_overrun_param_t *params)
           break;
         case 14:
           *(params->crushchange) = addr;
+
+          // In vanilla doom, this field is interpreted as a boolean,
+          //   but it now stores the crushing damage itself.
+          // Since any nonzero value should yield doom's damage,
+          //   we can set this explicitly.
+          if (*params->crushchange)
+            *params->crushchange = 10;
+
           break;
 
         default:

--- a/prboom2/src/g_overflow.h
+++ b/prboom2/src/g_overflow.h
@@ -113,7 +113,7 @@ typedef struct spechit_overrun_param_s
   fixed_t *tmfloorz;
   fixed_t *tmceilingz;
 
-  dboolean *crushchange;
+  int      *crushchange;
   dboolean *nofit;
 } spechit_overrun_param_t;
 

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -73,7 +73,7 @@ result_e T_MoveCeilingPlane
 ( sector_t*     sector,
   fixed_t       speed,
   fixed_t       dest,
-  dboolean      crush,
+  int           crush,
   int           direction,
   dboolean      hexencrush )
 {
@@ -118,7 +118,7 @@ result_e T_MoveCeilingPlane
 
         if (flag == true)
         {
-          if (!hexencrush && crush == true)
+          if (!hexencrush && crush >= 0)
             return crushed;
           sector->ceilingheight = lastpos;
           P_CheckSector(sector,crush);      //jff 3/19/98 use faster chk
@@ -182,7 +182,7 @@ void T_MoveCompatibleCeiling(ceiling_t * ceiling)
               ceiling->sector,
               ceiling->speed,
               ceiling->topheight,
-              false,
+              NO_CRUSH,
               ceiling->direction,
               false
             );
@@ -358,7 +358,7 @@ void T_MoveHexenCeiling(ceiling_t * ceiling)
     //                      break;
         case 1:                // UP
             res = T_MoveCeilingPlane(ceiling->sector, ceiling->speed,
-                                     ceiling->topheight, false,
+                                     ceiling->topheight, NO_CRUSH,
                                      ceiling->direction, true);
             if (res == pastdest)
             {
@@ -469,13 +469,13 @@ manual_ceiling://e6y
     sec->ceilingdata = ceiling;               //jff 2/22/98
     ceiling->thinker.function = T_MoveCeiling;
     ceiling->sector = sec;
-    ceiling->crush = false;
+    ceiling->crush = NO_CRUSH;
 
     // setup ceiling structure according to type of function
     switch(type)
     {
       case fastCrushAndRaise:
-        ceiling->crush = true;
+        ceiling->crush = DOOM_CRUSH;
         ceiling->topheight = sec->ceilingheight;
         ceiling->bottomheight = sec->floorheight + (8*FRACUNIT);
         ceiling->direction = -1;
@@ -485,7 +485,7 @@ manual_ceiling://e6y
       case silentCrushAndRaise:
         ceiling->silent = 1;
       case crushAndRaise:
-        ceiling->crush = true;
+        ceiling->crush = DOOM_CRUSH;
         ceiling->topheight = sec->ceilingheight;
         // fallthrough
       case lowerAndCrush:
@@ -959,12 +959,12 @@ int Hexen_EV_DoCeiling(line_t * line, byte * arg, ceiling_e type)
         sec->ceilingdata = ceiling;
         ceiling->thinker.function = T_MoveCeiling;
         ceiling->sector = sec;
-        ceiling->crush = 0;
+        ceiling->crush = NO_CRUSH;
         ceiling->speed = arg[1] * (FRACUNIT / 8);
         switch (type)
         {
             case CLEV_CRUSHRAISEANDSTAY:
-                ceiling->crush = arg[2];        // arg[2] = crushing value
+                ceiling->crush = P_ConvertHexenCrush(arg[2]);        // arg[2] = crushing value
                 ceiling->topheight = sec->ceilingheight;
                 ceiling->bottomheight = sec->floorheight + (8 * FRACUNIT);
                 ceiling->direction = -1;
@@ -972,7 +972,7 @@ int Hexen_EV_DoCeiling(line_t * line, byte * arg, ceiling_e type)
             case CLEV_CRUSHANDRAISE:
                 ceiling->topheight = sec->ceilingheight;
             case CLEV_LOWERANDCRUSH:
-                ceiling->crush = arg[2];        // arg[2] = crushing value
+                ceiling->crush = P_ConvertHexenCrush(arg[2]);        // arg[2] = crushing value
             case CLEV_LOWERTOFLOOR:
                 ceiling->bottomheight = sec->floorheight;
                 if (type != CLEV_LOWERTOFLOOR)

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -138,7 +138,7 @@ void T_VerticalCompatibleDoor(vldoor_t *door)
               door->sector,
               door->speed,
               door->sector->floorheight,
-              false,
+              NO_CRUSH,
               door->direction,
               false
             );
@@ -254,7 +254,7 @@ void T_VerticalCompatibleDoor(vldoor_t *door)
               door->sector,
               door->speed,
               door->topheight,
-              false,
+              NO_CRUSH,
               door->direction,
               false
             );
@@ -365,7 +365,7 @@ void T_VerticalHexenDoor(vldoor_t *door)
       break;
     case -1:               // DOWN
       res = T_MoveCeilingPlane(door->sector, door->speed,
-                               door->sector->floorheight, false,
+                               door->sector->floorheight, NO_CRUSH,
                                door->direction, true);
       if (res == pastdest)
       {
@@ -400,7 +400,7 @@ void T_VerticalHexenDoor(vldoor_t *door)
       break;
     case 1:                // UP
       res = T_MoveCeilingPlane(door->sector, door->speed,
-                               door->topheight, false, door->direction, true);
+                               door->topheight, NO_CRUSH, door->direction, true);
       if (res == pastdest)
       {
         SN_StopSequence((mobj_t *) & door->sector->soundorg);

--- a/prboom2/src/p_genlin.c
+++ b/prboom2/src/p_genlin.c
@@ -115,7 +115,7 @@ manual_floor:
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
     floor->thinker.function = T_MoveFloor;
-    floor->crush = Crsh;
+    floor->crush = (Crsh ? DOOM_CRUSH : NO_CRUSH);
     floor->direction = Dirn? 1 : -1;
     floor->sector = sec;
     floor->texture = sec->floorpic;
@@ -310,7 +310,7 @@ manual_ceiling:
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
     ceiling->thinker.function = T_MoveCeiling;
-    ceiling->crush = Crsh;
+    ceiling->crush = (Crsh ? DOOM_CRUSH : NO_CRUSH);
     ceiling->direction = Dirn? 1 : -1;
     ceiling->sector = sec;
     ceiling->texture = sec->ceilingpic;
@@ -510,7 +510,7 @@ manual_lift:
     plat->sector = sec;
     plat->sector->floordata = plat;
     plat->thinker.function = T_PlatRaise;
-    plat->crush = false;
+    plat->crush = NO_CRUSH;
     plat->tag = line->tag;
 
     plat->type = genLift;
@@ -713,7 +713,7 @@ manual_stair:
     height = sec->floorheight + floor->direction * stairsize;
     floor->floordestheight = height;
     texture = sec->floorpic;
-    floor->crush = false;
+    floor->crush = NO_CRUSH;
     floor->type = genBuildStair; // jff 3/31/98 do not leave uninited
 
     sec->stairlock = -2;         // jff 2/26/98 set up lock on current sector
@@ -777,7 +777,7 @@ manual_stair:
         floor->sector = sec;
         floor->speed = speed;
         floor->floordestheight = height;
-        floor->crush = false;
+        floor->crush = NO_CRUSH;
         floor->type = genBuildStair; // jff 3/31/98 do not leave uninited
 
         ok = 1;
@@ -857,7 +857,7 @@ manual_crusher:
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
     ceiling->thinker.function = T_MoveCeiling;
-    ceiling->crush = true;
+    ceiling->crush = DOOM_CRUSH;
     ceiling->direction = -1;
     ceiling->sector = sec;
     ceiling->texture = sec->ceilingpic;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -80,7 +80,8 @@ static int ls_y; // Lost Soul position for Lost Soul checks      // phares
 //  to undo the changes.
 //
 
-static dboolean crushchange, nofit;
+static int crushchange;
+static dboolean nofit;
 
 // If "floatok" true, move would be ok
 // if within "tmfloorz - tmceilingz".
@@ -2716,12 +2717,11 @@ dboolean PIT_ChangeSector (mobj_t* thing)
 
   nofit = true;
 
-  if (crushchange && !(leveltime & 3)) {
+  if (crushchange > 0 && !(leveltime & 3)) {
     int t;
-    int damage = hexen ? crushchange : 10;
 
-    P_DamageMobj(thing, NULL, NULL, damage);
-    dsda_WatchCrush(thing, damage);
+    P_DamageMobj(thing, NULL, NULL, crushchange);
+    dsda_WatchCrush(thing, crushchange);
 
     if (
       !hexen ||
@@ -2753,7 +2753,7 @@ dboolean PIT_ChangeSector (mobj_t* thing)
 //
 // P_ChangeSector
 //
-dboolean P_ChangeSector(sector_t* sector,dboolean crunch)
+dboolean P_ChangeSector(sector_t* sector, int crunch)
 {
   int   x;
   int   y;
@@ -2781,7 +2781,7 @@ dboolean P_ChangeSector(sector_t* sector,dboolean crunch)
 // sector. Both more accurate and faster.
 //
 
-dboolean P_CheckSector(sector_t* sector,dboolean crunch)
+dboolean P_CheckSector(sector_t* sector, int crunch)
 {
   msecnode_t *n;
 
@@ -3360,7 +3360,7 @@ void P_AppendSpecHit(line_t * ld)
       &tmfloorz,     // fixed_t *tmfloorz;
       &tmceilingz,   // fixed_t *tmceilingz;
 
-      &crushchange,  // dboolean *crushchange;
+      &crushchange,  // int *crushchange;
       &nofit,        // dboolean *nofit;
     };
     spechit_overrun_param.line = ld;

--- a/prboom2/src/p_map.h
+++ b/prboom2/src/p_map.h
@@ -74,8 +74,8 @@ void P_RadiusAttack(mobj_t *spot, mobj_t *source, int damage, int distance, dboo
 dboolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y);
 
 //jff 3/19/98 P_CheckSector(): new routine to replace P_ChangeSector()
-dboolean P_ChangeSector(sector_t* sector,dboolean crunch);
-dboolean P_CheckSector(sector_t *sector, dboolean crunch);
+dboolean P_ChangeSector(sector_t *sector, int crunch);
+dboolean P_CheckSector(sector_t *sector, int crunch);
 void    P_DelSeclist(msecnode_t*);                          // phares 3/16/98
 void    P_FreeSecNodeList(void);                            // sf
 void    P_CreateSecNodeList(mobj_t*,fixed_t,fixed_t);       // phares 3/14/98

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -87,7 +87,7 @@ void T_PlatRaise(plat_t* plat)
       }
 
       // if encountered an obstacle, and not a crush type, reverse direction
-      if (res == crushed && (!plat->crush))
+      if (res == crushed && plat->crush == NO_CRUSH)
       {
         plat->count = plat->wait;
         plat->status = down;
@@ -142,7 +142,7 @@ void T_PlatRaise(plat_t* plat)
       break;
 
     case down: // plat moving down
-      res = T_MoveFloorPlane(plat->sector, plat->speed, plat->low, false, -1, false);
+      res = T_MoveFloorPlane(plat->sector, plat->speed, plat->low, NO_CRUSH, -1, false);
 
       // handle reaching end of down stroke
       if (res == pastdest)
@@ -261,7 +261,7 @@ manual_plat://e6y
     plat->sector = sec;
     plat->sector->floordata = plat; //jff 2/23/98 multiple thinkers
     plat->thinker.function = T_PlatRaise;
-    plat->crush = false;
+    plat->crush = NO_CRUSH;
     plat->tag = line->tag;
 
     //jff 1/26/98 Avoid raise plat bouncing a head off a ceiling and then
@@ -339,7 +339,7 @@ manual_plat://e6y
       case toggleUpDn: //jff 3/14/98 add new type to support instant toggle
         plat->speed = PLATSPEED;  //not used
         plat->wait = 35*PLATWAIT; //not used
-        plat->crush = true; //jff 3/14/98 crush anything in the way
+        plat->crush = DOOM_CRUSH; //jff 3/14/98 crush anything in the way
 
         // set up toggling between ceiling, floor inclusive
         plat->low = sec->ceilingheight;
@@ -481,7 +481,7 @@ static void Hexen_T_PlatRaise(plat_t * plat)
     {
         case up:
             res = T_MoveFloorPlane(plat->sector, plat->speed, plat->high, plat->crush, 1, true);
-            if (res == crushed && (!plat->crush))
+            if (res == crushed && plat->crush == NO_CRUSH)
             {
                 plat->count = plat->wait;
                 plat->status = down;
@@ -505,7 +505,7 @@ static void Hexen_T_PlatRaise(plat_t * plat)
             }
             break;
         case down:
-            res = T_MoveFloorPlane(plat->sector, plat->speed, plat->low, false, -1, true);
+            res = T_MoveFloorPlane(plat->sector, plat->speed, plat->low, NO_CRUSH, -1, true);
             if (res == pastdest)
             {
                 plat->count = plat->wait;
@@ -563,7 +563,7 @@ int Hexen_EV_DoPlat(line_t * line, byte * args, plattype_e type, int amount)
         plat->sector = sec;
         plat->sector->floordata = plat;
         plat->thinker.function = T_PlatRaise;
-        plat->crush = false;
+        plat->crush = NO_CRUSH;
         plat->tag = args[0];
         plat->speed = args[1] * (FRACUNIT / 8);
         switch (type)

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -940,6 +940,12 @@ static void P_InitTagLists(void)
     }
 }
 
+// Converts Hexen's 0 (meaning no crush) to the internal value
+int P_ConvertHexenCrush(int crush)
+{
+  return (crush ? crush : NO_CRUSH);
+}
+
 //
 // P_FindMinSurroundingLight()
 //

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -1058,7 +1058,7 @@ result_e T_MoveFloorPlane
 ( sector_t* sector,
   fixed_t speed,
   fixed_t dest,
-  dboolean crush,
+  int crush,
   int direction,
   dboolean hexencrush );
 
@@ -1127,7 +1127,7 @@ result_e T_MoveCeilingPlane
 ( sector_t* sector,
   fixed_t speed,
   fixed_t dest,
-  dboolean crush,
+  int crush,
   int direction,
   dboolean hexencrush );
 
@@ -1409,7 +1409,7 @@ int Hexen_EV_DoFloor(line_t * line, byte * args, floor_e floortype);
 int EV_DoFloorAndCeiling(line_t * line, byte * args, dboolean raise);
 int Hexen_EV_BuildStairs(line_t * line, byte * args, int direction, stairs_e stairsType);
 void T_BuildPillar(pillar_t * pillar);
-int EV_BuildPillar(line_t * line, byte * args, dboolean crush);
+int EV_BuildPillar(line_t * line, byte * args, int crush);
 int EV_OpenPillar(line_t * line, byte * args);
 int EV_FloorCrushStop(line_t * line, byte * args);
 void T_FloorWaggle(floorWaggle_t * waggle);
@@ -1581,5 +1581,9 @@ void EV_LightChange(int tag, short change);
 void EV_LightSet(int tag, short level);
 void EV_LightSetMinNeighbor(int tag);
 void EV_LightSetMaxNeighbor(int tag);
+int P_ConvertHexenCrush(int crush);
+
+#define NO_CRUSH -1
+#define DOOM_CRUSH 10
 
 #endif


### PR DESCRIPTION
The crush variable has evolved over time:

| Engine | Value | Meaning |
|---------|-------|-----------|
| Doom | 0 | Not Crushing |
| Doom | 1 | Crushing |
| Heretic | 0 | Not Crushing |
| Heretic | 1 | Crushing |
| Hexen | 0 | Not Crushing |
| Hexen | X > 0 | Crushing Damage |
| ZDoom | -1 | Not Crushing |
| ZDoom | X >= 0 | Crushing Damage |

Note that ZDoom supports crushers that do crush but don't deal any damage. This PR adapts old crush references to the new format.