### PR TITLE
Reduce gl light modes

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -134,8 +134,7 @@ ExeptionParam_t ExeptionsParams[EXEPTION_MAX + 1] =
 {
   {NULL},
   {"gld_CreateScreenSizeFBO: Access violation in glFramebufferTexture2DEXT.\n\n"
-    "Are you using ATI graphics? Try to update your drivers "
-    "or change gl_compatibility variable in cfg to 1.\n"},
+    "Are you using ATI graphics? Try to update your drivers\n"},
   {NULL}
 };
 

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -327,7 +327,6 @@ extern float yaw;
 extern float inv_yaw;
 extern float pitch;
 
-extern int gl_compatibility;
 extern int gl_ztrick;
 extern int gl_finish;
 

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -120,7 +120,7 @@ void M_ChangeLightMode(void)
   gld_Calc2DLightLevel = gld_light[gl_lightmode].Get2DLight;
   gld_CalcFogDensity = gld_light[gl_lightmode].GetFog;
 
-  if (gld_light[gl_lightmode].use_hwgamma)
+  if (gl_hardware_gamma)
   {
     gld_SetGammaRamp(useglgamma);
   }

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -104,17 +104,6 @@ gld_CalcFogDensity_f gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
 void M_ChangeLightMode(void)
 {
-  if (gl_compatibility)
-  {
-    if (gl_lightmode_default == gl_lightmode_shaders)
-    {
-      lprintf(LO_INFO,
-        "M_ChangeLightMode: '%s' sector light mode is not allowed in gl_compatibility mode\n",
-        gl_lightmodes[gl_lightmode_default]);
-      gl_lightmode_default = gl_lightmode_glboom;
-    }
-  }
-
   if (gl_lightmode_default == gl_lightmode_shaders)
   {
     if (!glsl_Init())

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -49,7 +49,7 @@
 
 gl_lightmode_t gl_lightmode;
 gl_lightmode_t gl_lightmode_default;
-const char *gl_lightmodes[] = {"glboom", "gzdoom", "fog based", "shaders"};
+const char *gl_lightmodes[] = {"glboom", "shaders"};
 int gl_light_ambient;
 int gl_rellight;
 
@@ -75,21 +75,13 @@ typedef struct
 } GLLight;
 
 static float lighttable_glboom[5][256];
-static float lighttable_gzdoom[256];
-static float lighttable_fogbased[256];
 
 static void gld_InitLightTable_glboom(void);
-static void gld_InitLightTable_gzdoom(void);
-static void gld_InitLightTable_fogbased(void);
 
 static float gld_CalcLightLevel_glboom(int lightlevel);
-static float gld_CalcLightLevel_gzdoom(int lightlevel);
-static float gld_CalcLightLevel_fogbased(int lightlevel);
 static float gld_CalcLightLevel_shaders(int lightlevel);
 
 static float gld_CalcFogDensity_glboom(sector_t *sector, int lightlevel, GLDrawItemType type);
-static float gld_CalcFogDensity_gzdoom(sector_t *sector, int lightlevel, GLDrawItemType type);
-static float gld_CalcFogDensity_fogbased(sector_t *sector, int lightlevel, GLDrawItemType type);
 
 static GLLight gld_light[gl_lightmode_last] = {
   //gl_lightmode_glboom
@@ -97,18 +89,6 @@ static GLLight gld_light[gl_lightmode_last] = {
    gld_InitLightTable_glboom,
    gld_CalcLightLevel_glboom, gld_CalcLightLevel_glboom,
    gld_CalcFogDensity_glboom},
-
-   //gl_lightmode_gzdoom
-  {true, 8,
-   gld_InitLightTable_gzdoom,
-   gld_CalcLightLevel_gzdoom, gld_CalcLightLevel_gzdoom,
-   gld_CalcFogDensity_gzdoom},
-
-   //gl_lightmode_fogbased
-  {true, 8,
-   gld_InitLightTable_fogbased,
-   gld_CalcLightLevel_fogbased, gld_CalcLightLevel_gzdoom,
-   gld_CalcFogDensity_fogbased},
 
    //gl_lightmode_shaders
   {true, 16,
@@ -126,8 +106,7 @@ void M_ChangeLightMode(void)
 {
   if (gl_compatibility)
   {
-    if (gl_lightmode_default == gl_lightmode_fogbased ||
-      gl_lightmode_default == gl_lightmode_shaders)
+    if (gl_lightmode_default == gl_lightmode_shaders)
     {
       lprintf(LO_INFO,
         "M_ChangeLightMode: '%s' sector light mode is not allowed in gl_compatibility mode\n",
@@ -194,64 +173,9 @@ static void gld_InitLightTable_glboom(void)
   }
 }
 
-static void gld_InitLightTable_gzdoom(void)
-{
-  int i;
-  float light;
-
-  for (i = 0; i < 256; i++)
-  {
-    if (i < 192)
-      light = (192.0f - (192 - i) * 1.95f);
-    else
-      light = (float)i;
-
-    if (light < gl_light_ambient)
-      light = (float)gl_light_ambient;
-
-    lighttable_gzdoom[i] = light / 255.0f;
-  }
-
-  lighttable_gzdoom[0] = 0.0f;
-}
-
-static void gld_InitLightTable_fogbased(void)
-{
-  int i;
-  float light;
-
-  for (i = 0; i < 256; i++)
-  {
-    if (i < 192)
-      light = (float)255;
-    else
-      light = (float)i;
-
-    lighttable_fogbased[i] = light / 255.0f;
-  }
-}
-
 static float gld_CalcLightLevel_glboom(int lightlevel)
 {
   return lighttable_glboom[usegamma][BETWEEN(0, 255, lightlevel)];
-}
-
-static float gld_CalcLightLevel_gzdoom(int lightlevel)
-{
-  return lighttable_gzdoom[BETWEEN(0, 255, lightlevel)];
-}
-
-static float gld_CalcLightLevel_fogbased(int lightlevel)
-{
-  if (players[displayplayer].fixedcolormap)
-    return lighttable_gzdoom[BETWEEN(0, 255, lightlevel)];
-  else
-  {
-    if (extralight)
-      return lighttable_fogbased[255];
-    else
-      return lighttable_fogbased[BETWEEN(0, 255, lightlevel)];
-  }
 }
 
 static float gld_CalcLightLevel_shaders(int lightlevel)
@@ -371,48 +295,6 @@ void M_ChangeAllowFog(void)
 static float gld_CalcFogDensity_glboom(sector_t *sector, int lightlevel, GLDrawItemType type)
 {
   return 0;
-}
-
-static float gld_CalcFogDensity_gzdoom(sector_t *sector, int lightlevel, GLDrawItemType type)
-{
-  if ((!gl_use_fog) ||
-    (sector && (sector->ceilingpic == skyflatnum || sector->floorpic == skyflatnum)))
-  {
-    return 0;
-  }
-  else
-  {
-    return distfogtable[1][BETWEEN(0, 255, lightlevel)];
-  }
-}
-
-static float gld_CalcFogDensity_fogbased(sector_t *sector, int lightlevel, GLDrawItemType type)
-{
-  if (players[displayplayer].fixedcolormap)
-  {
-    return 0;
-  }
-  else
-  {
-    float fog = distfogtable[2][BETWEEN(0, 255, lightlevel)];
-
-    if (extralight)
-    {
-      if (extralight == 1)
-        fog -= fog / 3.0f;
-      else
-        fog -= fog / 2.0f;
-    }
-
-    if (type == GLDIT_CEILING || type == GLDIT_FLOOR || type == GLDIT_FWALL)
-    {
-      return fog * 2;
-    }
-    else
-    {
-      return fog;
-    }
-  }
 }
 
 void gld_SetFog(float fogdensity)

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1228,9 +1228,7 @@ void gld_StartDrawScene(void)
   gl_spriteindex = 0;
 
   //e6y: fog in frame
-  gl_use_fog = !gl_compatibility &&
-    (gl_fog || gl_lightmode == gl_lightmode_fogbased) &&
-    !frame_fixedcolormap && !boom_cm;
+  gl_use_fog = !gl_compatibility && gl_fog && !frame_fixedcolormap && !boom_cm;
 
 //e6y
   mlook_or_fov = dsda_MouseLook() || (render_fov != FOV90);
@@ -1693,9 +1691,7 @@ void gld_AddWall(seg_t *seg)
     rellight = seg->linedef->dx == 0 ? +gl_rellight : seg->linedef->dy==0 ? -gl_rellight : 0;
   }
   wall.light=gld_CalcLightLevel(frontsector->lightlevel+rellight+(extralight<<5));
-  wall.fogdensity = gld_CalcFogDensity(frontsector,
-    frontsector->lightlevel + (gl_lightmode == gl_lightmode_fogbased ? rellight : 0),
-    GLDIT_WALL);
+  wall.fogdensity = gld_CalcFogDensity(frontsector, frontsector->lightlevel, GLDIT_WALL);
   wall.alpha=1.0f;
   wall.gltexture=NULL;
   wall.seg = seg; //e6y

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -75,9 +75,6 @@
 #include "dsda/map_format.h"
 #include "dsda/settings.h"
 
-// All OpenGL extentions will be disabled in gl_compatibility mode
-int gl_compatibility = 0;
-
 int gl_clear;
 
 int gl_preprocessed = false;
@@ -382,7 +379,7 @@ void gld_Init(int width, int height)
     }
   }
 
-  gld_InitOpenGL(gl_compatibility);
+  gld_InitOpenGL();
   gld_InitPalettedTextures();
   gld_InitTextureParams();
 
@@ -1228,7 +1225,7 @@ void gld_StartDrawScene(void)
   gl_spriteindex = 0;
 
   //e6y: fog in frame
-  gl_use_fog = !gl_compatibility && gl_fog && !frame_fixedcolormap && !boom_cm;
+  gl_use_fog = gl_fog && !frame_fixedcolormap && !boom_cm;
 
 //e6y
   mlook_or_fov = dsda_MouseLook() || (render_fov != FOV90);

--- a/prboom2/src/gl_opengl.c
+++ b/prboom2/src/gl_opengl.c
@@ -47,8 +47,6 @@
 
 int gl_version;
 
-static dboolean gl_compatibility_mode;
-
 int GLEXT_CLAMP_TO_EDGE = GL_CLAMP;
 int gl_max_texture_size = 0;
 
@@ -176,12 +174,10 @@ void gld_InitOpenGLVersion(void)
   }
 }
 
-void gld_InitOpenGL(dboolean compatibility_mode)
+void gld_InitOpenGL(void)
 {
   GLenum texture;
   const char *extensions = (const char*)glGetString(GL_EXTENSIONS);
-
-  gl_compatibility_mode = compatibility_mode;
 
   gld_InitOpenGLVersion();
 
@@ -430,7 +426,7 @@ void gld_InitOpenGL(dboolean compatibility_mode)
     gl_ext_blend_color = false;
   }
 
-  if ((compatibility_mode) || (gl_version <= OPENGL_VERSION_1_1))
+  if (gl_version <= OPENGL_VERSION_1_1)
   {
     lprintf(LO_INFO, "gld_InitOpenGL: Compatibility mode is used.\n");
     gl_arb_texture_non_power_of_two = false;
@@ -592,11 +588,6 @@ void gld_EnableMultisample(int enable)
 
 void SetTextureMode(tex_mode_e type)
 {
-  if (gl_compatibility_mode)
-  {
-    type = TM_MODULATE;
-  }
-
   if (type == TM_MASK)
   {
     glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_COMBINE);

--- a/prboom2/src/gl_opengl.h
+++ b/prboom2/src/gl_opengl.h
@@ -166,7 +166,7 @@ extern PFNGLGETACTIVEUNIFORMARBPROC         GLEXT_glGetActiveUniformARB;
 extern PFNGLGETUNIFORMFVARBPROC             GLEXT_glGetUniformfvARB;
 #endif
 
-void gld_InitOpenGL(dboolean compatibility_mode);
+void gld_InitOpenGL(void);
 
 //states
 void gld_EnableTexture2D(GLenum texture, int enable);

--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -123,10 +123,7 @@ void gld_DrawFakeSkyStrips(void)
   // I need to render fake strips of sky before dome with using
   // full clearing of color buffer (only in compatibility mode)
 
-  if (!gl_compatibility)
-  {
-    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // no graphics
-  }
+  glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // no graphics
   gld_EnableTexture2D(GL_TEXTURE0_ARB, false);
 
   for (i = gld_drawinfo.num_items[GLDIT_SWALL] - 1; i >= 0; i--)
@@ -142,14 +139,7 @@ void gld_DrawFakeSkyStrips(void)
   }
 
   gld_EnableTexture2D(GL_TEXTURE0_ARB, true);
-  if (!gl_compatibility)
-  {
-    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-  }
-  else
-  {
-    glClear(GL_COLOR_BUFFER_BIT);
-  }
+  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 }
 
 void gld_GetScreenSkyScale(GLWall *wall, float *scale_x, float *scale_y)
@@ -460,10 +450,7 @@ void gld_DrawScreenSkybox(void)
     int i, k;
     float w;
 
-    if (!gl_compatibility)
-    {
-      glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // no graphics
-    }
+    glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // no graphics
     gld_EnableTexture2D(GL_TEXTURE0_ARB, false);
 
     for (i = gld_drawinfo.num_items[GLDIT_SWALL] - 1; i >= 0; i--)
@@ -479,14 +466,7 @@ void gld_DrawScreenSkybox(void)
     }
 
     gld_EnableTexture2D(GL_TEXTURE0_ARB, true);
-    if (!gl_compatibility)
-    {
-      glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-    }
-    else
-    {
-      glClear(GL_COLOR_BUFFER_BIT);
-    }
+    glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
     if (!mlook_or_fov)
     {

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -63,8 +63,6 @@ typedef enum {
 typedef enum
 {
   gl_lightmode_glboom,
-  gl_lightmode_gzdoom,
-  gl_lightmode_fogbased,
   gl_lightmode_shaders,
 
   gl_lightmode_last

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1138,7 +1138,7 @@ default_t defaults[] =
    def_str,ss_none},
   {"gl_motionblur_att_c", {NULL,&motion_blur.str_att_c}, {0,"0.9"},UL,UL,
    def_str,ss_none},
-  {"gl_lightmode",{(int*)&gl_lightmode_default},{gl_lightmode_glboom},
+  {"gl_lightmode",{(int*)&gl_lightmode_default},{gl_lightmode_shaders},
    gl_lightmode_glboom, gl_lightmode_last-1, def_int,ss_none},
   {"gl_light_ambient", {&gl_light_ambient},  {20},1,255,
    def_int,ss_stat},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -182,9 +182,6 @@ extern int gl_sky_detail;
 extern int gl_use_paletted_texture;
 extern int gl_use_shared_texture_palette;
 
-//e6y: all OpenGL extentions will be disabled with TRUE
-extern int gl_compatibility;
-
 //cfg values
 extern int gl_ext_texture_filter_anisotropic_default;
 extern int gl_arb_texture_non_power_of_two_default;
@@ -221,7 +218,6 @@ static const char *gl_tex_format_string;
 static int gl_sky_detail;
 static int gl_use_paletted_texture;
 static int gl_use_shared_texture_palette;
-static int gl_compatibility;
 static int gl_ext_texture_filter_anisotropic_default;
 static int gl_arb_texture_non_power_of_two_default;
 static int gl_arb_multitexture_default;
@@ -418,9 +414,6 @@ default_t defaults[] =
    RDRAW_MASKEDCOLUMNEDGE_SQUARE, RDRAW_MASKEDCOLUMNEDGE_SLOPED, def_int,ss_none},
 
   {"OpenGL settings",{NULL},{0},UL,UL,def_none,ss_none},
-  {"gl_compatibility", {&gl_compatibility},  {0},0,1,
-   def_bool,ss_stat},
-
   {"gl_arb_multitexture", {&gl_arb_multitexture_default}, {1},0,1,
    def_bool,ss_stat},
   {"gl_arb_texture_compression", {&gl_arb_texture_compression_default}, {1},0,1,


### PR DESCRIPTION
Reduces gl light modes to shaders, which is the new default, and glboom, which serves as a fallback. Also removes an old gl compatibility mode along the way.