### PR TITLE
Software: Allow taking screenshots at game scene resolution

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -124,7 +124,7 @@ int render_screen_multiply;
 int integer_scaling;
 int vanilla_keymap;
 SDL_Surface *screen;
-static SDL_Surface *buffer;
+SDL_Surface *sdl_buffer;
 SDL_Window *sdl_window;
 SDL_Renderer *sdl_renderer;
 static SDL_Texture *sdl_texture;
@@ -599,10 +599,10 @@ void I_FinishUpdate (void)
 
   // Blit from the paletted 8-bit screen buffer to the intermediate
   // 32-bit RGBA buffer that we can load into the texture.
-  SDL_LowerBlit(screen, &src_rect, buffer, &src_rect);
+  SDL_LowerBlit(screen, &src_rect, sdl_buffer, &src_rect);
 
   // Update the intermediate texture with the contents of the RGBA buffer.
-  SDL_UpdateTexture(sdl_texture, &src_rect, buffer->pixels, buffer->pitch);
+  SDL_UpdateTexture(sdl_texture, &src_rect, sdl_buffer->pixels, sdl_buffer->pitch);
 
   // Make sure the pillarboxes are kept clear each frame.
   SDL_RenderClear(sdl_renderer);
@@ -631,7 +631,7 @@ static void I_ShutdownSDL(void)
 {
   if (sdl_glcontext) SDL_GL_DeleteContext(sdl_glcontext);
   if (screen) SDL_FreeSurface(screen);
-  if (buffer) SDL_FreeSurface(buffer);
+  if (sdl_buffer) SDL_FreeSurface(sdl_buffer);
   if (sdl_texture) SDL_DestroyTexture(sdl_texture);
   if (sdl_renderer) SDL_DestroyRenderer(sdl_renderer);
   if (sdl_window) SDL_DestroyWindow(sdl_window);
@@ -1197,7 +1197,7 @@ void I_UpdateVideoMode(void)
 
     if (sdl_glcontext) SDL_GL_DeleteContext(sdl_glcontext);
     if (screen) SDL_FreeSurface(screen);
-    if (buffer) SDL_FreeSurface(buffer);
+    if (sdl_buffer) SDL_FreeSurface(sdl_buffer);
     if (sdl_texture) SDL_DestroyTexture(sdl_texture);
     if (sdl_renderer) SDL_DestroyRenderer(sdl_renderer);
     SDL_DestroyWindow(sdl_window);
@@ -1206,7 +1206,7 @@ void I_UpdateVideoMode(void)
     sdl_window = NULL;
     sdl_glcontext = NULL;
     screen = NULL;
-    buffer = NULL;
+    sdl_buffer = NULL;
     sdl_texture = NULL;
   }
 
@@ -1308,10 +1308,10 @@ void I_UpdateVideoMode(void)
     SDL_RenderSetIntegerScale(sdl_renderer, integer_scaling);
 
     screen = SDL_CreateRGBSurface(0, SCREENWIDTH, SCREENHEIGHT, 8, 0, 0, 0, 0);
-    buffer = SDL_CreateRGBSurface(0, SCREENWIDTH, SCREENHEIGHT, 32, 0, 0, 0, 0);
-    SDL_FillRect(buffer, NULL, 0);
+    sdl_buffer = SDL_CreateRGBSurface(0, SCREENWIDTH, SCREENHEIGHT, 32, 0, 0, 0, 0);
+    SDL_FillRect(sdl_buffer, NULL, 0);
 
-    sdl_texture = SDL_CreateTextureFromSurface(sdl_renderer, buffer);
+    sdl_texture = SDL_CreateTextureFromSurface(sdl_renderer, sdl_buffer);
 
     if(screen == NULL) {
       I_Error("Couldn't set %dx%d video mode [%s]", SCREENWIDTH, SCREENHEIGHT, SDL_GetError());

--- a/prboom2/src/i_video.h
+++ b/prboom2/src/i_video.h
@@ -50,12 +50,19 @@
 #pragma interface
 #endif
 
+enum software_sshot_resolution_type_e {
+  SSHOT_RES_WINDOW,
+  SSHOT_RES_GAME
+};
+
 extern int render_vsync;
 extern int render_screen_multiply;
 extern int integer_scaling;
+extern enum software_sshot_resolution_type_e software_sshot_type;
 
 extern SDL_Window *sdl_window;
 extern SDL_Renderer *sdl_renderer;
+extern SDL_Surface *sdl_buffer;
 
 extern const char *screen_resolutions_list[];
 extern const char *screen_resolution;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3246,6 +3246,7 @@ static const char *death_use_strings[] = { "default", "nothing", "reload", NULL 
 
 static const char *renderfilters[] = { "none", "point", "linear", "rounded" };
 static const char *edgetypes[] = { "jagged", "sloped" };
+static const char *software_sshot_types[] = { "window", "game" };
 
 static const char *gltexfilters[] = {
   "None",
@@ -3368,6 +3369,7 @@ setup_menu_t display_settings[] = {
   { "Software Options", S_SKIP | S_TITLE, m_null, G_X, G_Y + 15 * 8 },
   { "Screen Multiple Factor (1-None)", S_NUM, m_null, G_X, G_Y + 16 * 8, { "render_screen_multiply" }, 0, M_ChangeScreenMultipleFactor },
   { "Integer Screen Scaling", S_YESNO, m_null, G_X, G_Y + 17 * 8, { "integer_scaling" }, 0, M_ChangeScreenMultipleFactor },
+  { "Screenshot Resolution", S_CHOICE, m_null, G_X, G_Y + 18 * 8, { "software_sshot_type" }, 0, NULL, software_sshot_types },
 
   { "<-", S_SKIP | S_PREV, m_null, KB_PREV, KB_Y + 20 * 8, { misc_settings } },
   { "->", S_SKIP | S_NEXT, m_null, KB_NEXT, KB_Y + 20 * 8, { opengl_settings1 } },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -1110,6 +1110,8 @@ default_t defaults[] =
    def_int,ss_stat},
   {"integer_scaling", {&integer_scaling},  {0},0,1,
    def_bool,ss_stat},
+  {"software_sshot_type", {&software_sshot_type},  {0},0,1,
+    def_int,ss_stat},
   {"render_aspect", {&render_aspect},  {0},0,4,
    def_int,ss_stat},
   {"render_doom_lightmaps", {&render_doom_lightmaps},  {0},0,1,


### PR DESCRIPTION
Added a menu option for taking screenshots at the game's rendered resolution. By default this option uses the pre-existing behaviour of taking the screenshot at the full resolution of the window.