### PR TITLE
Rewrite scaled time management

### DIFF
--- a/prboom2/src/POSIX/i_system.c
+++ b/prboom2/src/POSIX/i_system.c
@@ -77,27 +77,6 @@ void I_uSleep(unsigned long usecs)
 static unsigned long lasttimereply;
 static unsigned long basetime;
 
-int I_GetTime_RealTime (void)
-{
-  struct timeval tv;
-  struct timezone tz;
-  unsigned long thistimereply;
-
-  gettimeofday(&tv, &tz);
-
-  thistimereply = (tv.tv_sec * TICRATE + (tv.tv_usec * TICRATE) / 1000000);
-
-  /* Fix for time problem */
-  if (!basetime) {
-    basetime = thistimereply; thistimereply = 0;
-  } else thistimereply -= basetime;
-
-  if (thistimereply < lasttimereply)
-    thistimereply = lasttimereply;
-
-  return (lasttimereply = thistimereply);
-}
-
 /*
  * I_GetRandomTimeSeed
  *

--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -81,81 +81,30 @@ typedef BOOL (WINAPI *SetAffinityFunc)(HANDLE hProcess, DWORD mask);
 #include "dsda/settings.h"
 #include "dsda/split_tracker.h"
 #include "dsda/text_file.h"
+#include "dsda/time.h"
 
 /* Most of the following has been rewritten by Lee Killough
  *
- * I_GetTime
  * killough 4/13/98: Make clock rate adjustable by scale factor
  * cphipps - much made static
  */
 
 int realtic_clock_rate = 100;
-static int_64_t I_GetTime_Scale = 1<<24;
-
-static int I_GetTime_Scaled(void)
-{
-  return (int)( (int_64_t) I_GetTime_RealTime() * I_GetTime_Scale >> 24);
-}
-
-
-
-static int  I_GetTime_FastDemo(void)
-{
-  static int fasttic;
-  return fasttic++;
-}
-
-
-
-static int I_GetTime_Error(void)
-{
-  I_Error("I_GetTime_Error: GetTime() used before initialization");
-  return 0;
-}
-
-
-
-int (*I_GetTime)(void) = I_GetTime_Error;
 
 void I_Init(void)
 {
-  /* killough 4/14/98: Adjustable speedup based on realtic_clock_rate */
-  if (fastdemo)
-    I_GetTime = I_GetTime_FastDemo;
-  else
-    if (dsda_RealticClockRate() != 100)
-      {
-        I_GetTime_Scale = ((int_64_t) dsda_RealticClockRate() << 24) / 100;
-        I_GetTime = I_GetTime_Scaled;
-      }
-    else
-      I_GetTime = I_GetTime_RealTime;
+  dsda_ResetTimeFunctions(fastdemo);
 
-  {
-    /* killough 2/21/98: avoid sound initialization if no sound & no music */
-    if (!(nomusicparm && nosfxparm))
-      I_InitSound();
-  }
-
-  R_InitInterpolation();
+  /* killough 2/21/98: avoid sound initialization if no sound & no music */
+  if (!(nomusicparm && nosfxparm))
+    I_InitSound();
 }
 
 //e6y
 void I_Init2(void)
 {
-  if (fastdemo)
-    I_GetTime = I_GetTime_FastDemo;
-  else
-  {
-    if (dsda_RealticClockRate() != 100)
-      {
-        I_GetTime_Scale = ((int_64_t) dsda_RealticClockRate() << 24) / 100;
-        I_GetTime = I_GetTime_Scaled;
-      }
-    else
-      I_GetTime = I_GetTime_RealTime;
-  }
-  R_InitInterpolation();
+  dsda_ResetTimeFunctions(fastdemo);
+
   force_singletics_to = gametic + BACKUPTICS;
 }
 

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -101,40 +101,6 @@ void I_uSleep(unsigned long usecs)
     SDL_Delay(usecs/1000);
 }
 
-int ms_to_next_tick;
-
-int I_GetTime_RealTime (void)
-{
-  static dboolean started = false;
-  int i;
-  unsigned long long t;
-
-  //e6y: removing startup delay
-  if (!started)
-  {
-    started = true;
-    dsda_StartTimer(dsda_timer_realtime);
-  }
-
-  t = dsda_ElapsedTime(dsda_timer_realtime);
-
-  i = t * TICRATE / 1000000;
-  ms_to_next_tick = (i + 1) * 1000 / TICRATE - t / 1000;
-  if (ms_to_next_tick > 1000 / TICRATE) ms_to_next_tick = 1;
-  if (ms_to_next_tick < 1) ms_to_next_tick = 0;
-  return i;
-}
-
-static unsigned long long I_TicStartTime(void)
-{
-  return (unsigned long long) I_GetTime_RealTime() * 1000000 / TICRATE;
-}
-
-static unsigned long long I_CurrentTime(void)
-{
-  return dsda_ElapsedTime(dsda_timer_realtime);
-}
-
 static dboolean InDisplay = false;
 static int saved_gametic = -1;
 dboolean realframe = false;
@@ -170,10 +136,11 @@ fixed_t I_GetTimeFrac (void)
   else
   {
     unsigned long long tic_time;
+    const double tics_per_usec = TICRATE / 1000000.0f;
 
-    tic_time = I_CurrentTime() - I_TicStartTime();
+    tic_time = dsda_TickElapsedTime();
 
-    frac = (fixed_t) (tic_time * FRACUNIT * tic_vars.tics_per_usec);
+    frac = (fixed_t) (tic_time * FRACUNIT * tics_per_usec);
     frac = BETWEEN(0, FRACUNIT, frac);
   }
 

--- a/prboom2/src/d_client.c
+++ b/prboom2/src/d_client.c
@@ -61,6 +61,7 @@
 #include "lprintf.h"
 #include "e6y.h"
 #include "dsda/settings.h"
+#include "dsda/time.h"
 
 ticcmd_t         netcmds[MAX_MAXPLAYERS][BACKUPTICS];
 static ticcmd_t* localcmds;
@@ -91,7 +92,7 @@ void FakeNetUpdate(void)
     return;
 
   { // Build new ticcmds
-    int newtics = I_GetTime() - lastmadetic;
+    int newtics = dsda_GetTick() - lastmadetic;
     lastmadetic += newtics;
 
     if (ffmap) newtics++;
@@ -111,10 +112,13 @@ void FakeNetUpdate(void)
   }
 }
 
+// Implicitly tracked whenever we check the current tick
+int ms_to_next_tick;
+
 void TryRunTics (void)
 {
   int runtics;
-  int entertime = I_GetTime();
+  int entertime = dsda_GetTick();
 
   // Wait for tics to run
   while (1) {
@@ -124,7 +128,7 @@ void TryRunTics (void)
       if (!movement_smooth || !window_focused) {
           I_uSleep(ms_to_next_tick*1000);
       }
-      if (I_GetTime() - entertime > 10) {
+      if (dsda_GetTick() - entertime > 10) {
         M_Ticker(); return;
       }
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -246,7 +246,7 @@ static void D_Wipe(void)
     I_Init2();
   }
 
-  wipestart = I_GetTime () - 1;
+  wipestart = dsda_GetTick() - 1;
 
   do
   {
@@ -254,7 +254,7 @@ static void D_Wipe(void)
     do
     {
       I_uSleep(5000); // CPhipps - don't thrash cpu in this loop
-      nowtime = I_GetTime();
+      nowtime = dsda_GetTick();
       tics = nowtime - wipestart;
     }
     while (!tics);

--- a/prboom2/src/dsda/time.c
+++ b/prboom2/src/dsda/time.c
@@ -119,3 +119,93 @@ void dsda_LimitFPS(void) {
     dsda_Throttle(dsda_timer_fps, target_time);
   }
 }
+
+#define TICRATE 35
+
+int dsda_RealticClockRate(void);
+
+static unsigned long long dsda_RealTime(void) {
+  static dboolean started = false;
+
+  if (!started)
+  {
+    started = true;
+    dsda_StartTimer(dsda_timer_realtime);
+  }
+
+  return dsda_ElapsedTime(dsda_timer_realtime);
+}
+
+static unsigned long long dsda_ScaledTime(void) {
+  return dsda_RealTime() * dsda_RealticClockRate() / 100;
+}
+
+extern int ms_to_next_tick;
+
+// During a fast demo, each call yields a new tick
+static int dsda_GetTickFastDemo(void)
+{
+  static int tick;
+  return tick++;
+}
+
+int dsda_GetTickRealTime(void) {
+  int i;
+  unsigned long long t;
+
+  t = dsda_RealTime();
+
+  i = t * TICRATE / 1000000;
+  ms_to_next_tick = (i + 1) * 1000 / TICRATE - t / 1000;
+  if (ms_to_next_tick > 1000 / TICRATE) ms_to_next_tick = 1;
+  if (ms_to_next_tick < 1) ms_to_next_tick = 0;
+  return i;
+}
+
+static int dsda_TickMS(int n) {
+  return n * 1000 * 100 / dsda_RealticClockRate() / TICRATE;
+}
+
+static int dsda_GetTickScaledTime(void) {
+  int i;
+  unsigned long long t;
+
+  t = dsda_RealTime();
+
+  i = t * TICRATE * dsda_RealticClockRate() / 100 / 1000000;
+  ms_to_next_tick = dsda_TickMS(i + 1) - t / 1000;
+  if (ms_to_next_tick > dsda_TickMS(1)) ms_to_next_tick = 1;
+  if (ms_to_next_tick < 1) ms_to_next_tick = 0;
+  return i;
+}
+
+// During a fast demo, no time elapses in between ticks
+static unsigned long long dsda_TickElapsedTimeFastDemo(void) {
+  return 0;
+}
+
+static unsigned long long dsda_TickElapsedRealTime(void) {
+  return dsda_RealTime() - (unsigned long long) dsda_GetTick() * 1000000 / TICRATE;
+}
+
+static unsigned long long dsda_TickElapsedScaledTime(void) {
+  return dsda_ScaledTime() - (unsigned long long) dsda_GetTick() * 1000000 / TICRATE;
+}
+
+int (*dsda_GetTick)(void) = dsda_GetTickRealTime;
+unsigned long long (*dsda_TickElapsedTime)(void) = dsda_TickElapsedRealTime;
+
+void dsda_ResetTimeFunctions(int fastdemo) {
+  if (fastdemo) {
+    dsda_GetTick = dsda_GetTickFastDemo;
+    dsda_TickElapsedTime = dsda_TickElapsedTimeFastDemo;
+  }
+  else if (dsda_RealticClockRate() != 100) {
+    dsda_GetTick = dsda_GetTickScaledTime;
+    dsda_TickElapsedTime = dsda_TickElapsedScaledTime;
+  }
+  else {
+    dsda_GetTick = dsda_GetTickRealTime;
+    dsda_TickElapsedTime = dsda_TickElapsedRealTime;
+  }
+}

--- a/prboom2/src/dsda/time.h
+++ b/prboom2/src/dsda/time.h
@@ -26,9 +26,14 @@ typedef enum {
   DSDA_TIMER_COUNT
 } dsda_timer_t;
 
+extern int (*dsda_GetTick)(void);
+extern unsigned long long (*dsda_TickElapsedTime)(void);
+
 void dsda_StartTimer(int timer);
 unsigned long long dsda_ElapsedTime(int timer);
 unsigned long long dsda_ElapsedTimeMS(int timer);
 void dsda_LimitFPS(void);
+int dsda_GetTickRealTime(void);
+void dsda_ResetTimeFunctions(int fastdemo);
 
 #endif

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -96,6 +96,7 @@
 #include "dsda/mouse.h"
 #include "dsda/options.h"
 #include "dsda/tas.h"
+#include "dsda/time.h"
 #include "dsda/split_tracker.h"
 #include "statdump.h"
 
@@ -1194,7 +1195,7 @@ static void G_DoLoadLevel (void)
     static int first=1;
     if (first)
       {
-        starttime = I_GetTime_RealTime ();
+        starttime = dsda_GetTickRealTime();
         first=0;
       }
   }
@@ -4184,7 +4185,7 @@ dboolean G_CheckDemoStatus (void)
 
   if (timingdemo)
   {
-    int endtime = I_GetTime_RealTime ();
+    int endtime = dsda_GetTickRealTime();
     // killough -- added fps information and made it work for longer demos:
     unsigned realtics = endtime-starttime;
 

--- a/prboom2/src/i_main.h
+++ b/prboom2/src/i_main.h
@@ -70,6 +70,4 @@ void I_Warning(const char *message, ...);
 void I_Init(void);
 void I_SafeExit(int rc);
 
-extern int (*I_GetTime)(void);
-
 #endif

--- a/prboom2/src/i_system.h
+++ b/prboom2/src/i_system.h
@@ -57,7 +57,6 @@ extern int interpolation_method;
 extern int ms_to_next_tick;
 dboolean I_StartDisplay(void);
 void I_EndDisplay(void);
-int I_GetTime_RealTime(void);     /* killough */
 fixed_t I_GetTimeFrac (void);
 
 unsigned long I_GetRandomTimeSeed(void); /* cphipps */

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -79,6 +79,7 @@
 #include "dsda/input.h"
 #include "dsda/palette.h"
 #include "dsda/save.h"
+#include "dsda/time.h"
 #include "dsda/console.h"
 #include "heretic/mn_menu.h"
 #include "heretic/sb_bar.h"
@@ -4408,45 +4409,45 @@ dboolean M_Responder (event_t* ev) {
 
   // Process joystick input
 
-  if (ev->type == ev_joystick && joywait < I_GetTime()) {
+  if (ev->type == ev_joystick && joywait < dsda_GetTick()) {
     if (ev->data3 == -1)
     {
       action = MENU_UP;                                // phares 3/7/98
       ch = 0;
-      joywait = I_GetTime() + 5;
+      joywait = dsda_GetTick() + 5;
     }
     else if (ev->data3 == 1)
     {
       action = MENU_DOWN;                              // phares 3/7/98
       ch = 0;
-      joywait = I_GetTime() + 5;
+      joywait = dsda_GetTick() + 5;
     }
 
     if (ev->data2 == -1)
     {
       action = MENU_LEFT;                              // phares 3/7/98
       ch = 0;
-      joywait = I_GetTime() + 2;
+      joywait = dsda_GetTick() + 2;
     }
     else if (ev->data2 == 1)
     {
       action = MENU_RIGHT;                             // phares 3/7/98
       ch = 0;
-      joywait = I_GetTime() + 2;
+      joywait = dsda_GetTick() + 2;
     }
 
     if (ev->data1&1)
     {
       action = MENU_ENTER;                             // phares 3/7/98
       ch = 0;
-      joywait = I_GetTime() + 5;
+      joywait = dsda_GetTick() + 5;
     }
 
     if (ev->data1&2)
     {
       action = MENU_BACKSPACE;                         // phares 3/7/98
       ch = 0;
-      joywait = I_GetTime() + 5;
+      joywait = dsda_GetTick() + 5;
     }
 
     // phares 4/4/98:
@@ -4457,25 +4458,25 @@ dboolean M_Responder (event_t* ev) {
       if (ev->data1 >> 2)
       {
         ch = 0; // meaningless, just to get you past the check for -1
-        joywait = I_GetTime() + 5;
+        joywait = dsda_GetTick() + 5;
       }
     }
   }
   else {
    // Process mouse input
-    if (ev->type == ev_mouse && mousewait < I_GetTime()) {
+    if (ev->type == ev_mouse && mousewait < dsda_GetTick()) {
       if (ev->data1&1)
       {
         action = MENU_ENTER;                           // phares 3/7/98
         ch = 0;
-        mousewait = I_GetTime() + 15;
+        mousewait = dsda_GetTick() + 15;
       }
 
       if (ev->data1&2)
       {
         action = MENU_BACKSPACE;                       // phares 3/7/98
         ch = 0;
-        mousewait = I_GetTime() + 15;
+        mousewait = dsda_GetTick() + 15;
       }
 
       // phares 4/4/98:
@@ -4483,7 +4484,7 @@ dboolean M_Responder (event_t* ev) {
       if (ev->data1 >> 2)
       {
         ch = 0; // meaningless, just to get you past the check for -1
-        mousewait = I_GetTime() + 15;
+        mousewait = dsda_GetTick() + 15;
       }
     }
     else

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -84,11 +84,6 @@ void M_ChangeUncappedFrameRate(void)
     movement_smooth = (singletics ? false : movement_smooth_default);
 }
 
-void R_InitInterpolation(void)
-{
-  tic_vars.tics_per_usec = dsda_RealticClockRate() * TICRATE / 100000000.0f;
-}
-
 typedef fixed_t fixed2_t[2];
 static fixed2_t *oldipos;
 static fixed2_t *bakipos;

--- a/prboom2/src/r_fps.h
+++ b/prboom2/src/r_fps.h
@@ -44,7 +44,6 @@ extern dboolean isExtraDDisplay;
 extern int interpolation_maxobjects;
 
 typedef struct {
-  double tics_per_usec;
   fixed_t frac;
 } tic_vars_t;
 
@@ -52,7 +51,6 @@ extern tic_vars_t tic_vars;
 
 void M_ChangeUncappedFrameRate(void);
 
-void R_InitInterpolation(void);
 void R_InterpolateView(player_t *player, fixed_t frac);
 
 extern dboolean WasRenderedInTryRunTics;


### PR DESCRIPTION
The core of the code managing scaled time (game clock rate above or below 100) is the question "what tick are we on?" The scaled code asked this question based on real time and then scaled the result itself. This means that the answer to the question changed exactly as frequently as the real time result. So if we ran the game at 150% speed, then we'd have the following:

| Elapsed Real Time | Real Time Tick | Scaled Time Tick |
| --- | --- | --- |
| 0 | 0 | 0 (0 * 1.5) |
| 1/35 s | 1 | 1 (1 * 1.5) |
| 2/35 s | 2 | 3 (2 * 1.5) |

Unfortunately, we never render tick 2, because 1 scales to 1 and 2 scales to 3.

While rates below 100% didn't have the missing tick problem, they still had the problem of the answer changing only as often as 1/35 of a second. If the game is run at 60% for instance, the time between ticks is inconsistent, as shown here:

| Elapsed Real Time | Real Time Tick | Scaled Time Tick |
| --- | --- | --- |
| 0 | 0 | 0 (0 * 0.6) |
| 1/35 s | 1 | 0 (1 * 0.6) |
| 2/35 s | 2 | 1 (2 * 0.6) |
| 3/35 s | 3 | 1 (3 * 0.6) |
| 4/35 s | 4 | 2 (4 * 0.6) |
| 5/35 s | 5 | 3 (5 * 0.6) |

The new code scales time before answering the question "what tick are we on?"