### PR TITLE
Completely initialize blocklinks in P_UnArchiveBlockLinks

### DIFF
--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -620,6 +620,22 @@ void P_UnArchiveBlockLinks(mobj_t** mobj_p, int mobj_count)
     memcpy(&count, save_p, sizeof(count));
     save_p += sizeof(count);
 
+    // Initialize 'blocklinks[i]' to empty value.
+    //
+    // We are restoring whole blocklist snapshot, so there is no need to keep
+    // any original data.
+    //
+    // There is even problem with original data - 'P_TrueUnArchiveThinkers'
+    // calls 'P_SetThingPosition', which setups some 'blocklinks'.
+    //
+    // When 'mobj' moves after storing in 'blocklist' (e.g. in case of friction
+    // 'P_Move' can update coordinates after calling 'P_TryMove') it leads to
+    // situation when 'mobj' is stored in two 'blocklinks'.
+    //
+    // This can further lead to infinite loops, when 'mobj' moves between this
+    // two 'blocklinks' ('bnext' forms loop).
+    blocklinks[i] = NULL;
+
     bprev = &blocklinks[i];
     for (j = 0; j < count; ++j)
     {

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -620,22 +620,7 @@ void P_UnArchiveBlockLinks(mobj_t** mobj_p, int mobj_count)
     memcpy(&count, save_p, sizeof(count));
     save_p += sizeof(count);
 
-    // Initialize 'blocklinks[i]' to empty value.
-    //
-    // We are restoring whole blocklist snapshot, so there is no need to keep
-    // any original data.
-    //
-    // There is even problem with original data - 'P_TrueUnArchiveThinkers'
-    // calls 'P_SetThingPosition', which setups some 'blocklinks'.
-    //
-    // When 'mobj' moves after storing in 'blocklist' (e.g. in case of friction
-    // 'P_Move' can update coordinates after calling 'P_TryMove') it leads to
-    // situation when 'mobj' is stored in two 'blocklinks'.
-    //
-    // This can further lead to infinite loops, when 'mobj' moves between this
-    // two 'blocklinks' ('bnext' forms loop).
     blocklinks[i] = NULL;
-
     bprev = &blocklinks[i];
     for (j = 0; j < count; ++j)
     {


### PR DESCRIPTION
When loading save game / restoring keyframe on maps with lot's of
monsters and friction floor, it can happen that Doom is blocked on
indefinite loop.

Problem is loop in 'blocklinks' linked list. It is cased by fact, that
'blocklinks' is initialized 2 times (in 'P_SetThingPosition' and in
'P_TrueUnArchiveThinkers', both called from 'P_TrueUnArchiveThinkers')
and these two sources can be unsynchronized (in case of friction floors,
'P_Move' updates coordinates "after" calling 'P_TryMove', so it is
possible that coordinates does not correspond to position in
'blocklist').