### PR TITLE
off64_t is not defined on macOS

### DIFF
--- a/prboom2/src/MUSIC/dumbplayer.c
+++ b/prboom2/src/MUSIC/dumbplayer.c
@@ -68,9 +68,11 @@ const music_player_t db_player =
 #if !defined(_FILE_OFFSET_BITS) || (_FILE_OFFSET_BITS < 64)
 #ifdef _MSC_VER
 #define DUMB_OFF_T_CUSTOM __int64
-#else /* !_MSC_VER */
+#elif defined(__APPLE__)
+#define DUMB_OFF_T_CUSTOM off_t
+#else
 #define DUMB_OFF_T_CUSTOM off64_t
-#endif /* _MSC_VER */
+#endif
 #endif
 
 #include <dumb.h>


### PR DESCRIPTION
Instead, we should use off_t.
I don't understand why it this only happens when using a newer version of Dumb (It compiled fine using Dumb 0.9.3)