### PR TITLE
Manage deh thing indices

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1418,9 +1418,22 @@ typedef struct {
   actionf_t cptr;  // actual pointer to the subroutine
   const char *lookup;  // mnemonic lookup string to be specified in BEX
   // CPhipps - const*
-  int argcount;  // [XA] number of mbf21 args this action uses, if any
+  short argcount;  // [XA] number of mbf21 args this action uses, if any
   long default_args[MAXSTATEARGS]; // default values for mbf21 args
+  short ti_flags; // thing index on these args
 } deh_bexptr;
+
+#define TI_MISC1 0x0001
+#define TI_MISC2 0x0002
+#define TI_ARGSSHIFT 2
+#define TI_ARGS1 0x0004
+#define TI_ARGS2 0x0008
+#define TI_ARGS3 0x0010
+#define TI_ARGS4 0x0020
+#define TI_ARGS5 0x0040
+#define TI_ARGS6 0x0080
+#define TI_ARGS7 0x0100
+#define TI_ARGS8 0x0200
 
 static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
 {
@@ -1501,7 +1514,7 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_Detonate,        "A_Detonate"},       // killough 8/9/98
   {A_Mushroom,        "A_Mushroom"},       // killough 10/98
   {A_Die,             "A_Die"},            // killough 11/98
-  {A_Spawn,           "A_Spawn"},          // killough 11/98
+  {A_Spawn,           "A_Spawn", 0, {0}, TI_MISC1},          // killough 11/98
   {A_Turn,            "A_Turn"},           // killough 11/98
   {A_Face,            "A_Face"},           // killough 11/98
   {A_Scratch,         "A_Scratch"},        // killough 11/98
@@ -1514,8 +1527,8 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_Stop,            "A_Stop"},
 
   // [XA] New mbf21 codepointers
-  {A_SpawnObject,         "A_SpawnObject", 8},
-  {A_MonsterProjectile,   "A_MonsterProjectile", 5},
+  {A_SpawnObject,         "A_SpawnObject", 8, {0}, TI_ARGS1},
+  {A_MonsterProjectile,   "A_MonsterProjectile", 5, {0}, TI_ARGS1},
   {A_MonsterBulletAttack, "A_MonsterBulletAttack", 5, {0, 0, 1, 3, 5}},
   {A_MonsterMeleeAttack,  "A_MonsterMeleeAttack", 4, {3, 8, 0, 0}},
   {A_RadiusDamage,        "A_RadiusDamage", 2},
@@ -1532,7 +1545,7 @@ static const deh_bexptr deh_bexptrs[] = // CPhipps - static const
   {A_JumpIfFlagsSet,      "A_JumpIfFlagsSet", 3},
   {A_AddFlags,            "A_AddFlags", 2},
   {A_RemoveFlags,         "A_RemoveFlags", 2},
-  {A_WeaponProjectile,    "A_WeaponProjectile", 5},
+  {A_WeaponProjectile,    "A_WeaponProjectile", 5, {0}, TI_ARGS1},
   {A_WeaponBulletAttack,  "A_WeaponBulletAttack", 5, {0, 0, 1, 5, 3}},
   {A_WeaponMeleeAttack,   "A_WeaponMeleeAttack", 5, {2, 10, 1 * FRACUNIT, 0, 0}},
   {A_WeaponSound,         "A_WeaponSound", 2},
@@ -1932,7 +1945,9 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint_64_t value) {
         return;
       }
       break;
-    case 24: mi->droppeditem = (int)(value - 1); return; // make it base zero (deh is 1-based)
+    case 24: // make it base zero (deh is 1-based)
+      mi->droppeditem = dsda_TranslateDehMobjIndex((int)value) - 1;
+      return;
 
     // mbf21
     // custom groups count from the end of the vanilla list
@@ -1990,6 +2005,7 @@ static void deh_procThing(DEHFILE *fpin, char *line)
   char inbuffer[DEH_BUFFERMAX];
   uint_64_t value;      // All deh values are ints or longs
   int indexnum;
+  int internal_index;
   int ix;
   char *strval;
   dsda_deh_mobjinfo_t deh_mobjinfo;
@@ -2003,9 +2019,9 @@ static void deh_procThing(DEHFILE *fpin, char *line)
 
   // Note that the mobjinfo[] array is base zero, but object numbers
   // in the dehacked file start with one.  Grumble.
-  --indexnum;
+  internal_index = dsda_TranslateDehMobjIndex(indexnum) - 1;
 
-  deh_mobjinfo = dsda_GetDehMobjInfo(indexnum);
+  deh_mobjinfo = dsda_GetDehMobjInfo(internal_index);
 
   // now process the stuff
   // Note that for Things we can look up the key and use its offset
@@ -2072,7 +2088,7 @@ static void deh_procThing(DEHFILE *fpin, char *line)
         // thus screwing everything up and making most DEH patches result in
         // unshootable enemy types. Moved to a separate function above
         // and stripped of all hairy struct address indexing. - POPE
-        setMobjInfoValue(indexnum, ix, value);
+        setMobjInfoValue(internal_index, ix, value);
       }
       else if (bGetData == 1)
       { // proff
@@ -3422,6 +3438,24 @@ void PostProcessDeh(void)
       for (; j >= 0; j--)
         if (!(defined_codeptr_args[i] & (1 << j)))
           states[i].args[j] = bexptr_match->default_args[j];
+
+      // State arguments that refer to thing indices need to be translated
+      if (bexptr_match->ti_flags)
+      {
+        short args_i;
+        short ti_flags = bexptr_match->ti_flags;
+
+        if (ti_flags & TI_MISC1)
+          states[i].misc1 = dsda_TranslateDehMobjIndex(states[i].misc1);
+
+        if (ti_flags & TI_MISC2)
+          states[i].misc2 = dsda_TranslateDehMobjIndex(states[i].misc2);
+
+        ti_flags >>= TI_ARGSSHIFT;
+        for (args_i = 0; args_i < MAXSTATEARGS; ++args_i)
+          if (ti_flags & (1 << args_i))
+            states[i].args[args_i] = dsda_TranslateDehMobjIndex(states[i].args[args_i]);
+      }
 
       // Flags specifications aren't cross-port consistent -> must translate / mask bits
       if (bexptr_match->cptr == A_AddFlags || bexptr_match->cptr == A_RemoveFlags)

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -3106,7 +3106,7 @@ static void deh_procHelperThing(DEHFILE *fpin, char *line)
     // Otherwise it's ok
     deh_log("Processing Helper Thing item '%s'\nvalue is %i", key, (int)value);
     if (!strncasecmp(key, "type", 4))
-      HelperThing = (int)value;
+      HelperThing = dsda_TranslateDehMobjIndex((int)value);
   }
 }
 

--- a/prboom2/src/dsda/mobjinfo.c
+++ b/prboom2/src/dsda/mobjinfo.c
@@ -59,6 +59,46 @@ static void dsda_EnsureCapacity(int limit) {
   }
 }
 
+typedef struct deh_mobj_index_entry_s {
+  int index_in;
+  int index_out;
+  struct deh_mobj_index_entry_s* next;
+} deh_mobj_index_entry_t;
+
+#define DEH_MOBJ_INDEX_HASH_SIZE 128
+
+static deh_mobj_index_entry_t deh_mobj_index_hash[DEH_MOBJ_INDEX_HASH_SIZE];
+
+static int deh_mobj_index_start;
+static int deh_mobj_index_end;
+
+static int dsda_GetDehMobjIndex(int index) {
+  deh_mobj_index_entry_t* entry;
+
+  if (index < deh_mobj_index_start)
+    return index;
+
+  entry = &deh_mobj_index_hash[index % DEH_MOBJ_INDEX_HASH_SIZE];
+
+  while (entry->next && entry->index_in != index)
+    entry = entry->next;
+
+  if (entry->index_in != index) {
+    entry->next = calloc(1, sizeof(*entry));
+    entry = entry->next;
+    entry->index_in = index;
+    entry->index_out = deh_mobj_index_end;
+    ++deh_mobj_index_end;
+  }
+
+  return entry->index_out;
+}
+
+// Dehacked has the index off by 1
+int dsda_TranslateDehMobjIndex(int index) {
+  return dsda_GetDehMobjIndex(index - 1) + 1;
+}
+
 dsda_deh_mobjinfo_t dsda_GetDehMobjInfo(int index) {
   dsda_deh_mobjinfo_t deh_mobjinfo;
 
@@ -80,6 +120,8 @@ void dsda_InitializeMobjInfo(int zero, int max, int count) {
 
   if (raven) return;
 
+  deh_mobj_index_start = num_mobj_types;
+  deh_mobj_index_end = num_mobj_types;
   edited_mobjinfo_bits = calloc(num_mobj_types, sizeof(*edited_mobjinfo_bits));
 }
 

--- a/prboom2/src/dsda/mobjinfo.h
+++ b/prboom2/src/dsda/mobjinfo.h
@@ -25,6 +25,7 @@ typedef struct {
   byte* edited_bits;
 } dsda_deh_mobjinfo_t;
 
+int dsda_TranslateDehMobjIndex(int index);
 dsda_deh_mobjinfo_t dsda_GetDehMobjInfo(int index);
 void dsda_InitializeMobjInfo(int zero, int max, int count);
 void dsda_FreeDehMobjInfo(void);

--- a/prboom2/src/info.h
+++ b/prboom2/src/info.h
@@ -5935,21 +5935,6 @@ typedef enum {
   MT_MUSICSOURCE, /* MUSINFO lump */
   MT_GIBDTH,
 
-  /* proff 11/22/98: Andy Baker's stealth monsters (next 12)
-   * cph - moved below the MBF stuff, no need to displace them */
-  MT_STEALTHBABY,
-  MT_STEALTHVILE,
-  MT_STEALTHBRUISER,
-  MT_STEALTHHEAD,
-  MT_STEALTHCHAINGUY,
-  MT_STEALTHSERGEANT,
-  MT_STEALTHKNIGHT,
-  MT_STEALTHIMP,
-  MT_STEALTHFATSO,
-  MT_STEALTHUNDEAD,
-  MT_STEALTHSHOTGUY,
-  MT_STEALTHZOMBIE,
-
   DOOM_NUMMOBJTYPES,
 
   // heretic


### PR DESCRIPTION
The current dsdhacked implementation allocates _up to_ the required index. Adding 1 new thing could require billions of things worth of space, if the dehacked file uses a large index. This PR adds dehacked thing index management so that values in the dehacked file are translated into the smallest available indices.