### PR TITLE
Z_FreeTag: always free memory from the given tag up to PU_MAX

### DIFF
--- a/prboom2/src/z_zone.c
+++ b/prboom2/src/z_zone.c
@@ -60,15 +60,8 @@
 #include <dpmi.h>
 #endif
 
-// Tunables
-
 // signature for block header
 #define ZONEID  0x931d4a11
-
-// Number of mallocs & frees kept in history buffer (must be a power of 2)
-#define ZONE_HISTORY 4
-
-// End Tunables
 
 typedef struct memblock {
   unsigned id;
@@ -163,24 +156,23 @@ void Z_FreeTag(int tag)
 {
   memblock_t *block, *end_block;
 
-#ifdef HEAPDUMP
-  Z_DumpMemory();
-#endif
-
   if (tag < 0 || tag >= PU_MAX)
     I_Error("Z_FreeTag: Tag %i does not exist", tag);
 
-  block = blockbytag[tag];
-  if (!block)
-    return;
-  end_block = block->prev;
-  while (1)
+  for (; tag < PU_MAX; tag++)
   {
-    memblock_t *next = block->next;
-    Z_Free((char *) block + HEADER_SIZE);
-    if (block == end_block)
-      break;
-    block = next;               // Advance to next block
+    block = blockbytag[tag];
+    if (!block)
+      continue;
+    end_block = block->prev;
+    while (1)
+    {
+      memblock_t *next = block->next;
+      Z_Free((char *) block + HEADER_SIZE);
+      if (block == end_block)
+        break;
+      block = next;               // Advance to next block
+    }
   }
 }
 


### PR DESCRIPTION
Also, some minor unrelated clean-up.