### PR TITLE
Cleanup DSDA Time's MSVC compatibility layer

### DIFF
--- a/prboom2/src/dsda/time.c
+++ b/prboom2/src/dsda/time.c
@@ -15,58 +15,37 @@
 //	DSDA Time
 //
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <time.h>
+#endif
 
 #include "i_system.h"
 
 #include "time.h"
 
-// [XA] MSVC hack: need to implement a handful of functions here.
-// this was yoinked from https://stackoverflow.com/a/31335254 so
-// no guarantees on if this stuff is accurate/kosher/whatever,
-// so maybe don't cut an official release with MSVC just yet.
-// it's enough to hack it into compiling for me, at least. ;)
+// lovey: Win32 interface
+#ifdef _WIN32
 
-#ifdef _MSC_VER
+static unsigned long long dsda_time[DSDA_TIMER_COUNT];
 
-#include <windows.h>
-
-#define CLOCK_MONOTONIC -1
-#define exp7           10000000i64 //1E+7
-#define exp9         1000000000i64 //1E+9
-#define w2ux 116444736000000000i64 //1.jan1601 to 1.jan1970
-
-void unix_time(struct timespec *spec) {
-  __int64 wintime; GetSystemTimeAsFileTime((FILETIME*)&wintime);
-  wintime -= w2ux;  spec->tv_sec = wintime / exp7;
-  spec->tv_nsec = wintime % exp7 * 100;
+void dsda_StartTimer(int timer) {
+  QueryPerformanceCounter((LARGE_INTEGER*)&dsda_time[timer]);
 }
 
-int clock_gettime(int _skip, struct timespec *spec)
-{
-  static struct timespec startspec;
-  static double ticks2nano;
-  static __int64 startticks, tps = 0;
-  __int64 tmp, curticks;
+unsigned long long dsda_ElapsedTime(int timer) {
+  static unsigned long long freq = 0;
+  unsigned long long now;
 
-  QueryPerformanceFrequency((LARGE_INTEGER*)&tmp);
+  if (!freq) QueryPerformanceFrequency((LARGE_INTEGER*)&freq);
 
-  if (tps != tmp) {
-    tps = tmp;
-    QueryPerformanceCounter((LARGE_INTEGER*)&startticks);
-    unix_time(&startspec); ticks2nano = (double)exp9 / tps;
-  }
-
-  QueryPerformanceCounter((LARGE_INTEGER*)&curticks); curticks -= startticks;
-  spec->tv_sec = startspec.tv_sec + (curticks / tps);
-  spec->tv_nsec = startspec.tv_nsec + (double)(curticks % tps) * ticks2nano;
-  if (!(spec->tv_nsec < exp9)) { spec->tv_sec++; spec->tv_nsec -= exp9; }
-  return 0;
+  QueryPerformanceCounter((LARGE_INTEGER*)&now);
+  return (now-dsda_time[timer])*1000000ll/freq;
 }
 
-#endif //_MSC_VER
-
-// [XA] END HACK
+// lovey: POSIX interface
+#else //_WIN32
 
 static struct timespec dsda_time[DSDA_TIMER_COUNT];
 
@@ -82,6 +61,8 @@ unsigned long long dsda_ElapsedTime(int timer) {
   return (now.tv_nsec - dsda_time[timer].tv_nsec) / 1000 +
          (now.tv_sec - dsda_time[timer].tv_sec) * 1000000;
 }
+
+#endif //_WIN32
 
 unsigned long long dsda_ElapsedTimeMS(int timer) {
   return dsda_ElapsedTime(timer) / 1000;


### PR DESCRIPTION
Compiled & tested in MSVC x86, MSVC x64, MinGW x64, GCC x64 and Clang x64

This pull request removes the MSVC hack in prboom2/src/dsda/time.c and adds a cleaner win32 interface to replace it.

It's not a huge pull request, just something I've wanted to do for a while now.