### PR TITLE
Update math for mouse stutter correction

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1463,7 +1463,7 @@ static void CorrectMouseStutter(int *x, int *y)
   *x += x_remainder_old;
   *y += y_remainder_old;
 
-  correction_factor = FixedDiv(fractic, fractic + FRACUNIT / 2);
+  correction_factor = FixedDiv(fractic, fractic + 1000000 / TICRATE);
 
   x_remainder = FixedMul(*x, correction_factor);
   *x -= x_remainder;


### PR DESCRIPTION
FRACUNIT / 2 should instead be 1000000 / GAMETIC, i.e. the number of microseconds per gametic. The math error probably isn't noticeable, but it's nice when code matches intention. :smile: 