### PR TITLE
Cleanup zone interface

### DIFF
--- a/prboom2/src/MUSIC/flplayer.c
+++ b/prboom2/src/MUSIC/flplayer.c
@@ -112,7 +112,7 @@ static void *fl_sfopen(const char *lumpname)
   MEMFILE *instream;
   int lumpnum = W_GetNumForName(lumpname);
   int len = W_LumpLength(lumpnum);
-  const void *data = W_CacheLumpNum(lumpnum);
+  const void *data = W_LumpByNum(lumpnum);
 
   instream = mem_fopen_read(data, len);
 

--- a/prboom2/src/MUSIC/oplplayer.c
+++ b/prboom2/src/MUSIC/oplplayer.c
@@ -346,8 +346,6 @@ static dboolean LoadInstrumentTable(void)
 
     if (strncmp((const char *) lump, GENMIDI_HEADER, strlen(GENMIDI_HEADER)) != 0)
     {
-        W_UnlockLumpName("GENMIDI");
-
         return false;
     }
 
@@ -1389,10 +1387,6 @@ static void I_OPL_ShutdownMusic(void)
         I_OPL_StopSong();
 
         OPL_Shutdown();
-
-        // Release GENMIDI lump
-
-        W_UnlockLumpName("GENMIDI");
 
         music_initialized = false;
     }

--- a/prboom2/src/MUSIC/oplplayer.c
+++ b/prboom2/src/MUSIC/oplplayer.c
@@ -340,7 +340,7 @@ static dboolean LoadInstrumentTable(void)
 {
     const byte *lump;
 
-    lump = (const byte*)W_CacheLumpName("GENMIDI");
+    lump = (const byte*)W_LumpByName("GENMIDI");
 
     // Check header
 

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -519,8 +519,6 @@ static void I_UploadNewPalette(int pal, int force)
       palette += 3;
     }
 
-    W_UnlockLumpNum(pplump);
-    W_UnlockLumpNum(gtlump);
     num_pals /= 256;
   }
 

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -499,8 +499,8 @@ static void I_UploadNewPalette(int pal, int force)
 
     pplump = W_GetNumForName(playpal_data->lump_name);
     gtlump = (W_CheckNumForName)("GAMMATBL", ns_prboom);
-    palette = (const byte*) W_CacheLumpNum(pplump);
-    gtable = (const byte*) W_CacheLumpNum(gtlump) + 256 * (cachedgamma = usegamma);
+    palette = (const byte*) W_LumpByNum(pplump);
+    gtable = (const byte*) W_LumpByNum(gtlump) + 256 * (cachedgamma = usegamma);
 
     num_pals = W_LumpLength(pplump) / (3 * 256);
     num_pals *= 256;

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1752,9 +1752,7 @@ void ProcessDehFile(const char *filename, const char *outfilename, int lumpnum)
     filepos = dehftell(filein);
   }
 
-  if (infile.lump)
-    W_UnlockLumpNum(lumpnum);                 // Mark purgable
-  else
+  if (!infile.lump)
     fclose(infile.f);                         // Close real file
 
   if (outfilename)   // killough 10/98: only at top recursion level

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1662,7 +1662,7 @@ void ProcessDehFile(const char *filename, const char *outfilename, int lumpnum)
   else  // DEH file comes from lump indicated by third argument
   {
     infile.size = W_LumpLength(lumpnum);
-    infile.inp = infile.lump = W_CacheLumpNum(lumpnum);
+    infile.inp = infile.lump = W_LumpByNum(lumpnum);
     // [FG] skip empty DEHACKED lumps
     if (!infile.inp)
     {

--- a/prboom2/src/dsda/compatibility.c
+++ b/prboom2/src/dsda/compatibility.c
@@ -283,7 +283,7 @@ static const dsda_compatibility_t** level_compatibilities[16] = {
 
 static void dsda_MD5UpdateLump(int lump, struct MD5Context *md5)
 {
-  MD5Update(md5, W_CacheLumpNum(lump), W_LumpLength(lump));
+  MD5Update(md5, W_LumpByNum(lump), W_LumpLength(lump));
 }
 
 static void dsda_GetLevelCheckSum(int lump, byte cksum[16])

--- a/prboom2/src/dsda/compatibility.c
+++ b/prboom2/src/dsda/compatibility.c
@@ -284,7 +284,6 @@ static const dsda_compatibility_t** level_compatibilities[16] = {
 static void dsda_MD5UpdateLump(int lump, struct MD5Context *md5)
 {
   MD5Update(md5, W_CacheLumpNum(lump), W_LumpLength(lump));
-  W_UnlockLumpNum(lump);
 }
 
 static void dsda_GetLevelCheckSum(int lump, byte cksum[16])

--- a/prboom2/src/dsda/ghost.c
+++ b/prboom2/src/dsda/ghost.c
@@ -220,7 +220,7 @@ void dsda_SpawnGhost(void) {
       continue;
     }
 
-    mobj = Z_Malloc(sizeof(*mobj), PU_LEVEL, NULL);
+    mobj = Z_Malloc(sizeof(*mobj), PU_LEVEL);
     memset(mobj, 0, sizeof(*mobj));
     mobj->type = MT_NULL;
     mobj->info = &dsda_ghost_info;
@@ -272,7 +272,7 @@ void dsda_SpawnGhost(void) {
   }
 
   if (dsda_ghost_import.count > 0) {
-    dsda_ghost_import.thinker = Z_Malloc(sizeof(thinker_t), PU_LEVEL, NULL);
+    dsda_ghost_import.thinker = Z_Malloc(sizeof(thinker_t), PU_LEVEL);
     memset(dsda_ghost_import.thinker, 0, sizeof(thinker_t));
     dsda_ghost_import.thinker->function = dsda_UpdateGhosts;
     P_AddThinker(dsda_ghost_import.thinker);

--- a/prboom2/src/dsda/ghost.c
+++ b/prboom2/src/dsda/ghost.c
@@ -220,7 +220,7 @@ void dsda_SpawnGhost(void) {
       continue;
     }
 
-    mobj = Z_Malloc(sizeof(*mobj), PU_LEVEL);
+    mobj = Z_MallocTag(sizeof(*mobj), PU_LEVEL);
     memset(mobj, 0, sizeof(*mobj));
     mobj->type = MT_NULL;
     mobj->info = &dsda_ghost_info;
@@ -272,7 +272,7 @@ void dsda_SpawnGhost(void) {
   }
 
   if (dsda_ghost_import.count > 0) {
-    dsda_ghost_import.thinker = Z_Malloc(sizeof(thinker_t), PU_LEVEL);
+    dsda_ghost_import.thinker = Z_MallocTag(sizeof(thinker_t), PU_LEVEL);
     memset(dsda_ghost_import.thinker, 0, sizeof(thinker_t));
     dsda_ghost_import.thinker->function = dsda_UpdateGhosts;
     P_AddThinker(dsda_ghost_import.thinker);

--- a/prboom2/src/dsda/ghost.c
+++ b/prboom2/src/dsda/ghost.c
@@ -220,7 +220,7 @@ void dsda_SpawnGhost(void) {
       continue;
     }
 
-    mobj = Z_MallocTag(sizeof(*mobj), PU_LEVEL);
+    mobj = Z_MallocLevel(sizeof(*mobj));
     memset(mobj, 0, sizeof(*mobj));
     mobj->type = MT_NULL;
     mobj->info = &dsda_ghost_info;
@@ -272,7 +272,7 @@ void dsda_SpawnGhost(void) {
   }
 
   if (dsda_ghost_import.count > 0) {
-    dsda_ghost_import.thinker = Z_MallocTag(sizeof(thinker_t), PU_LEVEL);
+    dsda_ghost_import.thinker = Z_MallocLevel(sizeof(*mobj));
     memset(dsda_ghost_import.thinker, 0, sizeof(thinker_t));
     dsda_ghost_import.thinker->function = dsda_UpdateGhosts;
     P_AddThinker(dsda_ghost_import.thinker);

--- a/prboom2/src/dsda/mapinfo/hexen.c
+++ b/prboom2/src/dsda/mapinfo/hexen.c
@@ -488,7 +488,7 @@ int dsda_HexenApplyFadeTable(void) {
 
   fade_lump = CurrentMap->fadetable;
 
-  colormaps[0] = (const lighttable_t *) W_CacheLumpNum(fade_lump);
+  colormaps[0] = (const lighttable_t *) W_LumpByNum(fade_lump);
 
   if (fade_lump == W_GetNumForName("COLORMAP"))
     LevelUseFullBright = true;

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -469,7 +469,7 @@ void dsda_ULoadMapInfo(void) {
 
   p = -1;
   while ((p = W_ListNumFromName("UMAPINFO", p)) >= 0) {
-    const unsigned char * lump = (const unsigned char *) W_CacheLumpNum(p);
+    const unsigned char * lump = (const unsigned char *) W_LumpByNum(p);
     ParseUMapInfo(lump, W_LumpLength(p), I_Error);
   }
 }

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -230,7 +230,7 @@ static const dsda_options_t* dsda_LumpOptions(int lumpnum) {
   dsda_option_t* option;
 
   lump.length = W_LumpLength(lumpnum);
-  lump.data = W_CacheLumpNum(lumpnum);
+  lump.data = W_LumpByNum(lumpnum);
 
   while (dsda_ReadOption(buf, OPTIONS_LINE_LENGTH, &lump)) {
     if (buf[0] == '#')

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -253,8 +253,6 @@ static const dsda_options_t* dsda_LumpOptions(int lumpnum) {
     }
   }
 
-  W_UnlockLumpNum(lumpnum);
-
   return &mbf_options;
 }
 

--- a/prboom2/src/dsda/palette.c
+++ b/prboom2/src/dsda/palette.c
@@ -93,7 +93,7 @@ void dsda_InitPlayPal(void) {
       if (lump < 0)
         continue;
 
-      playpal = W_CacheLumpNum(lump);
+      playpal = W_LumpByNum(lump);
 
       // find two duplicate palette entries. use one for transparency.
       // rewrite source pixels in patches to the other on composition.

--- a/prboom2/src/dsda/palette.c
+++ b/prboom2/src/dsda/palette.c
@@ -122,8 +122,6 @@ void dsda_InitPlayPal(void) {
         playpal_data[playpal_i].transparent = 255;
         playpal_data[playpal_i].duplicate   = -1;
       }
-
-      W_UnlockLumpNum(lump);
     }
   }
 }

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -109,7 +109,7 @@ static int dsda_WadCompatibilityLevel(void) {
       const char* data;
 
       length = W_LumpLength(num);
-      data = W_CacheLumpNum(num);
+      data = W_LumpByNum(num);
 
       if (length == 7 && !strncasecmp("vanilla", data, 7)) {
         if (gamemode == commercial) {

--- a/prboom2/src/dsda/thing_id.c
+++ b/prboom2/src/dsda/thing_id.c
@@ -27,7 +27,7 @@ static thing_id_list_t* thing_id_list_hash[THING_ID_HASH_MAX];
 static thing_id_list_t* dsda_NewThingIDList(short thing_id) {
   thing_id_list_t* result;
 
-  result = Z_CallocTag(1, sizeof(*result), PU_LEVEL);
+  result = Z_CallocLevel(1, sizeof(*result));
   result->thing_id = thing_id;
   return result;
 }
@@ -58,7 +58,7 @@ static thing_id_list_t* dsda_ThingIDList(short thing_id) {
 static thing_id_list_entry_t* dsda_NewThingIDListEntry(mobj_t* mo) {
   thing_id_list_entry_t* result;
 
-  result = Z_CallocTag(1, sizeof(*result), PU_LEVEL);
+  result = Z_CallocLevel(1, sizeof(*result));
   P_SetTarget(&result->mo, mo);
   return result;
 }
@@ -111,7 +111,7 @@ void dsda_RemoveMobjThingID(mobj_t* mo) {
   mo->tid = 0;
 }
 
-// The allocated memory is automatically removed (PU_LEVEL scope)
+// The allocated memory is automatically removed (zone memory)
 void dsda_WipeMobjThingIDList(void) {
   int i;
 

--- a/prboom2/src/dsda/thing_id.c
+++ b/prboom2/src/dsda/thing_id.c
@@ -27,7 +27,7 @@ static thing_id_list_t* thing_id_list_hash[THING_ID_HASH_MAX];
 static thing_id_list_t* dsda_NewThingIDList(short thing_id) {
   thing_id_list_t* result;
 
-  result = Z_Calloc(1, sizeof(*result), PU_LEVEL, NULL);
+  result = Z_Calloc(1, sizeof(*result), PU_LEVEL);
   result->thing_id = thing_id;
   return result;
 }
@@ -58,7 +58,7 @@ static thing_id_list_t* dsda_ThingIDList(short thing_id) {
 static thing_id_list_entry_t* dsda_NewThingIDListEntry(mobj_t* mo) {
   thing_id_list_entry_t* result;
 
-  result = Z_Calloc(1, sizeof(*result), PU_LEVEL, NULL);
+  result = Z_Calloc(1, sizeof(*result), PU_LEVEL);
   P_SetTarget(&result->mo, mo);
   return result;
 }

--- a/prboom2/src/dsda/thing_id.c
+++ b/prboom2/src/dsda/thing_id.c
@@ -27,7 +27,7 @@ static thing_id_list_t* thing_id_list_hash[THING_ID_HASH_MAX];
 static thing_id_list_t* dsda_NewThingIDList(short thing_id) {
   thing_id_list_t* result;
 
-  result = Z_Calloc(1, sizeof(*result), PU_LEVEL);
+  result = Z_CallocTag(1, sizeof(*result), PU_LEVEL);
   result->thing_id = thing_id;
   return result;
 }
@@ -58,7 +58,7 @@ static thing_id_list_t* dsda_ThingIDList(short thing_id) {
 static thing_id_list_entry_t* dsda_NewThingIDListEntry(mobj_t* mo) {
   thing_id_list_entry_t* result;
 
-  result = Z_Calloc(1, sizeof(*result), PU_LEVEL);
+  result = Z_CallocTag(1, sizeof(*result), PU_LEVEL);
   P_SetTarget(&result->mo, mo);
   return result;
 }

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -663,9 +663,6 @@ void F_BunnyScroll (void)
       // Widescreen mod PFUBs.
       p1offset = 0;
     }
-
-    W_UnlockLumpName(pfub2);
-    W_UnlockLumpName(pfub1);
   }
 
   {

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -649,8 +649,8 @@ void F_BunnyScroll (void)
   if (finalecount == 0)
   {
     const rpatch_t *p1, *p2;
-    p1 = R_CachePatchName(pfub1);
-    p2 = R_CachePatchName(pfub2);
+    p1 = R_PatchByName(pfub1);
+    p2 = R_PatchByName(pfub2);
 
     p2width = p2->width;
     if (p1->width == 320)

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1578,7 +1578,7 @@ static void G_PlayerFinishLevel(int player)
 
   memset(p->powers, 0, sizeof p->powers);
   memset(p->cards, 0, sizeof p->cards);
-  p->mo = NULL;           // cph - this is allocated PU_LEVEL so it's gone
+  p->mo = NULL;           // cph - this is zone-allocated so it's gone
   p->extralight = 0;      // cancel gun flashes
   p->fixedcolormap = 0;   // cancel ir gogles
   p->damagecount = 0;     // no palette changes

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2070,7 +2070,7 @@ static uint_64_t G_UpdateSignature(uint_64_t s, const char *name)
     do
       {
   int size = W_LumpLength(i);
-  const byte *p = W_CacheLumpNum(i);
+  const byte *p = W_LumpByNum(i);
   while (size--)
     s <<= 1, s += *p++;
       }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2073,7 +2073,6 @@ static uint_64_t G_UpdateSignature(uint_64_t s, const char *name)
   const byte *p = W_CacheLumpNum(i);
   while (size--)
     s <<= 1, s += *p++;
-  W_UnlockLumpNum(i);
       }
     while (--i > lump);
   return s;
@@ -3929,8 +3928,6 @@ dboolean G_CheckDemoStatus (void)
       I_SafeExit(0);  // killough
 
     if (demolumpnum != -1) {
-      // cph - unlock the demo lump
-      W_UnlockLumpNum(demolumpnum);
       demolumpnum = -1;
     }
     G_ReloadDefaults();    // killough 3/1/98

--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -361,8 +361,6 @@ void RejectOverrun(int rejectlump, const byte **rejectmatrix, int totallines)
     pad = prboom_comp[PC_REJECT_PAD_WITH_FF].state ? 0xff : 0;
 
     memset(newreject + length, pad, required - length);
-    // unlock the original lump, it is no longer needed
-    W_UnlockLumpNum(rejectlump);
     rejectlump = -1;
 
     if (!hexen && demo_compatibility && PROCESS(OVERFLOW_REJECT))

--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -350,7 +350,7 @@ void RejectOverrun(int rejectlump, const byte **rejectmatrix, int totallines)
   {
     // allocate a new block and copy the reject table into it; zero the rest
     // PU_LEVEL => will be freed on level exit
-    newreject = Z_Malloc(required, PU_LEVEL);
+    newreject = Z_MallocTag(required, PU_LEVEL);
     *rejectmatrix = memmove(newreject, *rejectmatrix, length);
 
     // e6y

--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -349,8 +349,7 @@ void RejectOverrun(int rejectlump, const byte **rejectmatrix, int totallines)
   if (length < required)
   {
     // allocate a new block and copy the reject table into it; zero the rest
-    // PU_LEVEL => will be freed on level exit
-    newreject = Z_MallocTag(required, PU_LEVEL);
+    newreject = Z_MallocLevel(required);
     *rejectmatrix = memmove(newreject, *rejectmatrix, length);
 
     // e6y

--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -350,7 +350,7 @@ void RejectOverrun(int rejectlump, const byte **rejectmatrix, int totallines)
   {
     // allocate a new block and copy the reject table into it; zero the rest
     // PU_LEVEL => will be freed on level exit
-    newreject = Z_Malloc(required, PU_LEVEL, NULL);
+    newreject = Z_Malloc(required, PU_LEVEL);
     *rejectmatrix = memmove(newreject, *rejectmatrix, length);
 
     // e6y

--- a/prboom2/src/gl_detail.c
+++ b/prboom2/src/gl_detail.c
@@ -707,8 +707,6 @@ GLuint gld_LoadDetailName(const char *name)
     surf_raw = SDL_LoadBMP_RW(SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump)), 1);
 #endif
 
-    W_UnlockLumpNum(lump);
-
     if (surf_raw)
     {
       fmt = *surf_raw->format;

--- a/prboom2/src/gl_detail.c
+++ b/prboom2/src/gl_detail.c
@@ -702,9 +702,9 @@ GLuint gld_LoadDetailName(const char *name)
     SDL_Surface *surf_raw;
 
 #ifdef HAVE_LIBSDL2_IMAGE
-    surf_raw = IMG_Load_RW(SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump)), 1);
+    surf_raw = IMG_Load_RW(SDL_RWFromConstMem(W_LumpByNum(lump), W_LumpLength(lump)), 1);
 #else
-    surf_raw = SDL_LoadBMP_RW(SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump)), 1);
+    surf_raw = SDL_LoadBMP_RW(SDL_RWFromConstMem(W_LumpByNum(lump), W_LumpLength(lump)), 1);
 #endif
 
     if (surf_raw)

--- a/prboom2/src/gl_hires.c
+++ b/prboom2/src/gl_hires.c
@@ -853,7 +853,7 @@ int gld_HiRes_BuildTables(void)
       {
         const byte* RGB2PAL_lump;
 
-        RGB2PAL_lump = W_CacheLumpNum(lump);
+        RGB2PAL_lump = W_LumpByNum(lump);
         RGB2PAL = malloc(RGB2PAL_size);
         memcpy(RGB2PAL, RGB2PAL_lump, RGB2PAL_size);
         return true;
@@ -1202,7 +1202,7 @@ int gld_LoadHiresTex(GLTexture *gltexture, int cm)
           int lump = (W_CheckNumForName)(lumpname, ns_hires);
           if (lump != -1)
           {
-            SDL_RWops *rw_data = SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump));
+            SDL_RWops *rw_data = SDL_RWFromConstMem(W_LumpByNum(lump), W_LumpLength(lump));
             SDL_Surface *surf_tmp = IMG_Load_RW(rw_data, false);
 
             // SDL can't load some TGA with common method

--- a/prboom2/src/gl_hires.c
+++ b/prboom2/src/gl_hires.c
@@ -856,7 +856,6 @@ int gld_HiRes_BuildTables(void)
         RGB2PAL_lump = W_CacheLumpNum(lump);
         RGB2PAL = malloc(RGB2PAL_size);
         memcpy(RGB2PAL, RGB2PAL_lump, RGB2PAL_size);
-        W_UnlockLumpName(RGB2PAL_NAME);
         return true;
       }
     }

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1082,10 +1082,10 @@ unsigned char *gld_ReadScreen(void)
     gld_ApplyGammaRamp(scr, pixels_per_row, gl_window_width, gl_window_height);
 
     // GL textures are bottom up, so copy the rows in reverse to flip vertically
-    for (src_row = gl_window_height - 1, dest_row = 0; src_row >= 0; --src_row, ++dest_row) 
+    for (src_row = gl_window_height - 1, dest_row = 0; src_row >= 0; --src_row, ++dest_row)
     {
-      memcpy(&buffer[dest_row * pixels_per_row], 
-              &scr[src_row * pixels_per_row], 
+      memcpy(&buffer[dest_row * pixels_per_row],
+              &scr[src_row * pixels_per_row],
               pixels_per_row);
     }
   }
@@ -2678,7 +2678,7 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
 
     // off the side?
     if (x1 > viewwidth || x2 < 0)
-      goto unlock_patch;
+      return;
   }
 
   // killough 3/27/98: exclude things totally separated
@@ -2693,16 +2693,16 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
     if (phs != -1 && viewz < sectors[phs].floorheight ?
         fz >= sectors[heightsec].floorheight :
         gzt < sectors[heightsec].floorheight)
-      goto unlock_patch;
+      return;
     if (phs != -1 && viewz > sectors[phs].ceilingheight ?
         gzt < sectors[heightsec].ceilingheight && viewz >= sectors[heightsec].ceilingheight :
         fz >= sectors[heightsec].ceilingheight)
-      goto unlock_patch;
+      return;
   }
 
   //e6y FIXME!!!
   if (thing == players[displayplayer].mo && walkcamera.type != 2)
-    goto unlock_patch;
+    return;
 
   sprite.x =-(float)fx / MAP_SCALE;
   sprite.y = (float)fz / MAP_SCALE;
@@ -2737,7 +2737,7 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
       //1.5 == sqrt(2) + small delta for MF_FOREGROUND
       (float)(MAX(patch->width, patch->height)) / MAP_COEFF / 2.0f * 1.5f))
     {
-      goto unlock_patch;
+      return;
     }
   }
 
@@ -2758,7 +2758,7 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
     sprite.cm = CR_LIMIT + (int)((thing->flags & MF_TRANSLATION) >> (MF_TRANSSHIFT));
   sprite.gltexture = gld_RegisterPatch(lump, sprite.cm, true);
   if (!sprite.gltexture)
-    goto unlock_patch;
+    return;
   sprite.flags = thing->flags;
 
   if (thing->flags & MF_FOREGROUND)
@@ -2797,9 +2797,6 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
   {
     gld_AddHealthBar(thing, &sprite);
   }
-
-unlock_patch:
-  R_UnlockPatchNum(lump);
 }
 
 /*****************

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -2656,7 +2656,7 @@ void gld_ProjectSprite(mobj_t* thing, int lightlevel)
   }
   lump += firstspritelump;
 
-  patch = R_CachePatchNum(lump);
+  patch = R_PatchByNum(lump);
   thing->patch_width = patch->width;
 
   // killough 4/9/98: clip things which are out of view due to height

--- a/prboom2/src/gl_map.c
+++ b/prboom2/src/gl_map.c
@@ -89,7 +89,7 @@ void gld_InitMapPics(void)
 #ifdef HAVE_LIBSDL2_IMAGE
       SDL_Surface *surf_raw;
 
-      surf_raw = IMG_Load_RW(SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump)), true);
+      surf_raw = IMG_Load_RW(SDL_RWFromConstMem(W_LumpByNum(lump), W_LumpLength(lump)), true);
 
       surf = SDL_ConvertSurface(surf_raw, &RGBAFormat, 0);
       SDL_FreeSurface(surf_raw);

--- a/prboom2/src/gl_map.c
+++ b/prboom2/src/gl_map.c
@@ -95,8 +95,6 @@ void gld_InitMapPics(void)
       SDL_FreeSurface(surf_raw);
 #endif
 
-      W_UnlockLumpNum(lump);
-
       if (surf)
       {
         glGenTextures(1, &am_icons[i].tex_id);

--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -73,7 +73,7 @@ static void gld_AddGlobalVertexes(int count)
   if ((gld_num_vertexes+count)>=gld_max_vertexes)
   {
     gld_max_vertexes+=count+1024;
-    flats_vbo = Z_Realloc(flats_vbo, gld_max_vertexes * sizeof(flats_vbo[0]), PU_STATIC, 0);
+    flats_vbo = Z_Realloc(flats_vbo, gld_max_vertexes * sizeof(flats_vbo[0]), PU_STATIC);
   }
 }
 
@@ -140,7 +140,7 @@ static vertex_t *gld_FlatEdgeClipper(int *numpoints, vertex_t *points, int numcl
         gld_CalcIntersectionVertex(&points[startIdx], &points[endIdx], curclip, &newvert);
 
         // Add the new vertex. Also modify the sidelist.
-        points = (vertex_t*)Z_Realloc(points,(++num)*sizeof(vertex_t),PU_LEVEL,0);
+        points = (vertex_t*)Z_Realloc(points,(++num)*sizeof(vertex_t),PU_LEVEL);
         if(num >= MAX_CC_SIDES)
           I_Error("gld_FlatEdgeClipper: Too many points in carver");
 
@@ -193,7 +193,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
   int i, numedgepoints;
   vertex_t *edgepoints;
 
-  clippers=(divline_t*)Z_Malloc(numclippers*sizeof(divline_t),PU_LEVEL,0);
+  clippers=(divline_t*)Z_Malloc(numclippers*sizeof(divline_t),PU_LEVEL);
   if (!clippers)
     return;
   for(i=0; i<num; i++)
@@ -214,7 +214,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
 
   // Setup the 'worldwide' polygon.
   numedgepoints = 4;
-  edgepoints = (vertex_t*)Z_Malloc(numedgepoints*sizeof(vertex_t),PU_LEVEL,0);
+  edgepoints = (vertex_t*)Z_Malloc(numedgepoints*sizeof(vertex_t),PU_LEVEL);
 
   edgepoints[0].x = INT_MIN;
   edgepoints[0].y = INT_MAX;
@@ -258,7 +258,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
         }
 
         (*loopcount)++;
-        (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount), PU_STATIC, 0);
+        (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount), PU_STATIC);
         ((*loop)[(*loopcount) - 1]).index = ssidx;
         ((*loop)[(*loopcount) - 1]).mode = GL_TRIANGLE_FAN;
         ((*loop)[(*loopcount) - 1]).vertexcount = numedgepoints;
@@ -305,7 +305,7 @@ static void gld_CarveFlats(int bspnode, int numdivlines, divline_t *divlines)
   nod = nodes + bspnode;
 
   // Allocate a new list for each child.
-  childlist = (divline_t*)Z_Malloc(childlistsize*sizeof(divline_t),PU_LEVEL,0);
+  childlist = (divline_t*)Z_Malloc(childlistsize*sizeof(divline_t),PU_LEVEL);
 
   // Copy the previous lines.
   if(divlines) memcpy(childlist,divlines,numdivlines*sizeof(divline_t));
@@ -357,7 +357,7 @@ static void CALLBACK ntessBegin( GLenum type )
   sectorloops[ currentsector ].loopcount++;
   // reallocate to get space for another loop
   // PU_LEVEL is used, so this gets freed before a new level is loaded
-  sectorloops[ currentsector ].loops=Z_Realloc(sectorloops[currentsector].loops,sizeof(GLLoopDef)*sectorloops[currentsector].loopcount, PU_STATIC, 0);
+  sectorloops[ currentsector ].loops=Z_Realloc(sectorloops[currentsector].loops,sizeof(GLLoopDef)*sectorloops[currentsector].loopcount, PU_STATIC);
   // set initial values for current loop
   // currentloop is -> sectorloops[currentsector].loopcount-1
   sectorloops[ currentsector ].loops[ sectorloops[currentsector].loopcount-1 ].index=-1;
@@ -477,7 +477,7 @@ static void gld_PrecalculateSector(int num)
   int vertexnum;
 
   currentsector=num;
-  lineadded=Z_Malloc(sectors[num].linecount*sizeof(dboolean),PU_LEVEL,0);
+  lineadded=Z_Malloc(sectors[num].linecount*sizeof(dboolean),PU_LEVEL);
   if (!lineadded)
   {
     if (levelinfo) fclose(levelinfo);
@@ -608,7 +608,7 @@ static void gld_PrecalculateSector(int num)
     if (vertexnum>=maxvertexnum)
     {
       maxvertexnum+=512;
-      v=Z_Realloc(v,maxvertexnum*3*sizeof(double),PU_LEVEL,0);
+      v=Z_Realloc(v,maxvertexnum*3*sizeof(double),PU_LEVEL);
     }
     // calculate coordinates for the glu tesselation functions
     v[vertexnum*3+0]=-(double)currentvertex->x/(double)MAP_SCALE;
@@ -744,7 +744,7 @@ static void gld_GetSubSectorVertices(void)
       }
 
       (*loopcount)++;
-      (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount), PU_STATIC, 0);
+      (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount), PU_STATIC);
       ((*loop)[(*loopcount) - 1]).index = i;
       ((*loop)[(*loopcount) - 1]).mode = GL_TRIANGLE_FAN;
       ((*loop)[(*loopcount) - 1]).vertexcount = numedgepoints;
@@ -869,7 +869,7 @@ static void gld_PreprocessSectors(void)
 
   if (numsectors)
   {
-    sectorloops=Z_Malloc(sizeof(GLSector)*numsectors,PU_STATIC,0);
+    sectorloops=Z_Malloc(sizeof(GLSector)*numsectors,PU_STATIC);
     if (!sectorloops)
       I_Error("gld_PreprocessSectors: Not enough memory for array sectorloops");
     memset(sectorloops, 0, sizeof(GLSector)*numsectors);
@@ -877,7 +877,7 @@ static void gld_PreprocessSectors(void)
 
   if (numsubsectors)
   {
-    subsectorloops=Z_Malloc(sizeof(GLMapSubsector)*numsubsectors,PU_STATIC,0);
+    subsectorloops=Z_Malloc(sizeof(GLMapSubsector)*numsubsectors,PU_STATIC);
     if (!subsectorloops)
       I_Error("gld_PreprocessSectors: Not enough memory for array subsectorloops");
     memset(subsectorloops, 0, sizeof(GLMapSubsector)*numsubsectors);
@@ -1012,7 +1012,7 @@ static void gld_PreprocessSegs(void)
 {
   int i;
 
-  gl_segs=Z_Malloc(numsegs*sizeof(GLSeg),PU_STATIC,0);
+  gl_segs=Z_Malloc(numsegs*sizeof(GLSeg),PU_STATIC);
   for (i=0; i<numsegs; i++)
   {
     gl_segs[i].x1=-(float)segs[i].v1->x/(float)MAP_SCALE;
@@ -1021,7 +1021,7 @@ static void gld_PreprocessSegs(void)
     gl_segs[i].z2= (float)segs[i].v2->y/(float)MAP_SCALE;
   }
 
-  gl_lines=Z_Malloc(numlines*sizeof(GLSeg),PU_STATIC,0);
+  gl_lines=Z_Malloc(numlines*sizeof(GLSeg),PU_STATIC);
   for (i=0; i<numlines; i++)
   {
     gl_lines[i].x1=-(float)lines[i].v1->x/(float)MAP_SCALE;

--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -140,7 +140,7 @@ static vertex_t *gld_FlatEdgeClipper(int *numpoints, vertex_t *points, int numcl
         gld_CalcIntersectionVertex(&points[startIdx], &points[endIdx], curclip, &newvert);
 
         // Add the new vertex. Also modify the sidelist.
-        points = (vertex_t*)Z_ReallocTag(points,(++num)*sizeof(vertex_t),PU_LEVEL);
+        points = (vertex_t*)Z_ReallocLevel(points,(++num)*sizeof(vertex_t));
         if(num >= MAX_CC_SIDES)
           I_Error("gld_FlatEdgeClipper: Too many points in carver");
 
@@ -193,7 +193,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
   int i, numedgepoints;
   vertex_t *edgepoints;
 
-  clippers=(divline_t*)Z_MallocTag(numclippers*sizeof(divline_t),PU_LEVEL);
+  clippers=(divline_t*)Z_MallocLevel(numclippers*sizeof(divline_t));
   if (!clippers)
     return;
   for(i=0; i<num; i++)
@@ -214,7 +214,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
 
   // Setup the 'worldwide' polygon.
   numedgepoints = 4;
-  edgepoints = (vertex_t*)Z_MallocTag(numedgepoints*sizeof(vertex_t),PU_LEVEL);
+  edgepoints = (vertex_t*)Z_MallocLevel(numedgepoints*sizeof(vertex_t));
 
   edgepoints[0].x = INT_MIN;
   edgepoints[0].y = INT_MAX;
@@ -305,7 +305,7 @@ static void gld_CarveFlats(int bspnode, int numdivlines, divline_t *divlines)
   nod = nodes + bspnode;
 
   // Allocate a new list for each child.
-  childlist = (divline_t*)Z_MallocTag(childlistsize*sizeof(divline_t),PU_LEVEL);
+  childlist = (divline_t*)Z_MallocLevel(childlistsize*sizeof(divline_t));
 
   // Copy the previous lines.
   if(divlines) memcpy(childlist,divlines,numdivlines*sizeof(divline_t));
@@ -476,7 +476,7 @@ static void gld_PrecalculateSector(int num)
   int vertexnum;
 
   currentsector=num;
-  lineadded=Z_MallocTag(sectors[num].linecount*sizeof(dboolean),PU_LEVEL);
+  lineadded=Z_MallocLevel(sectors[num].linecount*sizeof(dboolean));
   if (!lineadded)
   {
     if (levelinfo) fclose(levelinfo);
@@ -607,7 +607,7 @@ static void gld_PrecalculateSector(int num)
     if (vertexnum>=maxvertexnum)
     {
       maxvertexnum+=512;
-      v=Z_ReallocTag(v,maxvertexnum*3*sizeof(double),PU_LEVEL);
+      v=Z_ReallocLevel(v,maxvertexnum*3*sizeof(double));
     }
     // calculate coordinates for the glu tesselation functions
     v[vertexnum*3+0]=-(double)currentvertex->x/(double)MAP_SCALE;

--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -73,7 +73,7 @@ static void gld_AddGlobalVertexes(int count)
   if ((gld_num_vertexes+count)>=gld_max_vertexes)
   {
     gld_max_vertexes+=count+1024;
-    flats_vbo = Z_Realloc(flats_vbo, gld_max_vertexes * sizeof(flats_vbo[0]), PU_STATIC);
+    flats_vbo = Z_Realloc(flats_vbo, gld_max_vertexes * sizeof(flats_vbo[0]));
   }
 }
 
@@ -140,7 +140,7 @@ static vertex_t *gld_FlatEdgeClipper(int *numpoints, vertex_t *points, int numcl
         gld_CalcIntersectionVertex(&points[startIdx], &points[endIdx], curclip, &newvert);
 
         // Add the new vertex. Also modify the sidelist.
-        points = (vertex_t*)Z_Realloc(points,(++num)*sizeof(vertex_t),PU_LEVEL);
+        points = (vertex_t*)Z_ReallocTag(points,(++num)*sizeof(vertex_t),PU_LEVEL);
         if(num >= MAX_CC_SIDES)
           I_Error("gld_FlatEdgeClipper: Too many points in carver");
 
@@ -193,7 +193,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
   int i, numedgepoints;
   vertex_t *edgepoints;
 
-  clippers=(divline_t*)Z_Malloc(numclippers*sizeof(divline_t),PU_LEVEL);
+  clippers=(divline_t*)Z_MallocTag(numclippers*sizeof(divline_t),PU_LEVEL);
   if (!clippers)
     return;
   for(i=0; i<num; i++)
@@ -214,7 +214,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
 
   // Setup the 'worldwide' polygon.
   numedgepoints = 4;
-  edgepoints = (vertex_t*)Z_Malloc(numedgepoints*sizeof(vertex_t),PU_LEVEL);
+  edgepoints = (vertex_t*)Z_MallocTag(numedgepoints*sizeof(vertex_t),PU_LEVEL);
 
   edgepoints[0].x = INT_MIN;
   edgepoints[0].y = INT_MAX;
@@ -258,7 +258,7 @@ static void gld_FlatConvexCarver(int ssidx, int num, divline_t *list)
         }
 
         (*loopcount)++;
-        (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount), PU_STATIC);
+        (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount));
         ((*loop)[(*loopcount) - 1]).index = ssidx;
         ((*loop)[(*loopcount) - 1]).mode = GL_TRIANGLE_FAN;
         ((*loop)[(*loopcount) - 1]).vertexcount = numedgepoints;
@@ -305,7 +305,7 @@ static void gld_CarveFlats(int bspnode, int numdivlines, divline_t *divlines)
   nod = nodes + bspnode;
 
   // Allocate a new list for each child.
-  childlist = (divline_t*)Z_Malloc(childlistsize*sizeof(divline_t),PU_LEVEL);
+  childlist = (divline_t*)Z_MallocTag(childlistsize*sizeof(divline_t),PU_LEVEL);
 
   // Copy the previous lines.
   if(divlines) memcpy(childlist,divlines,numdivlines*sizeof(divline_t));
@@ -356,8 +356,7 @@ static void CALLBACK ntessBegin( GLenum type )
   // increase loopcount for currentsector
   sectorloops[ currentsector ].loopcount++;
   // reallocate to get space for another loop
-  // PU_LEVEL is used, so this gets freed before a new level is loaded
-  sectorloops[ currentsector ].loops=Z_Realloc(sectorloops[currentsector].loops,sizeof(GLLoopDef)*sectorloops[currentsector].loopcount, PU_STATIC);
+  sectorloops[ currentsector ].loops=Z_Realloc(sectorloops[currentsector].loops,sizeof(GLLoopDef)*sectorloops[currentsector].loopcount);
   // set initial values for current loop
   // currentloop is -> sectorloops[currentsector].loopcount-1
   sectorloops[ currentsector ].loops[ sectorloops[currentsector].loopcount-1 ].index=-1;
@@ -477,7 +476,7 @@ static void gld_PrecalculateSector(int num)
   int vertexnum;
 
   currentsector=num;
-  lineadded=Z_Malloc(sectors[num].linecount*sizeof(dboolean),PU_LEVEL);
+  lineadded=Z_MallocTag(sectors[num].linecount*sizeof(dboolean),PU_LEVEL);
   if (!lineadded)
   {
     if (levelinfo) fclose(levelinfo);
@@ -608,7 +607,7 @@ static void gld_PrecalculateSector(int num)
     if (vertexnum>=maxvertexnum)
     {
       maxvertexnum+=512;
-      v=Z_Realloc(v,maxvertexnum*3*sizeof(double),PU_LEVEL);
+      v=Z_ReallocTag(v,maxvertexnum*3*sizeof(double),PU_LEVEL);
     }
     // calculate coordinates for the glu tesselation functions
     v[vertexnum*3+0]=-(double)currentvertex->x/(double)MAP_SCALE;
@@ -744,7 +743,7 @@ static void gld_GetSubSectorVertices(void)
       }
 
       (*loopcount)++;
-      (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount), PU_STATIC);
+      (*loop) = Z_Realloc((*loop), sizeof(GLLoopDef)*(*loopcount));
       ((*loop)[(*loopcount) - 1]).index = i;
       ((*loop)[(*loopcount) - 1]).mode = GL_TRIANGLE_FAN;
       ((*loop)[(*loopcount) - 1]).vertexcount = numedgepoints;
@@ -869,7 +868,7 @@ static void gld_PreprocessSectors(void)
 
   if (numsectors)
   {
-    sectorloops=Z_Malloc(sizeof(GLSector)*numsectors,PU_STATIC);
+    sectorloops=Z_Malloc(sizeof(GLSector)*numsectors);
     if (!sectorloops)
       I_Error("gld_PreprocessSectors: Not enough memory for array sectorloops");
     memset(sectorloops, 0, sizeof(GLSector)*numsectors);
@@ -877,7 +876,7 @@ static void gld_PreprocessSectors(void)
 
   if (numsubsectors)
   {
-    subsectorloops=Z_Malloc(sizeof(GLMapSubsector)*numsubsectors,PU_STATIC);
+    subsectorloops=Z_Malloc(sizeof(GLMapSubsector)*numsubsectors);
     if (!subsectorloops)
       I_Error("gld_PreprocessSectors: Not enough memory for array subsectorloops");
     memset(subsectorloops, 0, sizeof(GLMapSubsector)*numsubsectors);
@@ -1012,7 +1011,7 @@ static void gld_PreprocessSegs(void)
 {
   int i;
 
-  gl_segs=Z_Malloc(numsegs*sizeof(GLSeg),PU_STATIC);
+  gl_segs=Z_Malloc(numsegs*sizeof(GLSeg));
   for (i=0; i<numsegs; i++)
   {
     gl_segs[i].x1=-(float)segs[i].v1->x/(float)MAP_SCALE;
@@ -1021,7 +1020,7 @@ static void gld_PreprocessSegs(void)
     gl_segs[i].z2= (float)segs[i].v2->y/(float)MAP_SCALE;
   }
 
-  gl_lines=Z_Malloc(numlines*sizeof(GLSeg),PU_STATIC);
+  gl_lines=Z_Malloc(numlines*sizeof(GLSeg));
   for (i=0; i<numlines; i++)
   {
     gl_lines[i].x1=-(float)lines[i].v1->x/(float)MAP_SCALE;

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -174,7 +174,7 @@ static int ReadLump(const char *filename, const char *lumpname, unsigned char **
     if (lump != -1)
     {
       size = W_LumpLength(lump);
-      data = W_CacheLumpNum(lump);
+      data = W_LumpByNum(lump);
       *buffer = calloc(1, size + 1);
       memcpy (*buffer, data, size);
       (*buffer)[size] = 0;

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -83,12 +83,12 @@ void get_light_shader_bindings()
     int idx;
 
     light_unifs.lightlevel_index = GLEXT_glGetUniformLocationARB(sh_main->hShader, "lightlevel");
-  
+
     GLEXT_glUseProgramObjectARB(sh_main->hShader);
-  
+
     idx = GLEXT_glGetUniformLocationARB(sh_main->hShader, "tex");
     GLEXT_glUniform1iARB(idx, 0);
-  
+
     GLEXT_glUseProgramObjectARB(0);
   }
 }
@@ -178,7 +178,6 @@ static int ReadLump(const char *filename, const char *lumpname, unsigned char **
       *buffer = calloc(1, size + 1);
       memcpy (*buffer, data, size);
       (*buffer)[size] = 0;
-      W_UnlockLumpNum(lump);
     }
   }
 
@@ -273,7 +272,7 @@ void glsl_SetFuzzShaderActive()
   if (active_shader != sh_fuzz)
   {
     GLEXT_glUseProgramObjectARB(sh_fuzz->hShader);
-    active_shader = sh_fuzz;  
+    active_shader = sh_fuzz;
   }
 }
 
@@ -302,7 +301,7 @@ void glsl_SetFuzzTime(int time)
   if (sh_fuzz)
   {
     if (active_shader != sh_fuzz)
-    {        
+    {
       prev_active_shader = active_shader;
       glsl_SetFuzzShaderActive();
     }
@@ -330,7 +329,7 @@ void glsl_SetFuzzScreenResolution(float screenwidth, float screenheight)
   if (sh_fuzz)
   {
     if (active_shader != sh_fuzz)
-    {        
+    {
       prev_active_shader = active_shader;
       glsl_SetFuzzShaderActive();
     }
@@ -357,7 +356,7 @@ void glsl_SetFuzzTextureDimensions(float texwidth, float texheight)
   if (sh_fuzz)
   {
     if (active_shader != sh_fuzz)
-    {        
+    {
       prev_active_shader = active_shader;
       glsl_SetFuzzShaderActive();
     }

--- a/prboom2/src/gl_shadow.c
+++ b/prboom2/src/gl_shadow.c
@@ -78,7 +78,6 @@ void gld_InitShadows(void)
     SDL_Surface *surf = NULL;
     SDL_Surface *surf_raw;
     surf_raw = SDL_LoadBMP_RW(SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump)), 1);
-    W_UnlockLumpNum(lump);
 
     fmt = *surf_raw->format;
     fmt.BitsPerPixel = 24;

--- a/prboom2/src/gl_shadow.c
+++ b/prboom2/src/gl_shadow.c
@@ -77,7 +77,7 @@ void gld_InitShadows(void)
     SDL_PixelFormat fmt;
     SDL_Surface *surf = NULL;
     SDL_Surface *surf_raw;
-    surf_raw = SDL_LoadBMP_RW(SDL_RWFromConstMem(W_CacheLumpNum(lump), W_LumpLength(lump)), 1);
+    surf_raw = SDL_LoadBMP_RW(SDL_RWFromConstMem(W_LumpByNum(lump), W_LumpLength(lump)), 1);
 
     fmt = *surf_raw->format;
     fmt.BitsPerPixel = 24;

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -1366,7 +1366,7 @@ void gld_Precache(void)
 
   {
     size_t size = numflats > num_sprites  ? numflats : num_sprites;
-    hitlist = Z_MallocTag((size_t)numtextures > size ? (size_t)numtextures : size,PU_LEVEL);
+    hitlist = Z_MallocLevel((size_t)numtextures > size ? (size_t)numtextures : size);
   }
 
   // Precache flats.

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -988,7 +988,6 @@ void gld_BindTexture(GLTexture *gltexture, unsigned int flags)
   patch=R_CacheTextureCompositePatchNum(gltexture->index);
   gld_AddPatchToTexture(gltexture, buffer, patch, 0, 0,
                         CR_DEFAULT, !(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture);
-  R_UnlockTextureCompositePatchNum(gltexture->index);
   if (*gltexture->texid_p == 0)
     glGenTextures(1, gltexture->texid_p);
   glBindTexture(GL_TEXTURE_2D, *gltexture->texid_p);
@@ -1065,7 +1064,6 @@ GLTexture *gld_RegisterPatch(int lump, int cm, dboolean is_sprite)
     gltexture->scaleyfac=(float)gltexture->height/(float)gltexture->tex_height;
 
     gltexture->buffer_size=gltexture->buffer_width*gltexture->buffer_height*4;
-    R_UnlockPatchNum(lump);
     if (gltexture->realtexwidth>gltexture->buffer_width)
       return gltexture;
     if (gltexture->realtexheight>gltexture->buffer_height)
@@ -1149,8 +1147,6 @@ void gld_BindPatch(GLTexture *gltexture, int cm)
   gld_BuildTexture(gltexture, buffer, false, w, h);
 
   gld_SetTexClamp(gltexture, GLTEXTURE_CLAMPXY);
-
-  R_UnlockPatchNum(gltexture->index);
 }
 
 GLTexture *gld_RegisterFlat(int lump, dboolean mipmap)

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -240,11 +240,11 @@ static GLTexture *gld_AddNewGLTexItem(int num, int count, GLTexture ***items)
     return NULL;
   if (!(*items))
   {
-    (*items)=Z_Calloc(count, sizeof(GLTexture *),PU_STATIC,0);
+    (*items)=Z_Calloc(count, sizeof(GLTexture *),PU_STATIC);
   }
   if (!(*items)[num])
   {
-    (*items)[num]=Z_Calloc(1, sizeof(GLTexture),PU_STATIC,0);
+    (*items)[num]=Z_Calloc(1, sizeof(GLTexture),PU_STATIC);
     (*items)[num]->textype=GLDT_UNREGISTERED;
 
     //if (gl_boom_colormaps)
@@ -980,7 +980,7 @@ void gld_BindTexture(GLTexture *gltexture, unsigned int flags)
     return;
   }
 
-  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC,0);
+  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
   if (!(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
@@ -1115,7 +1115,7 @@ void gld_BindPatch(GLTexture *gltexture, int cm)
   }
 
   patch=R_CachePatchNum(gltexture->index);
-  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC,0);
+  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
   if (gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
@@ -1251,7 +1251,7 @@ void gld_BindFlat(GLTexture *gltexture, unsigned int flags)
   }
 
   flat=W_CacheLumpNum(gltexture->index);
-  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC,0);
+  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
   if (!(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
@@ -1372,7 +1372,7 @@ void gld_Precache(void)
 
   {
     size_t size = numflats > num_sprites  ? numflats : num_sprites;
-    hitlist = Z_Malloc((size_t)numtextures > size ? (size_t)numtextures : size,PU_LEVEL,0);
+    hitlist = Z_Malloc((size_t)numtextures > size ? (size_t)numtextures : size,PU_LEVEL);
   }
 
   // Precache flats.

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -985,7 +985,7 @@ void gld_BindTexture(GLTexture *gltexture, unsigned int flags)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
     memset(buffer,0,gltexture->buffer_size);
-  patch=R_CacheTextureCompositePatchNum(gltexture->index);
+  patch=R_TextureCompositePatchByNum(gltexture->index);
   gld_AddPatchToTexture(gltexture, buffer, patch, 0, 0,
                         CR_DEFAULT, !(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture);
   if (*gltexture->texid_p == 0)
@@ -1014,7 +1014,7 @@ GLTexture *gld_RegisterPatch(int lump, int cm, dboolean is_sprite)
     return NULL;
   if (gltexture->textype==GLDT_UNREGISTERED)
   {
-    patch=R_CachePatchNum(lump);
+    patch=R_PatchByNum(lump);
     if (!patch)
       return NULL;
     gltexture->textype=GLDT_BROKEN;
@@ -1112,7 +1112,7 @@ void gld_BindPatch(GLTexture *gltexture, int cm)
     return;
   }
 
-  patch=R_CachePatchNum(gltexture->index);
+  patch=R_PatchByNum(gltexture->index);
   buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
   if (gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -1246,7 +1246,7 @@ void gld_BindFlat(GLTexture *gltexture, unsigned int flags)
     return;
   }
 
-  flat=W_CacheLumpNum(gltexture->index);
+  flat=W_LumpByNum(gltexture->index);
   buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
   if (!(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -240,11 +240,11 @@ static GLTexture *gld_AddNewGLTexItem(int num, int count, GLTexture ***items)
     return NULL;
   if (!(*items))
   {
-    (*items)=Z_Calloc(count, sizeof(GLTexture *),PU_STATIC);
+    (*items)=Z_Calloc(count, sizeof(GLTexture *));
   }
   if (!(*items)[num])
   {
-    (*items)[num]=Z_Calloc(1, sizeof(GLTexture),PU_STATIC);
+    (*items)[num]=Z_Calloc(1, sizeof(GLTexture));
     (*items)[num]->textype=GLDT_UNREGISTERED;
 
     //if (gl_boom_colormaps)
@@ -980,7 +980,7 @@ void gld_BindTexture(GLTexture *gltexture, unsigned int flags)
     return;
   }
 
-  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
+  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size);
   if (!(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
@@ -1113,7 +1113,7 @@ void gld_BindPatch(GLTexture *gltexture, int cm)
   }
 
   patch=R_PatchByNum(gltexture->index);
-  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
+  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size);
   if (gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
@@ -1247,7 +1247,7 @@ void gld_BindFlat(GLTexture *gltexture, unsigned int flags)
   }
 
   flat=W_LumpByNum(gltexture->index);
-  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size,PU_STATIC);
+  buffer=(unsigned char*)Z_Malloc(gltexture->buffer_size);
   if (!(gltexture->flags & GLTEXTURE_MIPMAP) && gl_paletted_texture)
     memset(buffer,transparent_pal_index,gltexture->buffer_size);
   else
@@ -1366,7 +1366,7 @@ void gld_Precache(void)
 
   {
     size_t size = numflats > num_sprites  ? numflats : num_sprites;
-    hitlist = Z_Malloc((size_t)numtextures > size ? (size_t)numtextures : size,PU_LEVEL);
+    hitlist = Z_MallocTag((size_t)numtextures > size ? (size_t)numtextures : size,PU_LEVEL);
   }
 
   // Precache flats.

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -1266,8 +1266,6 @@ void gld_BindFlat(GLTexture *gltexture, unsigned int flags)
   gld_BuildTexture(gltexture, buffer, false, w, h);
 
   gld_SetTexClamp(gltexture, flags);
-
-  W_UnlockLumpNum(gltexture->index);
 }
 
 // e6y

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -325,7 +325,7 @@ void MN_Drawer(void)
   //   y = CurrentMenu->y + (CurrentItPos * ITEM_HEIGHT) + SELECTOR_YOFFSET;
   //   selName = (MenuTime & 16 ? "M_SLCTR1" : "M_SLCTR2");
   //   V_DrawPatch(x + SELECTOR_XOFFSET, y,
-  //               W_LumpByName(selName, PU_CACHE));
+  //               W_LumpByName(selName));
   // }
 }
 

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -325,7 +325,7 @@ void MN_Drawer(void)
   //   y = CurrentMenu->y + (CurrentItPos * ITEM_HEIGHT) + SELECTOR_YOFFSET;
   //   selName = (MenuTime & 16 ? "M_SLCTR1" : "M_SLCTR2");
   //   V_DrawPatch(x + SELECTOR_XOFFSET, y,
-  //               W_CacheLumpName(selName, PU_CACHE));
+  //               W_LumpByName(selName, PU_CACHE));
   // }
 }
 

--- a/prboom2/src/hexen/f_finale.c
+++ b/prboom2/src/hexen/f_finale.c
@@ -191,9 +191,9 @@ static void InitializeFade(dboolean fadeIn)
 {
     // unsigned i;
     //
-    // Palette = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC, 0);
-    // PaletteDelta = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC, 0);
-    // RealPalette = Z_Malloc(768 * sizeof(byte), PU_STATIC, 0);
+    // Palette = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC);
+    // PaletteDelta = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC,);
+    // RealPalette = Z_Malloc(768 * sizeof(byte), PU_STATIC);
     //
     // if (fadeIn)
     // {

--- a/prboom2/src/hexen/f_finale.c
+++ b/prboom2/src/hexen/f_finale.c
@@ -301,7 +301,6 @@ static char *GetFinaleText(int sequence)
     }
 
     memcpy(ClusterMessage, W_CacheLumpNum(msgLump), msgSize);
-    W_UnlockLumpNum(msgLump);
     ClusterMessage[msgSize] = '\0';        // Append terminator
     return ClusterMessage;
 }

--- a/prboom2/src/hexen/f_finale.c
+++ b/prboom2/src/hexen/f_finale.c
@@ -201,7 +201,7 @@ static void InitializeFade(dboolean fadeIn)
     //     for (i = 0; i < 768; i++)
     //     {
     //         Palette[i] = 0;
-    //         PaletteDelta[i] = FixedDiv((*((byte *) W_CacheLumpName("playpal",
+    //         PaletteDelta[i] = FixedDiv((*((byte *) W_LumpByName("playpal",
     //                                                                PU_CACHE) +
     //                                       i)) << FRACBITS, 70 * FRACUNIT);
     //     }
@@ -211,7 +211,7 @@ static void InitializeFade(dboolean fadeIn)
     //     for (i = 0; i < 768; i++)
     //     {
     //         RealPalette[i] =
-    //             *((byte *) W_CacheLumpName("playpal", PU_CACHE) + i);
+    //             *((byte *) W_LumpByName("playpal", PU_CACHE) + i);
     //         Palette[i] = RealPalette[i] << FRACBITS;
     //         PaletteDelta[i] = FixedDiv(Palette[i], -70 * FRACUNIT);
     //     }
@@ -300,7 +300,7 @@ static char *GetFinaleText(int sequence)
         I_Error("Finale message too long (%s)", msgLumpName);
     }
 
-    memcpy(ClusterMessage, W_CacheLumpNum(msgLump), msgSize);
+    memcpy(ClusterMessage, W_LumpByNum(msgLump), msgSize);
     ClusterMessage[msgSize] = '\0';        // Append terminator
     return ClusterMessage;
 }

--- a/prboom2/src/hexen/f_finale.c
+++ b/prboom2/src/hexen/f_finale.c
@@ -201,8 +201,7 @@ static void InitializeFade(dboolean fadeIn)
     //     for (i = 0; i < 768; i++)
     //     {
     //         Palette[i] = 0;
-    //         PaletteDelta[i] = FixedDiv((*((byte *) W_LumpByName("playpal",
-    //                                                                PU_CACHE) +
+    //         PaletteDelta[i] = FixedDiv((*((byte *) W_LumpByName("playpal") +
     //                                       i)) << FRACBITS, 70 * FRACUNIT);
     //     }
     // }
@@ -211,7 +210,7 @@ static void InitializeFade(dboolean fadeIn)
     //     for (i = 0; i < 768; i++)
     //     {
     //         RealPalette[i] =
-    //             *((byte *) W_LumpByName("playpal", PU_CACHE) + i);
+    //             *((byte *) W_LumpByName("playpal") + i);
     //         Palette[i] = RealPalette[i] << FRACBITS;
     //         PaletteDelta[i] = FixedDiv(Palette[i], -70 * FRACUNIT);
     //     }

--- a/prboom2/src/hexen/f_finale.c
+++ b/prboom2/src/hexen/f_finale.c
@@ -191,9 +191,9 @@ static void InitializeFade(dboolean fadeIn)
 {
     // unsigned i;
     //
-    // Palette = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC);
-    // PaletteDelta = Z_Malloc(768 * sizeof(fixed_t), PU_STATIC,);
-    // RealPalette = Z_Malloc(768 * sizeof(byte), PU_STATIC);
+    // Palette = Z_Malloc(768 * sizeof(fixed_t));
+    // PaletteDelta = Z_Malloc(768 * sizeof(fixed_t),);
+    // RealPalette = Z_Malloc(768 * sizeof(byte));
     //
     // if (fadeIn)
     // {

--- a/prboom2/src/hexen/in_lude.c
+++ b/prboom2/src/hexen/in_lude.c
@@ -145,7 +145,7 @@ static void InitStats(void)
                 {
                     I_Error("Cluster message too long (%s)", msgLumpName);
                 }
-                memcpy(ClusterMessage, W_CacheLumpNum(msgLump), msgSize);
+                memcpy(ClusterMessage, W_LumpByNum(msgLump), msgSize);
                 ClusterMessage[msgSize] = '\0';    // Append terminator
                 HubText = ClusterMessage;
                 HubCount = strlen(HubText) * TEXTSPEED + TEXTWAIT;

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -399,7 +399,7 @@ void P_LoadACScripts(int lump)
         return;
     }
 
-    ACSInfo = Z_MallocTag(ACScriptCount * sizeof(acsInfo_t), PU_LEVEL);
+    ACSInfo = Z_MallocLevel(ACScriptCount * sizeof(acsInfo_t));
     memset(ACSInfo, 0, ACScriptCount * sizeof(acsInfo_t));
     for (i = 0, info = ACSInfo; i < ACScriptCount; i++, info++)
     {
@@ -431,7 +431,7 @@ void P_LoadACScripts(int lump)
 
     ACStringCount = ReadCodeInt();
     ACSAssert(ACStringCount >= 0, "negative string count %d", ACStringCount);
-    ACStrings = Z_MallocTag(ACStringCount * sizeof(char *), PU_LEVEL);
+    ACStrings = Z_MallocLevel(ACStringCount * sizeof(char *));
 
     for (i=0; i<ACStringCount; ++i)
     {
@@ -448,7 +448,7 @@ static void StartOpenACS(int number, int infoIndex, int offset)
 {
     acs_t *script;
 
-    script = Z_MallocTag(sizeof(acs_t), PU_LEVEL);
+    script = Z_MallocLevel(sizeof(acs_t));
     memset(script, 0, sizeof(acs_t));
     script->number = number;
 
@@ -512,7 +512,7 @@ dboolean P_StartACS(int number, int map, byte * args, mobj_t * activator,
     {                           // Script is already executing
         return false;
     }
-    script = Z_MallocTag(sizeof(acs_t), PU_LEVEL);
+    script = Z_MallocLevel(sizeof(acs_t));
     memset(script, 0, sizeof(acs_t));
     script->number = number;
     script->infoIndex = infoIndex;

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -383,7 +383,7 @@ void P_LoadACScripts(int lump)
     const acsHeader_t *header;
     acsInfo_t *info;
 
-    ActionCodeBase = W_CacheLumpNum(lump);
+    ActionCodeBase = W_LumpByNum(lump);
     ActionCodeSize = W_LumpLength(lump);
 
     doom_snprintf(EvalContext, sizeof(EvalContext),

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -399,7 +399,7 @@ void P_LoadACScripts(int lump)
         return;
     }
 
-    ACSInfo = Z_Malloc(ACScriptCount * sizeof(acsInfo_t), PU_LEVEL, 0);
+    ACSInfo = Z_Malloc(ACScriptCount * sizeof(acsInfo_t), PU_LEVEL);
     memset(ACSInfo, 0, ACScriptCount * sizeof(acsInfo_t));
     for (i = 0, info = ACSInfo; i < ACScriptCount; i++, info++)
     {
@@ -431,7 +431,7 @@ void P_LoadACScripts(int lump)
 
     ACStringCount = ReadCodeInt();
     ACSAssert(ACStringCount >= 0, "negative string count %d", ACStringCount);
-    ACStrings = Z_Malloc(ACStringCount * sizeof(char *), PU_LEVEL, NULL);
+    ACStrings = Z_Malloc(ACStringCount * sizeof(char *), PU_LEVEL);
 
     for (i=0; i<ACStringCount; ++i)
     {
@@ -448,7 +448,7 @@ static void StartOpenACS(int number, int infoIndex, int offset)
 {
     acs_t *script;
 
-    script = Z_Malloc(sizeof(acs_t), PU_LEVEL, 0);
+    script = Z_Malloc(sizeof(acs_t), PU_LEVEL);
     memset(script, 0, sizeof(acs_t));
     script->number = number;
 
@@ -512,7 +512,7 @@ dboolean P_StartACS(int number, int map, byte * args, mobj_t * activator,
     {                           // Script is already executing
         return false;
     }
-    script = Z_Malloc(sizeof(acs_t), PU_LEVEL, 0);
+    script = Z_Malloc(sizeof(acs_t), PU_LEVEL);
     memset(script, 0, sizeof(acs_t));
     script->number = number;
     script->infoIndex = infoIndex;

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -399,7 +399,7 @@ void P_LoadACScripts(int lump)
         return;
     }
 
-    ACSInfo = Z_Malloc(ACScriptCount * sizeof(acsInfo_t), PU_LEVEL);
+    ACSInfo = Z_MallocTag(ACScriptCount * sizeof(acsInfo_t), PU_LEVEL);
     memset(ACSInfo, 0, ACScriptCount * sizeof(acsInfo_t));
     for (i = 0, info = ACSInfo; i < ACScriptCount; i++, info++)
     {
@@ -431,7 +431,7 @@ void P_LoadACScripts(int lump)
 
     ACStringCount = ReadCodeInt();
     ACSAssert(ACStringCount >= 0, "negative string count %d", ACStringCount);
-    ACStrings = Z_Malloc(ACStringCount * sizeof(char *), PU_LEVEL);
+    ACStrings = Z_MallocTag(ACStringCount * sizeof(char *), PU_LEVEL);
 
     for (i=0; i<ACStringCount; ++i)
     {
@@ -448,7 +448,7 @@ static void StartOpenACS(int number, int infoIndex, int offset)
 {
     acs_t *script;
 
-    script = Z_Malloc(sizeof(acs_t), PU_LEVEL);
+    script = Z_MallocTag(sizeof(acs_t), PU_LEVEL);
     memset(script, 0, sizeof(acs_t));
     script->number = number;
 
@@ -512,7 +512,7 @@ dboolean P_StartACS(int number, int map, byte * args, mobj_t * activator,
     {                           // Script is already executing
         return false;
     }
-    script = Z_Malloc(sizeof(acs_t), PU_LEVEL);
+    script = Z_MallocTag(sizeof(acs_t), PU_LEVEL);
     memset(script, 0, sizeof(acs_t));
     script->number = number;
     script->infoIndex = infoIndex;

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -345,7 +345,7 @@ void P_InitLightning(void)
         LevelHasLightning = false;
         return;
     }
-    LightningLightLevels = (int *) Z_MallocTag(secCount * sizeof(int), PU_LEVEL);
+    LightningLightLevels = (int *) Z_MallocLevel(secCount * sizeof(int));
     NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * 35;  // don't flash at level start
 }
 

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -345,7 +345,7 @@ void P_InitLightning(void)
         LevelHasLightning = false;
         return;
     }
-    LightningLightLevels = (int *) Z_Malloc(secCount * sizeof(int), PU_LEVEL);
+    LightningLightLevels = (int *) Z_MallocTag(secCount * sizeof(int), PU_LEVEL);
     NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * 35;  // don't flash at level start
 }
 

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -345,8 +345,7 @@ void P_InitLightning(void)
         LevelHasLightning = false;
         return;
     }
-    LightningLightLevels = (int *) Z_Malloc(secCount * sizeof(int), PU_LEVEL,
-                                            NULL);
+    LightningLightLevels = (int *) Z_Malloc(secCount * sizeof(int), PU_LEVEL);
     NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * 35;  // don't flash at level start
 }
 

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -177,7 +177,7 @@ dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overR
     {
         I_Error("EV_RotatePoly:  Invalid polyobj num: %d\n", polyNum);
     }
-    pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL, 0);
+    pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
     P_AddThinker(&pe->thinker);
     pe->thinker.function = T_RotatePoly;
     pe->polyobj = polyNum;
@@ -208,7 +208,7 @@ dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overR
         {                       // mirroring poly is already in motion
             break;
         }
-        pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL, 0);
+        pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
         P_AddThinker(&pe->thinker);
         pe->thinker.function = T_RotatePoly;
         poly->specialdata = pe;
@@ -273,7 +273,7 @@ static void EV_SpawnMovePolyEvent(int polyNum, polyobj_t *poly, fixed_t speed,
     int mirror;
     polyevent_t *pe;
 
-    pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL, 0);
+    pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
     P_AddThinker(&pe->thinker);
     pe->thinker.function = T_MovePoly;
     pe->polyobj = polyNum;
@@ -292,7 +292,7 @@ static void EV_SpawnMovePolyEvent(int polyNum, polyobj_t *poly, fixed_t speed,
         {                       // mirroring poly is already in motion
             break;
         }
-        pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL, 0);
+        pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
         P_AddThinker(&pe->thinker);
         pe->thinker.function = T_MovePoly;
         pe->polyobj = mirror;
@@ -516,7 +516,7 @@ dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)
     {
         I_Error("EV_OpenPolyDoor:  Invalid polyobj num: %d\n", polyNum);
     }
-    pd = Z_Malloc(sizeof(polydoor_t), PU_LEVEL, 0);
+    pd = Z_Malloc(sizeof(polydoor_t), PU_LEVEL);
     memset(pd, 0, sizeof(polydoor_t));
     P_AddThinker(&pd->thinker);
     pd->thinker.function = T_PolyDoor;
@@ -555,7 +555,7 @@ dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)
         {                       // mirroring poly is already in motion
             break;
         }
-        pd = Z_Malloc(sizeof(polydoor_t), PU_LEVEL, 0);
+        pd = Z_Malloc(sizeof(polydoor_t), PU_LEVEL);
         memset(pd, 0, sizeof(polydoor_t));
         P_AddThinker(&pd->thinker);
         pd->thinker.function = T_PolyDoor;
@@ -993,7 +993,7 @@ static void LinkPolyobj(polyobj_t * po)
                 link = &PolyBlockMap[j + i];
                 if (!(*link))
                 {               // Create a new link at the current block cell
-                    *link = Z_Malloc(sizeof(polyblock_t), PU_LEVEL, 0);
+                    *link = Z_Malloc(sizeof(polyblock_t), PU_LEVEL);
                     (*link)->next = NULL;
                     (*link)->prev = NULL;
                     (*link)->polyobj = po;
@@ -1015,8 +1015,7 @@ static void LinkPolyobj(polyobj_t * po)
                 }
                 else
                 {
-                    tempLink->next = Z_Malloc(sizeof(polyblock_t),
-                                              PU_LEVEL, 0);
+                    tempLink->next = Z_Malloc(sizeof(polyblock_t), PU_LEVEL);
                     tempLink->next->next = NULL;
                     tempLink->next->prev = tempLink;
                     tempLink->next->polyobj = po;
@@ -1090,7 +1089,7 @@ static dboolean CheckMobjBlocking(seg_t * seg, polyobj_t * po)
 void PO_ResetBlockMap(dboolean allocate)
 {
   if (allocate)
-    PolyBlockMap = Z_Malloc(bmapwidth * bmapheight * sizeof(polyblock_t *), PU_LEVEL, 0);
+    PolyBlockMap = Z_Malloc(bmapwidth * bmapheight * sizeof(polyblock_t *), PU_LEVEL);
   memset(PolyBlockMap, 0, bmapwidth * bmapheight * sizeof(polyblock_t *));
 }
 
@@ -1187,8 +1186,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             IterFindPolySegs(segs[i].v2->x, segs[i].v2->y, NULL);
 
             polyobjs[index].numsegs = PolySegCount;
-            polyobjs[index].segs = Z_Malloc(PolySegCount * sizeof(seg_t *),
-                                            PU_LEVEL, 0);
+            polyobjs[index].segs = Z_Malloc(PolySegCount * sizeof(seg_t *), PU_LEVEL);
             *(polyobjs[index].segs) = &segs[i]; // insert the first seg
             IterFindPolySegs(segs[i].v2->x, segs[i].v2->y,
                              polyobjs[index].segs + 1);
@@ -1270,8 +1268,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             polyobjs[index].crush = crush;
             polyobjs[index].hurt = hurt;
             polyobjs[index].tag = tag;
-            polyobjs[index].segs = Z_Malloc(polyobjs[index].numsegs
-                                            * sizeof(seg_t *), PU_LEVEL, 0);
+            polyobjs[index].segs = Z_Malloc(polyobjs[index].numsegs * sizeof(seg_t *), PU_LEVEL);
             for (i = 0; i < polyobjs[index].numsegs; i++)
             {
                 polyobjs[index].segs[i] = polySegList[i];
@@ -1317,8 +1314,8 @@ static void TranslateToStartSpot(int tag, int originX, int originY)
             ("TranslateToStartSpot:  Anchor point located without a StartSpot point: %d\n",
              tag);
     }
-    po->originalPts = Z_Malloc(po->numsegs * sizeof(vertex_t), PU_LEVEL, 0);
-    po->prevPts = Z_Malloc(po->numsegs * sizeof(vertex_t), PU_LEVEL, 0);
+    po->originalPts = Z_Malloc(po->numsegs * sizeof(vertex_t), PU_LEVEL);
+    po->prevPts = Z_Malloc(po->numsegs * sizeof(vertex_t), PU_LEVEL);
     deltaX = originX - po->startSpot.x;
     deltaY = originY - po->startSpot.y;
 
@@ -1400,7 +1397,7 @@ void PO_Init(int lump)
     int numthings;
     int polyIndex;
 
-    polyobjs = Z_Malloc(po_NumPolyobjs * sizeof(polyobj_t), PU_LEVEL, 0);
+    polyobjs = Z_Malloc(po_NumPolyobjs * sizeof(polyobj_t), PU_LEVEL);
     memset(polyobjs, 0, po_NumPolyobjs * sizeof(polyobj_t));
 
     data = W_CacheLumpNum(lump);

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -177,7 +177,7 @@ dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overR
     {
         I_Error("EV_RotatePoly:  Invalid polyobj num: %d\n", polyNum);
     }
-    pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
+    pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
     P_AddThinker(&pe->thinker);
     pe->thinker.function = T_RotatePoly;
     pe->polyobj = polyNum;
@@ -208,7 +208,7 @@ dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overR
         {                       // mirroring poly is already in motion
             break;
         }
-        pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
+        pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
         P_AddThinker(&pe->thinker);
         pe->thinker.function = T_RotatePoly;
         poly->specialdata = pe;
@@ -273,7 +273,7 @@ static void EV_SpawnMovePolyEvent(int polyNum, polyobj_t *poly, fixed_t speed,
     int mirror;
     polyevent_t *pe;
 
-    pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
+    pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
     P_AddThinker(&pe->thinker);
     pe->thinker.function = T_MovePoly;
     pe->polyobj = polyNum;
@@ -292,7 +292,7 @@ static void EV_SpawnMovePolyEvent(int polyNum, polyobj_t *poly, fixed_t speed,
         {                       // mirroring poly is already in motion
             break;
         }
-        pe = Z_Malloc(sizeof(polyevent_t), PU_LEVEL);
+        pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
         P_AddThinker(&pe->thinker);
         pe->thinker.function = T_MovePoly;
         pe->polyobj = mirror;
@@ -516,7 +516,7 @@ dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)
     {
         I_Error("EV_OpenPolyDoor:  Invalid polyobj num: %d\n", polyNum);
     }
-    pd = Z_Malloc(sizeof(polydoor_t), PU_LEVEL);
+    pd = Z_MallocTag(sizeof(polydoor_t), PU_LEVEL);
     memset(pd, 0, sizeof(polydoor_t));
     P_AddThinker(&pd->thinker);
     pd->thinker.function = T_PolyDoor;
@@ -555,7 +555,7 @@ dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)
         {                       // mirroring poly is already in motion
             break;
         }
-        pd = Z_Malloc(sizeof(polydoor_t), PU_LEVEL);
+        pd = Z_MallocTag(sizeof(polydoor_t), PU_LEVEL);
         memset(pd, 0, sizeof(polydoor_t));
         P_AddThinker(&pd->thinker);
         pd->thinker.function = T_PolyDoor;
@@ -993,7 +993,7 @@ static void LinkPolyobj(polyobj_t * po)
                 link = &PolyBlockMap[j + i];
                 if (!(*link))
                 {               // Create a new link at the current block cell
-                    *link = Z_Malloc(sizeof(polyblock_t), PU_LEVEL);
+                    *link = Z_MallocTag(sizeof(polyblock_t), PU_LEVEL);
                     (*link)->next = NULL;
                     (*link)->prev = NULL;
                     (*link)->polyobj = po;
@@ -1015,7 +1015,7 @@ static void LinkPolyobj(polyobj_t * po)
                 }
                 else
                 {
-                    tempLink->next = Z_Malloc(sizeof(polyblock_t), PU_LEVEL);
+                    tempLink->next = Z_MallocTag(sizeof(polyblock_t), PU_LEVEL);
                     tempLink->next->next = NULL;
                     tempLink->next->prev = tempLink;
                     tempLink->next->polyobj = po;
@@ -1089,7 +1089,7 @@ static dboolean CheckMobjBlocking(seg_t * seg, polyobj_t * po)
 void PO_ResetBlockMap(dboolean allocate)
 {
   if (allocate)
-    PolyBlockMap = Z_Malloc(bmapwidth * bmapheight * sizeof(polyblock_t *), PU_LEVEL);
+    PolyBlockMap = Z_MallocTag(bmapwidth * bmapheight * sizeof(polyblock_t *), PU_LEVEL);
   memset(PolyBlockMap, 0, bmapwidth * bmapheight * sizeof(polyblock_t *));
 }
 
@@ -1186,7 +1186,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             IterFindPolySegs(segs[i].v2->x, segs[i].v2->y, NULL);
 
             polyobjs[index].numsegs = PolySegCount;
-            polyobjs[index].segs = Z_Malloc(PolySegCount * sizeof(seg_t *), PU_LEVEL);
+            polyobjs[index].segs = Z_MallocTag(PolySegCount * sizeof(seg_t *), PU_LEVEL);
             *(polyobjs[index].segs) = &segs[i]; // insert the first seg
             IterFindPolySegs(segs[i].v2->x, segs[i].v2->y,
                              polyobjs[index].segs + 1);
@@ -1268,7 +1268,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             polyobjs[index].crush = crush;
             polyobjs[index].hurt = hurt;
             polyobjs[index].tag = tag;
-            polyobjs[index].segs = Z_Malloc(polyobjs[index].numsegs * sizeof(seg_t *), PU_LEVEL);
+            polyobjs[index].segs = Z_MallocTag(polyobjs[index].numsegs * sizeof(seg_t *), PU_LEVEL);
             for (i = 0; i < polyobjs[index].numsegs; i++)
             {
                 polyobjs[index].segs[i] = polySegList[i];
@@ -1314,8 +1314,8 @@ static void TranslateToStartSpot(int tag, int originX, int originY)
             ("TranslateToStartSpot:  Anchor point located without a StartSpot point: %d\n",
              tag);
     }
-    po->originalPts = Z_Malloc(po->numsegs * sizeof(vertex_t), PU_LEVEL);
-    po->prevPts = Z_Malloc(po->numsegs * sizeof(vertex_t), PU_LEVEL);
+    po->originalPts = Z_MallocTag(po->numsegs * sizeof(vertex_t), PU_LEVEL);
+    po->prevPts = Z_MallocTag(po->numsegs * sizeof(vertex_t), PU_LEVEL);
     deltaX = originX - po->startSpot.x;
     deltaY = originY - po->startSpot.y;
 
@@ -1397,7 +1397,7 @@ void PO_Init(int lump)
     int numthings;
     int polyIndex;
 
-    polyobjs = Z_Malloc(po_NumPolyobjs * sizeof(polyobj_t), PU_LEVEL);
+    polyobjs = Z_MallocTag(po_NumPolyobjs * sizeof(polyobj_t), PU_LEVEL);
     memset(polyobjs, 0, po_NumPolyobjs * sizeof(polyobj_t));
 
     data = W_LumpByNum(lump);

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -1438,7 +1438,6 @@ void PO_Init(int lump)
                                  spawnthing.y << FRACBITS);
         }
     }
-    W_UnlockLumpNum(lump);
     // check for a startspot without an anchor point
     for (i = 0; i < po_NumPolyobjs; i++)
     {

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -177,7 +177,7 @@ dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overR
     {
         I_Error("EV_RotatePoly:  Invalid polyobj num: %d\n", polyNum);
     }
-    pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
+    pe = Z_MallocLevel(sizeof(polyevent_t));
     P_AddThinker(&pe->thinker);
     pe->thinker.function = T_RotatePoly;
     pe->polyobj = polyNum;
@@ -208,7 +208,7 @@ dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overR
         {                       // mirroring poly is already in motion
             break;
         }
-        pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
+        pe = Z_MallocLevel(sizeof(polyevent_t));
         P_AddThinker(&pe->thinker);
         pe->thinker.function = T_RotatePoly;
         poly->specialdata = pe;
@@ -273,7 +273,7 @@ static void EV_SpawnMovePolyEvent(int polyNum, polyobj_t *poly, fixed_t speed,
     int mirror;
     polyevent_t *pe;
 
-    pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
+    pe = Z_MallocLevel(sizeof(polyevent_t));
     P_AddThinker(&pe->thinker);
     pe->thinker.function = T_MovePoly;
     pe->polyobj = polyNum;
@@ -292,7 +292,7 @@ static void EV_SpawnMovePolyEvent(int polyNum, polyobj_t *poly, fixed_t speed,
         {                       // mirroring poly is already in motion
             break;
         }
-        pe = Z_MallocTag(sizeof(polyevent_t), PU_LEVEL);
+        pe = Z_MallocLevel(sizeof(polyevent_t));
         P_AddThinker(&pe->thinker);
         pe->thinker.function = T_MovePoly;
         pe->polyobj = mirror;
@@ -516,7 +516,7 @@ dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)
     {
         I_Error("EV_OpenPolyDoor:  Invalid polyobj num: %d\n", polyNum);
     }
-    pd = Z_MallocTag(sizeof(polydoor_t), PU_LEVEL);
+    pd = Z_MallocLevel(sizeof(polydoor_t));
     memset(pd, 0, sizeof(polydoor_t));
     P_AddThinker(&pd->thinker);
     pd->thinker.function = T_PolyDoor;
@@ -555,7 +555,7 @@ dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)
         {                       // mirroring poly is already in motion
             break;
         }
-        pd = Z_MallocTag(sizeof(polydoor_t), PU_LEVEL);
+        pd = Z_MallocLevel(sizeof(polydoor_t));
         memset(pd, 0, sizeof(polydoor_t));
         P_AddThinker(&pd->thinker);
         pd->thinker.function = T_PolyDoor;
@@ -993,7 +993,7 @@ static void LinkPolyobj(polyobj_t * po)
                 link = &PolyBlockMap[j + i];
                 if (!(*link))
                 {               // Create a new link at the current block cell
-                    *link = Z_MallocTag(sizeof(polyblock_t), PU_LEVEL);
+                    *link = Z_MallocLevel(sizeof(polyblock_t));
                     (*link)->next = NULL;
                     (*link)->prev = NULL;
                     (*link)->polyobj = po;
@@ -1015,7 +1015,7 @@ static void LinkPolyobj(polyobj_t * po)
                 }
                 else
                 {
-                    tempLink->next = Z_MallocTag(sizeof(polyblock_t), PU_LEVEL);
+                    tempLink->next = Z_MallocLevel(sizeof(polyblock_t));
                     tempLink->next->next = NULL;
                     tempLink->next->prev = tempLink;
                     tempLink->next->polyobj = po;
@@ -1089,7 +1089,7 @@ static dboolean CheckMobjBlocking(seg_t * seg, polyobj_t * po)
 void PO_ResetBlockMap(dboolean allocate)
 {
   if (allocate)
-    PolyBlockMap = Z_MallocTag(bmapwidth * bmapheight * sizeof(polyblock_t *), PU_LEVEL);
+    PolyBlockMap = Z_MallocLevel(bmapwidth * bmapheight * sizeof(polyblock_t *));
   memset(PolyBlockMap, 0, bmapwidth * bmapheight * sizeof(polyblock_t *));
 }
 
@@ -1186,7 +1186,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             IterFindPolySegs(segs[i].v2->x, segs[i].v2->y, NULL);
 
             polyobjs[index].numsegs = PolySegCount;
-            polyobjs[index].segs = Z_MallocTag(PolySegCount * sizeof(seg_t *), PU_LEVEL);
+            polyobjs[index].segs = Z_MallocLevel(PolySegCount * sizeof(seg_t *));
             *(polyobjs[index].segs) = &segs[i]; // insert the first seg
             IterFindPolySegs(segs[i].v2->x, segs[i].v2->y,
                              polyobjs[index].segs + 1);
@@ -1268,7 +1268,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             polyobjs[index].crush = crush;
             polyobjs[index].hurt = hurt;
             polyobjs[index].tag = tag;
-            polyobjs[index].segs = Z_MallocTag(polyobjs[index].numsegs * sizeof(seg_t *), PU_LEVEL);
+            polyobjs[index].segs = Z_MallocLevel(polyobjs[index].numsegs * sizeof(seg_t *));
             for (i = 0; i < polyobjs[index].numsegs; i++)
             {
                 polyobjs[index].segs[i] = polySegList[i];
@@ -1314,8 +1314,8 @@ static void TranslateToStartSpot(int tag, int originX, int originY)
             ("TranslateToStartSpot:  Anchor point located without a StartSpot point: %d\n",
              tag);
     }
-    po->originalPts = Z_MallocTag(po->numsegs * sizeof(vertex_t), PU_LEVEL);
-    po->prevPts = Z_MallocTag(po->numsegs * sizeof(vertex_t), PU_LEVEL);
+    po->originalPts = Z_MallocLevel(po->numsegs * sizeof(vertex_t));
+    po->prevPts = Z_MallocLevel(po->numsegs * sizeof(vertex_t));
     deltaX = originX - po->startSpot.x;
     deltaY = originY - po->startSpot.y;
 
@@ -1397,7 +1397,7 @@ void PO_Init(int lump)
     int numthings;
     int polyIndex;
 
-    polyobjs = Z_MallocTag(po_NumPolyobjs * sizeof(polyobj_t), PU_LEVEL);
+    polyobjs = Z_MallocLevel(po_NumPolyobjs * sizeof(polyobj_t));
     memset(polyobjs, 0, po_NumPolyobjs * sizeof(polyobj_t));
 
     data = W_LumpByNum(lump);

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -1400,7 +1400,7 @@ void PO_Init(int lump)
     polyobjs = Z_Malloc(po_NumPolyobjs * sizeof(polyobj_t), PU_LEVEL);
     memset(polyobjs, 0, po_NumPolyobjs * sizeof(polyobj_t));
 
-    data = W_CacheLumpNum(lump);
+    data = W_LumpByNum(lump);
     numthings = W_LumpLength(lump) / sizeof(mapthing_t);
     mt = (const mapthing_t *) data;
     polyIndex = 0;              // index polyobj number

--- a/prboom2/src/hexen/sn_sonix.c
+++ b/prboom2/src/hexen/sn_sonix.c
@@ -161,8 +161,7 @@ void SN_InitSequenceScript(void)
             {
                 SC_ScriptError("SN_InitSequenceScript:  Nested Script Error");
             }
-            tempDataStart = (int *) Z_Malloc(SS_TEMPBUFFER_SIZE,
-                                             PU_STATIC, NULL);
+            tempDataStart = (int *) Z_Malloc(SS_TEMPBUFFER_SIZE, PU_STATIC);
             memset(tempDataStart, 0, SS_TEMPBUFFER_SIZE);
             tempDataPtr = tempDataStart;
             for (i = 0; i < SS_MAX_SCRIPTS; i++)
@@ -252,7 +251,7 @@ void SN_InitSequenceScript(void)
 
             *tempDataPtr++ = SS_CMD_END;
             dataSize = (tempDataPtr - tempDataStart) * sizeof(int);
-            SequenceData[i] = (int *) Z_Malloc(dataSize, PU_STATIC, NULL);
+            SequenceData[i] = (int *) Z_Malloc(dataSize, PU_STATIC);
             memcpy(SequenceData[i], tempDataStart, dataSize);
             Z_Free(tempDataStart);
             inSequence = -1;
@@ -276,7 +275,7 @@ void SN_StartSequence(mobj_t * mobj, int sequence)
     seqnode_t *node;
 
     SN_StopSequence(mobj);      // Stop any previous sequence
-    node = (seqnode_t *) Z_Malloc(sizeof(seqnode_t), PU_STATIC, NULL);
+    node = (seqnode_t *) Z_Malloc(sizeof(seqnode_t), PU_STATIC);
     node->sequencePtr = SequenceData[SequenceTranslate[sequence].scriptNum];
     node->sequence = sequence;
     node->mobj = mobj;

--- a/prboom2/src/hexen/sn_sonix.c
+++ b/prboom2/src/hexen/sn_sonix.c
@@ -161,7 +161,7 @@ void SN_InitSequenceScript(void)
             {
                 SC_ScriptError("SN_InitSequenceScript:  Nested Script Error");
             }
-            tempDataStart = (int *) Z_Malloc(SS_TEMPBUFFER_SIZE, PU_STATIC);
+            tempDataStart = (int *) Z_Malloc(SS_TEMPBUFFER_SIZE);
             memset(tempDataStart, 0, SS_TEMPBUFFER_SIZE);
             tempDataPtr = tempDataStart;
             for (i = 0; i < SS_MAX_SCRIPTS; i++)
@@ -251,7 +251,7 @@ void SN_InitSequenceScript(void)
 
             *tempDataPtr++ = SS_CMD_END;
             dataSize = (tempDataPtr - tempDataStart) * sizeof(int);
-            SequenceData[i] = (int *) Z_Malloc(dataSize, PU_STATIC);
+            SequenceData[i] = (int *) Z_Malloc(dataSize);
             memcpy(SequenceData[i], tempDataStart, dataSize);
             Z_Free(tempDataStart);
             inSequence = -1;
@@ -275,7 +275,7 @@ void SN_StartSequence(mobj_t * mobj, int sequence)
     seqnode_t *node;
 
     SN_StopSequence(mobj);      // Stop any previous sequence
-    node = (seqnode_t *) Z_Malloc(sizeof(seqnode_t), PU_STATIC);
+    node = (seqnode_t *) Z_Malloc(sizeof(seqnode_t));
     node->sequencePtr = SequenceData[SequenceTranslate[sequence].scriptNum];
     node->sequence = sequence;
     node->mobj = mobj;

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -1481,14 +1481,13 @@ static void UnarchiveMobjs(void)
     mobj_t *mobj;
 
     AssertSegment(ASEG_MOBJS);
-    TargetPlayerAddrs = Z_Malloc(MAX_TARGET_PLAYERS * sizeof(mobj_t **),
-                                 PU_STATIC, NULL);
+    TargetPlayerAddrs = Z_Malloc(MAX_TARGET_PLAYERS * sizeof(mobj_t **), PU_STATIC);
     TargetPlayerCount = 0;
     MobjCount = SV_ReadLong();
-    MobjList = Z_Malloc(MobjCount * sizeof(mobj_t *), PU_STATIC, NULL);
+    MobjList = Z_Malloc(MobjCount * sizeof(mobj_t *), PU_STATIC);
     for (i = 0; i < MobjCount; i++)
     {
-        MobjList[i] = Z_Malloc(sizeof(mobj_t), PU_LEVEL, NULL);
+        MobjList[i] = Z_Malloc(sizeof(mobj_t), PU_LEVEL);
         memset(MobjList[i], 0, sizeof(mobj_t));
     }
     for (i = 0; i < MobjCount; i++)
@@ -1697,7 +1696,7 @@ static void UnarchiveThinkers(void)
         {
             if (tClass == info->tClass)
             {
-                thinker = Z_Malloc(info->size, PU_LEVEL, NULL);
+                thinker = Z_Malloc(info->size, PU_LEVEL);
                 memset(thinker, 0, info->size);
                 info->readFunc(thinker);
                 thinker->function = info->thinkerFunc;

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -1481,13 +1481,13 @@ static void UnarchiveMobjs(void)
     mobj_t *mobj;
 
     AssertSegment(ASEG_MOBJS);
-    TargetPlayerAddrs = Z_Malloc(MAX_TARGET_PLAYERS * sizeof(mobj_t **), PU_STATIC);
+    TargetPlayerAddrs = Z_Malloc(MAX_TARGET_PLAYERS * sizeof(mobj_t **));
     TargetPlayerCount = 0;
     MobjCount = SV_ReadLong();
-    MobjList = Z_Malloc(MobjCount * sizeof(mobj_t *), PU_STATIC);
+    MobjList = Z_Malloc(MobjCount * sizeof(mobj_t *));
     for (i = 0; i < MobjCount; i++)
     {
-        MobjList[i] = Z_Malloc(sizeof(mobj_t), PU_LEVEL);
+        MobjList[i] = Z_MallocTag(sizeof(mobj_t), PU_LEVEL);
         memset(MobjList[i], 0, sizeof(mobj_t));
     }
     for (i = 0; i < MobjCount; i++)
@@ -1696,7 +1696,7 @@ static void UnarchiveThinkers(void)
         {
             if (tClass == info->tClass)
             {
-                thinker = Z_Malloc(info->size, PU_LEVEL);
+                thinker = Z_MallocTag(info->size, PU_LEVEL);
                 memset(thinker, 0, info->size);
                 info->readFunc(thinker);
                 thinker->function = info->thinkerFunc;

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -1487,7 +1487,7 @@ static void UnarchiveMobjs(void)
     MobjList = Z_Malloc(MobjCount * sizeof(mobj_t *));
     for (i = 0; i < MobjCount; i++)
     {
-        MobjList[i] = Z_MallocTag(sizeof(mobj_t), PU_LEVEL);
+        MobjList[i] = Z_MallocLevel(sizeof(mobj_t));
         memset(MobjList[i], 0, sizeof(mobj_t));
     }
     for (i = 0; i < MobjCount; i++)
@@ -1696,7 +1696,7 @@ static void UnarchiveThinkers(void)
         {
             if (tClass == info->tClass)
             {
-                thinker = Z_MallocTag(info->size, PU_LEVEL);
+                thinker = Z_MallocLevel(info->size);
                 memset(thinker, 0, info->size);
                 info->readFunc(thinker);
                 thinker->function = info->thinkerFunc;

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -2860,7 +2860,7 @@ int SetCustomMessage(int plr, const char *msg, int delay, int ticks, int cm, int
   }
   else
   {
-    message_thinker_t *message = Z_CallocTag(1, sizeof(*message), PU_LEVEL);
+    message_thinker_t *message = Z_CallocLevel(1, sizeof(*message));
     message->thinker.function = T_ShowMessage;
     message->delay = delay;
     message->plr = plr;

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -2860,7 +2860,7 @@ int SetCustomMessage(int plr, const char *msg, int delay, int ticks, int cm, int
   }
   else
   {
-    message_thinker_t *message = Z_Calloc(1, sizeof(*message), PU_LEVEL);
+    message_thinker_t *message = Z_CallocTag(1, sizeof(*message), PU_LEVEL);
     message->thinker.function = T_ShowMessage;
     message->delay = delay;
     message->plr = plr;

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -2860,7 +2860,7 @@ int SetCustomMessage(int plr, const char *msg, int delay, int ticks, int cm, int
   }
   else
   {
-    message_thinker_t *message = Z_Calloc(1, sizeof(*message), PU_LEVEL, NULL);
+    message_thinker_t *message = Z_Calloc(1, sizeof(*message), PU_LEVEL);
     message->thinker.function = T_ShowMessage;
     message->delay = delay;
     message->plr = plr;

--- a/prboom2/src/i_pcsound.c
+++ b/prboom2/src/i_pcsound.c
@@ -110,7 +110,7 @@ static dboolean CachePCSLump(int sound_id)
 
     // Load from WAD
 
-    current_sound_lump = W_CacheLumpNum(S_sfx[sound_id].lumpnum);
+    current_sound_lump = W_LumpByNum(S_sfx[sound_id].lumpnum);
     lumplen = W_LumpLength(S_sfx[sound_id].lumpnum);
 
     // Read header

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -138,7 +138,7 @@ int M_ReadFile(char const *name, byte **buffer)
       fseek(fp, 0, SEEK_END);
       length = ftell(fp);
       fseek(fp, 0, SEEK_SET);
-      *buffer = Z_Malloc(length, PU_STATIC);
+      *buffer = Z_Malloc(length);
       if (fread(*buffer, 1, length, fp) == length)
         {
           fclose(fp);

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -138,7 +138,7 @@ int M_ReadFile(char const *name, byte **buffer)
       fseek(fp, 0, SEEK_END);
       length = ftell(fp);
       fseek(fp, 0, SEEK_SET);
-      *buffer = Z_Malloc(length, PU_STATIC, 0);
+      *buffer = Z_Malloc(length, PU_STATIC);
       if (fread(*buffer, 1, length, fp) == length)
         {
           fclose(fp);

--- a/prboom2/src/memio.c
+++ b/prboom2/src/memio.c
@@ -54,7 +54,7 @@ MEMFILE *mem_fopen_read(const void *buf, size_t buflen)
 {
   MEMFILE *file;
 
-  file = Z_Malloc(sizeof(MEMFILE), PU_STATIC);
+  file = Z_Malloc(sizeof(MEMFILE));
 
   // The MEMFILE struct is overloaded for both read-only and write use cases
   // This is required to interface with 3rd party libraries (I think)
@@ -107,10 +107,10 @@ MEMFILE *mem_fopen_write(void)
 {
   MEMFILE *file;
 
-  file = Z_Malloc(sizeof(MEMFILE), PU_STATIC);
+  file = Z_Malloc(sizeof(MEMFILE));
 
   file->alloced = 1024;
-  file->buf = Z_Malloc(file->alloced, PU_STATIC);
+  file->buf = Z_Malloc(file->alloced);
   file->buflen = 0;
   file->position = 0;
   file->mode = MODE_WRITE;
@@ -138,7 +138,7 @@ size_t mem_fwrite(const void *ptr, size_t size, size_t nmemb, MEMFILE *stream)
   {
     unsigned char *newbuf;
 
-    newbuf = Z_Malloc(stream->alloced * 2, PU_STATIC);
+    newbuf = Z_Malloc(stream->alloced * 2);
     memcpy(newbuf, stream->buf, stream->alloced);
     Z_Free(stream->buf);
     stream->buf = newbuf;

--- a/prboom2/src/memio.c
+++ b/prboom2/src/memio.c
@@ -54,7 +54,7 @@ MEMFILE *mem_fopen_read(const void *buf, size_t buflen)
 {
   MEMFILE *file;
 
-  file = Z_Malloc(sizeof(MEMFILE), PU_STATIC, 0);
+  file = Z_Malloc(sizeof(MEMFILE), PU_STATIC);
 
   // The MEMFILE struct is overloaded for both read-only and write use cases
   // This is required to interface with 3rd party libraries (I think)
@@ -107,10 +107,10 @@ MEMFILE *mem_fopen_write(void)
 {
   MEMFILE *file;
 
-  file = Z_Malloc(sizeof(MEMFILE), PU_STATIC, 0);
+  file = Z_Malloc(sizeof(MEMFILE), PU_STATIC);
 
   file->alloced = 1024;
-  file->buf = Z_Malloc(file->alloced, PU_STATIC, 0);
+  file->buf = Z_Malloc(file->alloced, PU_STATIC);
   file->buflen = 0;
   file->position = 0;
   file->mode = MODE_WRITE;
@@ -138,7 +138,7 @@ size_t mem_fwrite(const void *ptr, size_t size, size_t nmemb, MEMFILE *stream)
   {
     unsigned char *newbuf;
 
-    newbuf = Z_Malloc(stream->alloced * 2, PU_STATIC, 0);
+    newbuf = Z_Malloc(stream->alloced * 2, PU_STATIC);
     memcpy(newbuf, stream->buf, stream->alloced);
     Z_Free(stream->buf);
     stream->buf = newbuf;

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -463,7 +463,7 @@ manual_ceiling://e6y
 
     // create a new ceiling thinker
     rtn = 1;
-    ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
+    ceiling = Z_MallocLevel (sizeof(*ceiling));
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling;               //jff 2/22/98
@@ -706,7 +706,7 @@ static void P_SpawnZDoomCeiling(sector_t *sec, ceiling_e type, line_t *line, int
   ceiling_t *ceiling;
   fixed_t targheight = 0;
 
-  ceiling = Z_MallocTag(sizeof(*ceiling), PU_LEVEL);
+  ceiling = Z_MallocLevel(sizeof(*ceiling));
   memset(ceiling, 0, sizeof(*ceiling));
   P_AddThinker(&ceiling->thinker);
   sec->ceilingdata = ceiling;
@@ -979,7 +979,7 @@ int Hexen_EV_DoCeiling(line_t * line, byte * arg, ceiling_e type)
         // new door thinker
         //
         rtn = 1;
-        ceiling = Z_MallocTag(sizeof(*ceiling), PU_LEVEL);
+        ceiling = Z_MallocLevel(sizeof(*ceiling));
         memset(ceiling, 0, sizeof(*ceiling));
         P_AddThinker(&ceiling->thinker);
         sec->ceilingdata = ceiling;

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -463,7 +463,7 @@ manual_ceiling://e6y
 
     // create a new ceiling thinker
     rtn = 1;
-    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL, 0);
+    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling;               //jff 2/22/98
@@ -706,7 +706,7 @@ static void P_SpawnZDoomCeiling(sector_t *sec, ceiling_e type, line_t *line, int
   ceiling_t *ceiling;
   fixed_t targheight = 0;
 
-  ceiling = Z_Malloc(sizeof(*ceiling), PU_LEVEL, 0);
+  ceiling = Z_Malloc(sizeof(*ceiling), PU_LEVEL);
   memset(ceiling, 0, sizeof(*ceiling));
   P_AddThinker(&ceiling->thinker);
   sec->ceilingdata = ceiling;
@@ -979,7 +979,7 @@ int Hexen_EV_DoCeiling(line_t * line, byte * arg, ceiling_e type)
         // new door thinker
         //
         rtn = 1;
-        ceiling = Z_Malloc(sizeof(*ceiling), PU_LEVEL, 0);
+        ceiling = Z_Malloc(sizeof(*ceiling), PU_LEVEL);
         memset(ceiling, 0, sizeof(*ceiling));
         P_AddThinker(&ceiling->thinker);
         sec->ceilingdata = ceiling;

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -463,7 +463,7 @@ manual_ceiling://e6y
 
     // create a new ceiling thinker
     rtn = 1;
-    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
+    ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling;               //jff 2/22/98
@@ -706,7 +706,7 @@ static void P_SpawnZDoomCeiling(sector_t *sec, ceiling_e type, line_t *line, int
   ceiling_t *ceiling;
   fixed_t targheight = 0;
 
-  ceiling = Z_Malloc(sizeof(*ceiling), PU_LEVEL);
+  ceiling = Z_MallocTag(sizeof(*ceiling), PU_LEVEL);
   memset(ceiling, 0, sizeof(*ceiling));
   P_AddThinker(&ceiling->thinker);
   sec->ceilingdata = ceiling;
@@ -979,7 +979,7 @@ int Hexen_EV_DoCeiling(line_t * line, byte * arg, ceiling_e type)
         // new door thinker
         //
         rtn = 1;
-        ceiling = Z_Malloc(sizeof(*ceiling), PU_LEVEL);
+        ceiling = Z_MallocTag(sizeof(*ceiling), PU_LEVEL);
         memset(ceiling, 0, sizeof(*ceiling));
         P_AddThinker(&ceiling->thinker);
         sec->ceilingdata = ceiling;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -527,7 +527,7 @@ manual_door://e6y
 
     // new door thinker
     rtn = 1;
-    door = Z_Malloc (sizeof(*door), PU_LEVEL, 0);
+    door = Z_Malloc (sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98
@@ -753,7 +753,7 @@ int EV_VerticalDoor
   }
 
   // new door thinker
-  door = Z_Malloc (sizeof(*door), PU_LEVEL, 0);
+  door = Z_Malloc (sizeof(*door), PU_LEVEL);
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
   sec->ceilingdata = door; //jff 2/22/98
@@ -825,7 +825,7 @@ void P_SpawnDoorCloseIn30 (sector_t* sec)
 {
   vldoor_t* door;
 
-  door = Z_Malloc ( sizeof(*door), PU_LEVEL, 0);
+  door = Z_Malloc ( sizeof(*door), PU_LEVEL);
 
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
@@ -857,7 +857,7 @@ void P_SpawnDoorRaiseIn5Mins
 {
   vldoor_t* door;
 
-  door = Z_Malloc ( sizeof(*door), PU_LEVEL, 0);
+  door = Z_Malloc ( sizeof(*door), PU_LEVEL);
 
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
@@ -970,7 +970,7 @@ void Heretic_EV_VerticalDoor(line_t * line, mobj_t * thing)
     //
     // new door thinker
     //
-    door = Z_Malloc(sizeof(*door), PU_LEVEL, 0);
+    door = Z_Malloc(sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker(&door->thinker);
     sec->ceilingdata = door;
@@ -1012,7 +1012,7 @@ static void P_SpawnZDoomDoor(sector_t *sec, vldoor_e type, line_t *line, fixed_t
 {
   vldoor_t *door;
 
-  door = Z_Malloc(sizeof(*door), PU_LEVEL, 0);
+  door = Z_Malloc(sizeof(*door), PU_LEVEL);
   memset(door, 0, sizeof(*door));
   P_AddThinker(&door->thinker);
   sec->ceilingdata = door;
@@ -1176,7 +1176,7 @@ int Hexen_EV_DoDoor(line_t * line, byte * args, vldoor_e type)
         }
         // Add new door thinker
         retcode = 1;
-        door = Z_Malloc(sizeof(*door), PU_LEVEL, 0);
+        door = Z_Malloc(sizeof(*door), PU_LEVEL);
         memset(door, 0, sizeof(*door));
         P_AddThinker(&door->thinker);
         sec->ceilingdata = door;
@@ -1229,7 +1229,7 @@ dboolean Hexen_EV_VerticalDoor(line_t * line, mobj_t * thing)
     //
     // new door thinker
     //
-    door = Z_Malloc(sizeof(*door), PU_LEVEL, 0);
+    door = Z_Malloc(sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker(&door->thinker);
     sec->ceilingdata = door;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -527,7 +527,7 @@ manual_door://e6y
 
     // new door thinker
     rtn = 1;
-    door = Z_Malloc (sizeof(*door), PU_LEVEL);
+    door = Z_MallocTag (sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98
@@ -753,7 +753,7 @@ int EV_VerticalDoor
   }
 
   // new door thinker
-  door = Z_Malloc (sizeof(*door), PU_LEVEL);
+  door = Z_MallocTag (sizeof(*door), PU_LEVEL);
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
   sec->ceilingdata = door; //jff 2/22/98
@@ -825,7 +825,7 @@ void P_SpawnDoorCloseIn30 (sector_t* sec)
 {
   vldoor_t* door;
 
-  door = Z_Malloc ( sizeof(*door), PU_LEVEL);
+  door = Z_MallocTag ( sizeof(*door), PU_LEVEL);
 
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
@@ -857,7 +857,7 @@ void P_SpawnDoorRaiseIn5Mins
 {
   vldoor_t* door;
 
-  door = Z_Malloc ( sizeof(*door), PU_LEVEL);
+  door = Z_MallocTag ( sizeof(*door), PU_LEVEL);
 
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
@@ -970,7 +970,7 @@ void Heretic_EV_VerticalDoor(line_t * line, mobj_t * thing)
     //
     // new door thinker
     //
-    door = Z_Malloc(sizeof(*door), PU_LEVEL);
+    door = Z_MallocTag(sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker(&door->thinker);
     sec->ceilingdata = door;
@@ -1012,7 +1012,7 @@ static void P_SpawnZDoomDoor(sector_t *sec, vldoor_e type, line_t *line, fixed_t
 {
   vldoor_t *door;
 
-  door = Z_Malloc(sizeof(*door), PU_LEVEL);
+  door = Z_MallocTag(sizeof(*door), PU_LEVEL);
   memset(door, 0, sizeof(*door));
   P_AddThinker(&door->thinker);
   sec->ceilingdata = door;
@@ -1176,7 +1176,7 @@ int Hexen_EV_DoDoor(line_t * line, byte * args, vldoor_e type)
         }
         // Add new door thinker
         retcode = 1;
-        door = Z_Malloc(sizeof(*door), PU_LEVEL);
+        door = Z_MallocTag(sizeof(*door), PU_LEVEL);
         memset(door, 0, sizeof(*door));
         P_AddThinker(&door->thinker);
         sec->ceilingdata = door;
@@ -1229,7 +1229,7 @@ dboolean Hexen_EV_VerticalDoor(line_t * line, mobj_t * thing)
     //
     // new door thinker
     //
-    door = Z_Malloc(sizeof(*door), PU_LEVEL);
+    door = Z_MallocTag(sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker(&door->thinker);
     sec->ceilingdata = door;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -527,7 +527,7 @@ manual_door://e6y
 
     // new door thinker
     rtn = 1;
-    door = Z_MallocTag (sizeof(*door), PU_LEVEL);
+    door = Z_MallocLevel (sizeof(*door));
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98
@@ -753,7 +753,7 @@ int EV_VerticalDoor
   }
 
   // new door thinker
-  door = Z_MallocTag (sizeof(*door), PU_LEVEL);
+  door = Z_MallocLevel (sizeof(*door));
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
   sec->ceilingdata = door; //jff 2/22/98
@@ -825,7 +825,7 @@ void P_SpawnDoorCloseIn30 (sector_t* sec)
 {
   vldoor_t* door;
 
-  door = Z_MallocTag ( sizeof(*door), PU_LEVEL);
+  door = Z_MallocLevel ( sizeof(*door));
 
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
@@ -857,7 +857,7 @@ void P_SpawnDoorRaiseIn5Mins
 {
   vldoor_t* door;
 
-  door = Z_MallocTag ( sizeof(*door), PU_LEVEL);
+  door = Z_MallocLevel ( sizeof(*door));
 
   memset(door, 0, sizeof(*door));
   P_AddThinker (&door->thinker);
@@ -970,7 +970,7 @@ void Heretic_EV_VerticalDoor(line_t * line, mobj_t * thing)
     //
     // new door thinker
     //
-    door = Z_MallocTag(sizeof(*door), PU_LEVEL);
+    door = Z_MallocLevel(sizeof(*door));
     memset(door, 0, sizeof(*door));
     P_AddThinker(&door->thinker);
     sec->ceilingdata = door;
@@ -1012,7 +1012,7 @@ static void P_SpawnZDoomDoor(sector_t *sec, vldoor_e type, line_t *line, fixed_t
 {
   vldoor_t *door;
 
-  door = Z_MallocTag(sizeof(*door), PU_LEVEL);
+  door = Z_MallocLevel(sizeof(*door));
   memset(door, 0, sizeof(*door));
   P_AddThinker(&door->thinker);
   sec->ceilingdata = door;
@@ -1176,7 +1176,7 @@ int Hexen_EV_DoDoor(line_t * line, byte * args, vldoor_e type)
         }
         // Add new door thinker
         retcode = 1;
-        door = Z_MallocTag(sizeof(*door), PU_LEVEL);
+        door = Z_MallocLevel(sizeof(*door));
         memset(door, 0, sizeof(*door));
         P_AddThinker(&door->thinker);
         sec->ceilingdata = door;
@@ -1229,7 +1229,7 @@ dboolean Hexen_EV_VerticalDoor(line_t * line, mobj_t * thing)
     //
     // new door thinker
     //
-    door = Z_MallocTag(sizeof(*door), PU_LEVEL);
+    door = Z_MallocLevel(sizeof(*door));
     memset(door, 0, sizeof(*door));
     P_AddThinker(&door->thinker);
     sec->ceilingdata = door;

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -503,7 +503,7 @@ manual_floor://e6y
 
     // new floor thinker
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor; //jff 2/22/98
@@ -815,7 +815,7 @@ manual_stair://e6y
 
     // create new floor thinker for first step
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -932,7 +932,7 @@ manual_stair://e6y
         secnum = newsecnum;
 
         // create and initialize a thinker for the next step
-        floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+        floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
         memset(floor, 0, sizeof(*floor));
         P_AddThinker (&floor->thinker);
 
@@ -1075,7 +1075,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
     }
 
     //  Spawn rising slime
-    floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     s2->floordata = floor; //jff 2/22/98
@@ -1089,7 +1089,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
     floor->floordestheight = s3_floorheight;
 
     //  Spawn lowering donut-hole pillar
-    floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     s1->floordata = floor; //jff 2/22/98
@@ -1143,7 +1143,7 @@ void P_SpawnElevator(sector_t *sec, line_t *line, elevator_e type, fixed_t speed
 {
   elevator_t *elevator;
 
-  elevator = Z_Malloc(sizeof(*elevator), PU_LEVEL);
+  elevator = Z_MallocTag(sizeof(*elevator), PU_LEVEL);
   memset(elevator, 0, sizeof(*elevator));
   P_AddThinker(&elevator->thinker);
   sec->floordata = elevator; //jff 2/22/98
@@ -1268,7 +1268,7 @@ static void P_SpawnZDoomFloor(sector_t *sec, floor_e floortype, line_t *line,
 {
   floormove_t *floor;
 
-  floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+  floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
   memset(floor, 0, sizeof(*floor));
   P_AddThinker(&floor->thinker);
   sec->floordata = floor;
@@ -1464,7 +1464,7 @@ int Hexen_EV_DoFloor(line_t * line, byte * args, floor_e floortype)
         //      new floor thinker
         //
         rtn = 1;
-        floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
+        floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
         memset(floor, 0, sizeof(*floor));
         P_AddThinker(&floor->thinker);
         sec->floordata = floor;
@@ -1662,7 +1662,7 @@ static void ProcessStairSector(sector_t * sec, int type, int height,
     // new floor thinker
     //
     height += StepDelta;
-    floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     sec->floordata = floor;
@@ -1761,7 +1761,7 @@ static void P_SpawnZDoomStair(sector_t *sec, stair_e type, fixed_t stairstep,
 {
   floormove_t *floor;
 
-  floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
+  floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
   memset(floor, 0, sizeof(*floor));
   P_AddThinker(&floor->thinker);
   sec->floordata = floor;
@@ -2060,7 +2060,7 @@ void P_SpawnZDoomPillar(sector_t *sec, pillar_e type, fixed_t speed,
   pillar_t *pillar;
   fixed_t newheight;
 
-  pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
+  pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
   memset(pillar, 0, sizeof(*pillar));
   sec->floordata = pillar;
   sec->ceilingdata = pillar;
@@ -2176,7 +2176,7 @@ int EV_BuildPillar(line_t * line, byte * args, int crush)
             newHeight = sec->floorheight + (args[2] << FRACBITS);
         }
 
-        pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
+        pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
         memset(pillar, 0, sizeof(*pillar));
         sec->floordata = pillar;
         P_AddThinker(&pillar->thinker);
@@ -2233,7 +2233,7 @@ int EV_OpenPillar(line_t * line, byte * args)
             continue;
         }
         rtn = 1;
-        pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
+        pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
         memset(pillar, 0, sizeof(*pillar));
         sec->floordata = pillar;
         P_AddThinker(&pillar->thinker);
@@ -2389,7 +2389,7 @@ static void P_SpawnPlaneWaggle(sector_t *sector, int height, int speed,
 {
   planeWaggle_t *waggle;
 
-  waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL);
+  waggle = Z_MallocTag(sizeof(*waggle), PU_LEVEL);
   memset(waggle, 0, sizeof(*waggle));
   if (ceiling)
   {

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -503,7 +503,7 @@ manual_floor://e6y
 
     // new floor thinker
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor; //jff 2/22/98
@@ -815,7 +815,7 @@ manual_stair://e6y
 
     // create new floor thinker for first step
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -932,7 +932,7 @@ manual_stair://e6y
         secnum = newsecnum;
 
         // create and initialize a thinker for the next step
-        floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+        floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
         memset(floor, 0, sizeof(*floor));
         P_AddThinker (&floor->thinker);
 
@@ -1075,7 +1075,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
     }
 
     //  Spawn rising slime
-    floor = Z_Malloc(sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     s2->floordata = floor; //jff 2/22/98
@@ -1089,7 +1089,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
     floor->floordestheight = s3_floorheight;
 
     //  Spawn lowering donut-hole pillar
-    floor = Z_Malloc(sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     s1->floordata = floor; //jff 2/22/98
@@ -1143,7 +1143,7 @@ void P_SpawnElevator(sector_t *sec, line_t *line, elevator_e type, fixed_t speed
 {
   elevator_t *elevator;
 
-  elevator = Z_Malloc(sizeof(*elevator), PU_LEVEL, 0);
+  elevator = Z_Malloc(sizeof(*elevator), PU_LEVEL);
   memset(elevator, 0, sizeof(*elevator));
   P_AddThinker(&elevator->thinker);
   sec->floordata = elevator; //jff 2/22/98
@@ -1268,7 +1268,7 @@ static void P_SpawnZDoomFloor(sector_t *sec, floor_e floortype, line_t *line,
 {
   floormove_t *floor;
 
-  floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+  floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
   memset(floor, 0, sizeof(*floor));
   P_AddThinker(&floor->thinker);
   sec->floordata = floor;
@@ -1464,7 +1464,7 @@ int Hexen_EV_DoFloor(line_t * line, byte * args, floor_e floortype)
         //      new floor thinker
         //
         rtn = 1;
-        floor = Z_Malloc(sizeof(*floor), PU_LEVEL, 0);
+        floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
         memset(floor, 0, sizeof(*floor));
         P_AddThinker(&floor->thinker);
         sec->floordata = floor;
@@ -1662,7 +1662,7 @@ static void ProcessStairSector(sector_t * sec, int type, int height,
     // new floor thinker
     //
     height += StepDelta;
-    floor = Z_Malloc(sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     sec->floordata = floor;
@@ -1761,7 +1761,7 @@ static void P_SpawnZDoomStair(sector_t *sec, stair_e type, fixed_t stairstep,
 {
   floormove_t *floor;
 
-  floor = Z_Malloc(sizeof(*floor), PU_LEVEL, 0);
+  floor = Z_Malloc(sizeof(*floor), PU_LEVEL);
   memset(floor, 0, sizeof(*floor));
   P_AddThinker(&floor->thinker);
   sec->floordata = floor;
@@ -2060,7 +2060,7 @@ void P_SpawnZDoomPillar(sector_t *sec, pillar_e type, fixed_t speed,
   pillar_t *pillar;
   fixed_t newheight;
 
-  pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL, 0);
+  pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
   memset(pillar, 0, sizeof(*pillar));
   sec->floordata = pillar;
   sec->ceilingdata = pillar;
@@ -2176,7 +2176,7 @@ int EV_BuildPillar(line_t * line, byte * args, int crush)
             newHeight = sec->floorheight + (args[2] << FRACBITS);
         }
 
-        pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL, 0);
+        pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
         memset(pillar, 0, sizeof(*pillar));
         sec->floordata = pillar;
         P_AddThinker(&pillar->thinker);
@@ -2233,7 +2233,7 @@ int EV_OpenPillar(line_t * line, byte * args)
             continue;
         }
         rtn = 1;
-        pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL, 0);
+        pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
         memset(pillar, 0, sizeof(*pillar));
         sec->floordata = pillar;
         P_AddThinker(&pillar->thinker);
@@ -2389,7 +2389,7 @@ static void P_SpawnPlaneWaggle(sector_t *sector, int height, int speed,
 {
   planeWaggle_t *waggle;
 
-  waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL, 0);
+  waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL);
   memset(waggle, 0, sizeof(*waggle));
   if (ceiling)
   {

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -503,7 +503,7 @@ manual_floor://e6y
 
     // new floor thinker
     rtn = 1;
-    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel (sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor; //jff 2/22/98
@@ -815,7 +815,7 @@ manual_stair://e6y
 
     // create new floor thinker for first step
     rtn = 1;
-    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel (sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -932,7 +932,7 @@ manual_stair://e6y
         secnum = newsecnum;
 
         // create and initialize a thinker for the next step
-        floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+        floor = Z_MallocLevel (sizeof(*floor));
         memset(floor, 0, sizeof(*floor));
         P_AddThinker (&floor->thinker);
 
@@ -1075,7 +1075,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
     }
 
     //  Spawn rising slime
-    floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel(sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     s2->floordata = floor; //jff 2/22/98
@@ -1089,7 +1089,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
     floor->floordestheight = s3_floorheight;
 
     //  Spawn lowering donut-hole pillar
-    floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel(sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     s1->floordata = floor; //jff 2/22/98
@@ -1143,7 +1143,7 @@ void P_SpawnElevator(sector_t *sec, line_t *line, elevator_e type, fixed_t speed
 {
   elevator_t *elevator;
 
-  elevator = Z_MallocTag(sizeof(*elevator), PU_LEVEL);
+  elevator = Z_MallocLevel(sizeof(*elevator));
   memset(elevator, 0, sizeof(*elevator));
   P_AddThinker(&elevator->thinker);
   sec->floordata = elevator; //jff 2/22/98
@@ -1268,7 +1268,7 @@ static void P_SpawnZDoomFloor(sector_t *sec, floor_e floortype, line_t *line,
 {
   floormove_t *floor;
 
-  floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+  floor = Z_MallocLevel (sizeof(*floor));
   memset(floor, 0, sizeof(*floor));
   P_AddThinker(&floor->thinker);
   sec->floordata = floor;
@@ -1464,7 +1464,7 @@ int Hexen_EV_DoFloor(line_t * line, byte * args, floor_e floortype)
         //      new floor thinker
         //
         rtn = 1;
-        floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
+        floor = Z_MallocLevel(sizeof(*floor));
         memset(floor, 0, sizeof(*floor));
         P_AddThinker(&floor->thinker);
         sec->floordata = floor;
@@ -1662,7 +1662,7 @@ static void ProcessStairSector(sector_t * sec, int type, int height,
     // new floor thinker
     //
     height += StepDelta;
-    floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel(sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker(&floor->thinker);
     sec->floordata = floor;
@@ -1761,7 +1761,7 @@ static void P_SpawnZDoomStair(sector_t *sec, stair_e type, fixed_t stairstep,
 {
   floormove_t *floor;
 
-  floor = Z_MallocTag(sizeof(*floor), PU_LEVEL);
+  floor = Z_MallocLevel(sizeof(*floor));
   memset(floor, 0, sizeof(*floor));
   P_AddThinker(&floor->thinker);
   sec->floordata = floor;
@@ -2060,7 +2060,7 @@ void P_SpawnZDoomPillar(sector_t *sec, pillar_e type, fixed_t speed,
   pillar_t *pillar;
   fixed_t newheight;
 
-  pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
+  pillar = Z_MallocLevel(sizeof(*pillar));
   memset(pillar, 0, sizeof(*pillar));
   sec->floordata = pillar;
   sec->ceilingdata = pillar;
@@ -2176,7 +2176,7 @@ int EV_BuildPillar(line_t * line, byte * args, int crush)
             newHeight = sec->floorheight + (args[2] << FRACBITS);
         }
 
-        pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
+        pillar = Z_MallocLevel(sizeof(*pillar));
         memset(pillar, 0, sizeof(*pillar));
         sec->floordata = pillar;
         P_AddThinker(&pillar->thinker);
@@ -2233,7 +2233,7 @@ int EV_OpenPillar(line_t * line, byte * args)
             continue;
         }
         rtn = 1;
-        pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
+        pillar = Z_MallocLevel(sizeof(*pillar));
         memset(pillar, 0, sizeof(*pillar));
         sec->floordata = pillar;
         P_AddThinker(&pillar->thinker);
@@ -2389,7 +2389,7 @@ static void P_SpawnPlaneWaggle(sector_t *sector, int height, int speed,
 {
   planeWaggle_t *waggle;
 
-  waggle = Z_MallocTag(sizeof(*waggle), PU_LEVEL);
+  waggle = Z_MallocLevel(sizeof(*waggle));
   memset(waggle, 0, sizeof(*waggle));
   if (ceiling)
   {

--- a/prboom2/src/p_genlin.c
+++ b/prboom2/src/p_genlin.c
@@ -110,7 +110,7 @@ manual_floor:
 
     // new floor thinker
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -305,7 +305,7 @@ manual_ceiling:
 
     // new ceiling thinker
     rtn = 1;
-    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL, 0);
+    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
@@ -503,7 +503,7 @@ manual_lift:
 
     // Setup the plat thinker
     rtn = 1;
-    plat = Z_Malloc( sizeof(*plat), PU_LEVEL, 0);
+    plat = Z_Malloc( sizeof(*plat), PU_LEVEL);
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -665,7 +665,7 @@ manual_stair:
 
     // new floor thinker
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -766,7 +766,7 @@ manual_stair:
 
         sec = tsec;
         secnum = newsecnum;
-        floor = Z_Malloc (sizeof(*floor), PU_LEVEL, 0);
+        floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
 
         memset(floor, 0, sizeof(*floor));
         P_AddThinker (&floor->thinker);
@@ -852,7 +852,7 @@ manual_crusher:
 
     // new ceiling thinker
     rtn = 1;
-    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL, 0);
+    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
@@ -950,7 +950,7 @@ manual_locked:
 
     // new door thinker
     rtn = 1;
-    door = Z_Malloc (sizeof(*door), PU_LEVEL, 0);
+    door = Z_Malloc (sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98
@@ -1061,7 +1061,7 @@ manual_door:
 
     // new door thinker
     rtn = 1;
-    door = Z_Malloc (sizeof(*door), PU_LEVEL, 0);
+    door = Z_Malloc (sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98

--- a/prboom2/src/p_genlin.c
+++ b/prboom2/src/p_genlin.c
@@ -110,7 +110,7 @@ manual_floor:
 
     // new floor thinker
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -305,7 +305,7 @@ manual_ceiling:
 
     // new ceiling thinker
     rtn = 1;
-    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
+    ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
@@ -503,7 +503,7 @@ manual_lift:
 
     // Setup the plat thinker
     rtn = 1;
-    plat = Z_Malloc( sizeof(*plat), PU_LEVEL);
+    plat = Z_MallocTag( sizeof(*plat), PU_LEVEL);
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -665,7 +665,7 @@ manual_stair:
 
     // new floor thinker
     rtn = 1;
-    floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -766,7 +766,7 @@ manual_stair:
 
         sec = tsec;
         secnum = newsecnum;
-        floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+        floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
 
         memset(floor, 0, sizeof(*floor));
         P_AddThinker (&floor->thinker);
@@ -852,7 +852,7 @@ manual_crusher:
 
     // new ceiling thinker
     rtn = 1;
-    ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
+    ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
@@ -950,7 +950,7 @@ manual_locked:
 
     // new door thinker
     rtn = 1;
-    door = Z_Malloc (sizeof(*door), PU_LEVEL);
+    door = Z_MallocTag (sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98
@@ -1061,7 +1061,7 @@ manual_door:
 
     // new door thinker
     rtn = 1;
-    door = Z_Malloc (sizeof(*door), PU_LEVEL);
+    door = Z_MallocTag (sizeof(*door), PU_LEVEL);
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98

--- a/prboom2/src/p_genlin.c
+++ b/prboom2/src/p_genlin.c
@@ -110,7 +110,7 @@ manual_floor:
 
     // new floor thinker
     rtn = 1;
-    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel (sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -305,7 +305,7 @@ manual_ceiling:
 
     // new ceiling thinker
     rtn = 1;
-    ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
+    ceiling = Z_MallocLevel (sizeof(*ceiling));
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
@@ -503,7 +503,7 @@ manual_lift:
 
     // Setup the plat thinker
     rtn = 1;
-    plat = Z_MallocTag( sizeof(*plat), PU_LEVEL);
+    plat = Z_MallocLevel( sizeof(*plat));
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -665,7 +665,7 @@ manual_stair:
 
     // new floor thinker
     rtn = 1;
-    floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+    floor = Z_MallocLevel (sizeof(*floor));
     memset(floor, 0, sizeof(*floor));
     P_AddThinker (&floor->thinker);
     sec->floordata = floor;
@@ -766,7 +766,7 @@ manual_stair:
 
         sec = tsec;
         secnum = newsecnum;
-        floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+        floor = Z_MallocLevel (sizeof(*floor));
 
         memset(floor, 0, sizeof(*floor));
         P_AddThinker (&floor->thinker);
@@ -852,7 +852,7 @@ manual_crusher:
 
     // new ceiling thinker
     rtn = 1;
-    ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
+    ceiling = Z_MallocLevel (sizeof(*ceiling));
     memset(ceiling, 0, sizeof(*ceiling));
     P_AddThinker (&ceiling->thinker);
     sec->ceilingdata = ceiling; //jff 2/22/98
@@ -950,7 +950,7 @@ manual_locked:
 
     // new door thinker
     rtn = 1;
-    door = Z_MallocTag (sizeof(*door), PU_LEVEL);
+    door = Z_MallocLevel (sizeof(*door));
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98
@@ -1061,7 +1061,7 @@ manual_door:
 
     // new door thinker
     rtn = 1;
-    door = Z_MallocTag (sizeof(*door), PU_LEVEL);
+    door = Z_MallocLevel (sizeof(*door));
     memset(door, 0, sizeof(*door));
     P_AddThinker (&door->thinker);
     sec->ceilingdata = door; //jff 2/22/98

--- a/prboom2/src/p_lights.c
+++ b/prboom2/src/p_lights.c
@@ -180,7 +180,7 @@ void P_SpawnFireFlicker (sector_t*  sector)
 
   P_ClearNonGeneralizedSectorSpecial(sector);
 
-  flick = Z_Malloc ( sizeof(*flick), PU_LEVEL);
+  flick = Z_MallocTag ( sizeof(*flick), PU_LEVEL);
 
   memset(flick, 0, sizeof(*flick));
   P_AddThinker (&flick->thinker);
@@ -207,7 +207,7 @@ void P_SpawnLightFlash (sector_t* sector)
 
   P_ClearNonGeneralizedSectorSpecial(sector);
 
-  flash = Z_Malloc ( sizeof(*flash), PU_LEVEL);
+  flash = Z_MallocTag ( sizeof(*flash), PU_LEVEL);
 
   memset(flash, 0, sizeof(*flash));
   P_AddThinker (&flash->thinker);
@@ -240,7 +240,7 @@ void P_SpawnStrobeFlash
 {
   strobe_t* flash;
 
-  flash = Z_Malloc ( sizeof(*flash), PU_LEVEL);
+  flash = Z_MallocTag ( sizeof(*flash), PU_LEVEL);
 
   memset(flash, 0, sizeof(*flash));
   P_AddThinker (&flash->thinker);
@@ -276,7 +276,7 @@ void P_SpawnGlowingLight(sector_t*  sector)
 {
   glow_t* g;
 
-  g = Z_Malloc( sizeof(*g), PU_LEVEL);
+  g = Z_MallocTag( sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -530,7 +530,7 @@ static void P_SpawnZDoomLightGlow(sector_t *sec, short startlevel, short endleve
 {
   zdoom_glow_t *g;
 
-  g = Z_Malloc(sizeof(*g), PU_LEVEL);
+  g = Z_MallocTag(sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -614,7 +614,7 @@ static void P_SpawnZDoomLightFlicker(sector_t *sec, short upper, short lower)
 {
   zdoom_flicker_t *g;
 
-  g = Z_Malloc(sizeof(*g), PU_LEVEL);
+  g = Z_MallocTag(sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -647,7 +647,7 @@ static void P_SpawnZDoomLightStrobe(sector_t *sector, int upper, int lower,
 {
   strobe_t* g;
 
-  g = Z_Malloc ( sizeof(*g), PU_LEVEL);
+  g = Z_MallocTag ( sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker (&g->thinker);
@@ -821,7 +821,7 @@ dboolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
         think = false;
         sec = &sectors[secNum];
 
-        light = (light_t *) Z_Malloc(sizeof(light_t), PU_LEVEL);
+        light = (light_t *) Z_MallocTag(sizeof(light_t), PU_LEVEL);
         light->type = type;
         light->sector = sec;
         light->count = 0;
@@ -934,7 +934,7 @@ void P_SpawnPhasedLight(sector_t * sector, int base, int index)
 {
     phase_t *phase;
 
-    phase = Z_Malloc(sizeof(*phase), PU_LEVEL);
+    phase = Z_MallocTag(sizeof(*phase), PU_LEVEL);
     P_AddThinker(&phase->thinker);
     phase->sector = sector;
     sector->lightingdata = phase;

--- a/prboom2/src/p_lights.c
+++ b/prboom2/src/p_lights.c
@@ -180,7 +180,7 @@ void P_SpawnFireFlicker (sector_t*  sector)
 
   P_ClearNonGeneralizedSectorSpecial(sector);
 
-  flick = Z_Malloc ( sizeof(*flick), PU_LEVEL, 0);
+  flick = Z_Malloc ( sizeof(*flick), PU_LEVEL);
 
   memset(flick, 0, sizeof(*flick));
   P_AddThinker (&flick->thinker);
@@ -207,7 +207,7 @@ void P_SpawnLightFlash (sector_t* sector)
 
   P_ClearNonGeneralizedSectorSpecial(sector);
 
-  flash = Z_Malloc ( sizeof(*flash), PU_LEVEL, 0);
+  flash = Z_Malloc ( sizeof(*flash), PU_LEVEL);
 
   memset(flash, 0, sizeof(*flash));
   P_AddThinker (&flash->thinker);
@@ -240,7 +240,7 @@ void P_SpawnStrobeFlash
 {
   strobe_t* flash;
 
-  flash = Z_Malloc ( sizeof(*flash), PU_LEVEL, 0);
+  flash = Z_Malloc ( sizeof(*flash), PU_LEVEL);
 
   memset(flash, 0, sizeof(*flash));
   P_AddThinker (&flash->thinker);
@@ -276,7 +276,7 @@ void P_SpawnGlowingLight(sector_t*  sector)
 {
   glow_t* g;
 
-  g = Z_Malloc( sizeof(*g), PU_LEVEL, 0);
+  g = Z_Malloc( sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -530,7 +530,7 @@ static void P_SpawnZDoomLightGlow(sector_t *sec, short startlevel, short endleve
 {
   zdoom_glow_t *g;
 
-  g = Z_Malloc(sizeof(*g), PU_LEVEL, 0);
+  g = Z_Malloc(sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -614,7 +614,7 @@ static void P_SpawnZDoomLightFlicker(sector_t *sec, short upper, short lower)
 {
   zdoom_flicker_t *g;
 
-  g = Z_Malloc(sizeof(*g), PU_LEVEL, 0);
+  g = Z_Malloc(sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -647,7 +647,7 @@ static void P_SpawnZDoomLightStrobe(sector_t *sector, int upper, int lower,
 {
   strobe_t* g;
 
-  g = Z_Malloc ( sizeof(*g), PU_LEVEL, 0);
+  g = Z_Malloc ( sizeof(*g), PU_LEVEL);
 
   memset(g, 0, sizeof(*g));
   P_AddThinker (&g->thinker);
@@ -821,7 +821,7 @@ dboolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
         think = false;
         sec = &sectors[secNum];
 
-        light = (light_t *) Z_Malloc(sizeof(light_t), PU_LEVEL, 0);
+        light = (light_t *) Z_Malloc(sizeof(light_t), PU_LEVEL);
         light->type = type;
         light->sector = sec;
         light->count = 0;
@@ -934,7 +934,7 @@ void P_SpawnPhasedLight(sector_t * sector, int base, int index)
 {
     phase_t *phase;
 
-    phase = Z_Malloc(sizeof(*phase), PU_LEVEL, 0);
+    phase = Z_Malloc(sizeof(*phase), PU_LEVEL);
     P_AddThinker(&phase->thinker);
     phase->sector = sector;
     sector->lightingdata = phase;

--- a/prboom2/src/p_lights.c
+++ b/prboom2/src/p_lights.c
@@ -180,7 +180,7 @@ void P_SpawnFireFlicker (sector_t*  sector)
 
   P_ClearNonGeneralizedSectorSpecial(sector);
 
-  flick = Z_MallocTag ( sizeof(*flick), PU_LEVEL);
+  flick = Z_MallocLevel ( sizeof(*flick));
 
   memset(flick, 0, sizeof(*flick));
   P_AddThinker (&flick->thinker);
@@ -207,7 +207,7 @@ void P_SpawnLightFlash (sector_t* sector)
 
   P_ClearNonGeneralizedSectorSpecial(sector);
 
-  flash = Z_MallocTag ( sizeof(*flash), PU_LEVEL);
+  flash = Z_MallocLevel ( sizeof(*flash));
 
   memset(flash, 0, sizeof(*flash));
   P_AddThinker (&flash->thinker);
@@ -240,7 +240,7 @@ void P_SpawnStrobeFlash
 {
   strobe_t* flash;
 
-  flash = Z_MallocTag ( sizeof(*flash), PU_LEVEL);
+  flash = Z_MallocLevel ( sizeof(*flash));
 
   memset(flash, 0, sizeof(*flash));
   P_AddThinker (&flash->thinker);
@@ -276,7 +276,7 @@ void P_SpawnGlowingLight(sector_t*  sector)
 {
   glow_t* g;
 
-  g = Z_MallocTag( sizeof(*g), PU_LEVEL);
+  g = Z_MallocLevel( sizeof(*g));
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -530,7 +530,7 @@ static void P_SpawnZDoomLightGlow(sector_t *sec, short startlevel, short endleve
 {
   zdoom_glow_t *g;
 
-  g = Z_MallocTag(sizeof(*g), PU_LEVEL);
+  g = Z_MallocLevel(sizeof(*g));
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -614,7 +614,7 @@ static void P_SpawnZDoomLightFlicker(sector_t *sec, short upper, short lower)
 {
   zdoom_flicker_t *g;
 
-  g = Z_MallocTag(sizeof(*g), PU_LEVEL);
+  g = Z_MallocLevel(sizeof(*g));
 
   memset(g, 0, sizeof(*g));
   P_AddThinker(&g->thinker);
@@ -647,7 +647,7 @@ static void P_SpawnZDoomLightStrobe(sector_t *sector, int upper, int lower,
 {
   strobe_t* g;
 
-  g = Z_MallocTag ( sizeof(*g), PU_LEVEL);
+  g = Z_MallocLevel ( sizeof(*g));
 
   memset(g, 0, sizeof(*g));
   P_AddThinker (&g->thinker);
@@ -821,7 +821,7 @@ dboolean EV_SpawnLight(line_t * line, byte * arg, lighttype_t type)
         think = false;
         sec = &sectors[secNum];
 
-        light = (light_t *) Z_MallocTag(sizeof(light_t), PU_LEVEL);
+        light = (light_t *) Z_MallocLevel(sizeof(light_t));
         light->type = type;
         light->sector = sec;
         light->count = 0;
@@ -934,7 +934,7 @@ void P_SpawnPhasedLight(sector_t * sector, int base, int index)
 {
     phase_t *phase;
 
-    phase = Z_MallocTag(sizeof(*phase), PU_LEVEL);
+    phase = Z_MallocLevel(sizeof(*phase));
     P_AddThinker(&phase->thinker);
     phase->sector = sector;
     sector->lightingdata = phase;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2913,7 +2913,7 @@ dboolean P_CheckSector(sector_t* sector, int crunch)
 
 #include "z_bmalloc.h"
 
-IMPLEMENT_BLOCK_MEMORY_ALLOC_ZONE(secnodezone, sizeof(msecnode_t), PU_LEVEL, 256, "SecNodes");
+IMPLEMENT_BLOCK_MEMORY_ALLOC_ZONE(secnodezone, sizeof(msecnode_t), 256, "SecNodes");
 
 //
 // P_FreeSecNodeList
@@ -2964,7 +2964,7 @@ msecnode_t *P_GetSecnode(void)
 
   return headsecnode ?
     node = headsecnode, headsecnode = node->m_snext, node :
-  (msecnode_t *)(Z_Malloc(sizeof *node, PU_LEVEL));
+  (msecnode_t *)(Z_MallocTag(sizeof *node, PU_LEVEL));
 }
 
 //

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2964,7 +2964,7 @@ msecnode_t *P_GetSecnode(void)
 
   return headsecnode ?
     node = headsecnode, headsecnode = node->m_snext, node :
-  (msecnode_t *)(Z_Malloc(sizeof *node, PU_LEVEL, NULL));
+  (msecnode_t *)(Z_Malloc(sizeof *node, PU_LEVEL));
 }
 
 //

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2964,7 +2964,7 @@ msecnode_t *P_GetSecnode(void)
 
   return headsecnode ?
     node = headsecnode, headsecnode = node->m_snext, node :
-  (msecnode_t *)(Z_MallocTag(sizeof *node, PU_LEVEL));
+  (msecnode_t *)(Z_MallocLevel(sizeof *node));
 }
 
 //

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1444,7 +1444,7 @@ static PUREFUNC int P_FindDoomedNum(unsigned type)
 
   if (!hash)
   {
-    hash = Z_Malloc(sizeof(*hash) * num_mobj_types, PU_STATIC);
+    hash = Z_Malloc(sizeof(*hash) * num_mobj_types);
 
     for (i = 0; i < num_mobj_types; i++)
       hash[i].first = num_mobj_types;
@@ -1627,7 +1627,7 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   state_t*    st;
   mobjinfo_t* info;
 
-  mobj = Z_Malloc (sizeof(*mobj), PU_LEVEL);
+  mobj = Z_MallocTag (sizeof(*mobj), PU_LEVEL);
   memset (mobj, 0, sizeof (*mobj));
   info = &mobjinfo[type];
   mobj->type = type;

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1444,7 +1444,7 @@ static PUREFUNC int P_FindDoomedNum(unsigned type)
 
   if (!hash)
   {
-    hash = Z_Malloc(sizeof *hash * num_mobj_types, PU_CACHE, (void **) &hash);
+    hash = Z_Malloc(sizeof(*hash) * num_mobj_types, PU_STATIC);
 
     for (i = 0; i < num_mobj_types; i++)
       hash[i].first = num_mobj_types;
@@ -1627,7 +1627,7 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   state_t*    st;
   mobjinfo_t* info;
 
-  mobj = Z_Malloc (sizeof(*mobj), PU_LEVEL, NULL);
+  mobj = Z_Malloc (sizeof(*mobj), PU_LEVEL);
   memset (mobj, 0, sizeof (*mobj));
   info = &mobjinfo[type];
   mobj->type = type;

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1627,7 +1627,7 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   state_t*    st;
   mobjinfo_t* info;
 
-  mobj = Z_MallocTag (sizeof(*mobj), PU_LEVEL);
+  mobj = Z_MallocLevel (sizeof(*mobj));
   memset (mobj, 0, sizeof (*mobj));
   info = &mobjinfo[type];
   mobj->type = type;

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -370,7 +370,7 @@ int EV_DoZDoomPlat(int tag, line_t *line, plattype_e type, fixed_t height,
 
     rtn = 1;
 
-    plat = Z_Malloc(sizeof(*plat), PU_LEVEL, 0);
+    plat = Z_Malloc(sizeof(*plat), PU_LEVEL);
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -513,7 +513,7 @@ manual_plat://e6y
 
     // Create a thinker
     rtn = 1;
-    plat = Z_Malloc( sizeof(*plat), PU_LEVEL, 0);
+    plat = Z_Malloc( sizeof(*plat), PU_LEVEL);
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -838,7 +838,7 @@ int EV_DoHexenPlat(line_t * line, byte * args, plattype_e type, int amount)
         // Find lowest & highest floors around sector
         //
         rtn = 1;
-        plat = Z_Malloc(sizeof(*plat), PU_LEVEL, 0);
+        plat = Z_Malloc(sizeof(*plat), PU_LEVEL);
         memset(plat, 0, sizeof(*plat));
         P_AddThinker(&plat->thinker);
 

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -370,7 +370,7 @@ int EV_DoZDoomPlat(int tag, line_t *line, plattype_e type, fixed_t height,
 
     rtn = 1;
 
-    plat = Z_Malloc(sizeof(*plat), PU_LEVEL);
+    plat = Z_MallocTag(sizeof(*plat), PU_LEVEL);
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -513,7 +513,7 @@ manual_plat://e6y
 
     // Create a thinker
     rtn = 1;
-    plat = Z_Malloc( sizeof(*plat), PU_LEVEL);
+    plat = Z_MallocTag( sizeof(*plat), PU_LEVEL);
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -838,7 +838,7 @@ int EV_DoHexenPlat(line_t * line, byte * args, plattype_e type, int amount)
         // Find lowest & highest floors around sector
         //
         rtn = 1;
-        plat = Z_Malloc(sizeof(*plat), PU_LEVEL);
+        plat = Z_MallocTag(sizeof(*plat), PU_LEVEL);
         memset(plat, 0, sizeof(*plat));
         P_AddThinker(&plat->thinker);
 

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -370,7 +370,7 @@ int EV_DoZDoomPlat(int tag, line_t *line, plattype_e type, fixed_t height,
 
     rtn = 1;
 
-    plat = Z_MallocTag(sizeof(*plat), PU_LEVEL);
+    plat = Z_MallocLevel(sizeof(*plat));
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -513,7 +513,7 @@ manual_plat://e6y
 
     // Create a thinker
     rtn = 1;
-    plat = Z_MallocTag( sizeof(*plat), PU_LEVEL);
+    plat = Z_MallocLevel( sizeof(*plat));
     memset(plat, 0, sizeof(*plat));
     P_AddThinker(&plat->thinker);
 
@@ -838,7 +838,7 @@ int EV_DoHexenPlat(line_t * line, byte * args, plattype_e type, int amount)
         // Find lowest & highest floors around sector
         //
         rtn = 1;
-        plat = Z_MallocTag(sizeof(*plat), PU_LEVEL);
+        plat = Z_MallocLevel(sizeof(*plat));
         memset(plat, 0, sizeof(*plat));
         P_AddThinker(&plat->thinker);
 

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -1159,7 +1159,7 @@ void P_TrueUnArchiveThinkers(void) {
     switch (tc) {
       case tc_true_ceiling:
         {
-          ceiling_t *ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL, NULL);
+          ceiling_t *ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
           memcpy (ceiling, save_p, sizeof(*ceiling));
           save_p += sizeof(*ceiling);
           ceiling->sector = &sectors[(size_t)ceiling->sector];
@@ -1175,7 +1175,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_door:
         {
-          vldoor_t *door = Z_Malloc (sizeof(*door), PU_LEVEL, NULL);
+          vldoor_t *door = Z_Malloc (sizeof(*door), PU_LEVEL);
           memcpy (door, save_p, sizeof(*door));
           save_p += sizeof(*door);
           door->sector = &sectors[(size_t)door->sector];
@@ -1191,7 +1191,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_floor:
         {
-          floormove_t *floor = Z_Malloc (sizeof(*floor), PU_LEVEL, NULL);
+          floormove_t *floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
           memcpy (floor, save_p, sizeof(*floor));
           save_p += sizeof(*floor);
           floor->sector = &sectors[(size_t)floor->sector];
@@ -1203,7 +1203,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_plat:
         {
-          plat_t *plat = Z_Malloc (sizeof(*plat), PU_LEVEL, NULL);
+          plat_t *plat = Z_Malloc (sizeof(*plat), PU_LEVEL);
           memcpy (plat, save_p, sizeof(*plat));
           save_p += sizeof(*plat);
           plat->sector = &sectors[(size_t)plat->sector];
@@ -1219,7 +1219,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_flash:
         {
-          lightflash_t *flash = Z_Malloc (sizeof(*flash), PU_LEVEL, NULL);
+          lightflash_t *flash = Z_Malloc (sizeof(*flash), PU_LEVEL);
           memcpy (flash, save_p, sizeof(*flash));
           save_p += sizeof(*flash);
           flash->sector = &sectors[(size_t)flash->sector];
@@ -1231,7 +1231,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_strobe:
         {
-          strobe_t *strobe = Z_Malloc (sizeof(*strobe), PU_LEVEL, NULL);
+          strobe_t *strobe = Z_Malloc (sizeof(*strobe), PU_LEVEL);
           memcpy (strobe, save_p, sizeof(*strobe));
           save_p += sizeof(*strobe);
           strobe->sector = &sectors[(size_t)strobe->sector];
@@ -1243,7 +1243,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_glow:
         {
-          glow_t *glow = Z_Malloc (sizeof(*glow), PU_LEVEL, NULL);
+          glow_t *glow = Z_Malloc (sizeof(*glow), PU_LEVEL);
           memcpy (glow, save_p, sizeof(*glow));
           save_p += sizeof(*glow);
           glow->sector = &sectors[(size_t)glow->sector];
@@ -1255,7 +1255,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_zdoom_glow:
         {
-          zdoom_glow_t *glow = Z_Malloc (sizeof(*glow), PU_LEVEL, NULL);
+          zdoom_glow_t *glow = Z_Malloc (sizeof(*glow), PU_LEVEL);
           memcpy (glow, save_p, sizeof(*glow));
           save_p += sizeof(*glow);
           glow->sector = &sectors[(size_t)glow->sector];
@@ -1267,7 +1267,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_flicker:           // killough 10/4/98
         {
-          fireflicker_t *flicker = Z_Malloc (sizeof(*flicker), PU_LEVEL, NULL);
+          fireflicker_t *flicker = Z_Malloc (sizeof(*flicker), PU_LEVEL);
           memcpy (flicker, save_p, sizeof(*flicker));
           save_p += sizeof(*flicker);
           flicker->sector = &sectors[(size_t)flicker->sector];
@@ -1279,7 +1279,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_zdoom_flicker:
         {
-          zdoom_flicker_t *flicker = Z_Malloc (sizeof(*flicker), PU_LEVEL, NULL);
+          zdoom_flicker_t *flicker = Z_Malloc (sizeof(*flicker), PU_LEVEL);
           memcpy (flicker, save_p, sizeof(*flicker));
           save_p += sizeof(*flicker);
           flicker->sector = &sectors[(size_t)flicker->sector];
@@ -1292,7 +1292,7 @@ void P_TrueUnArchiveThinkers(void) {
         //jff 2/22/98 new case for elevators
       case tc_true_elevator:
         {
-          elevator_t *elevator = Z_Malloc (sizeof(*elevator), PU_LEVEL, NULL);
+          elevator_t *elevator = Z_Malloc (sizeof(*elevator), PU_LEVEL);
           memcpy (elevator, save_p, sizeof(*elevator));
           save_p += sizeof(*elevator);
           elevator->sector = &sectors[(size_t)elevator->sector];
@@ -1305,7 +1305,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_scroll:       // killough 3/7/98: scroll effect thinkers
         {
-          scroll_t *scroll = Z_Malloc (sizeof(scroll_t), PU_LEVEL, NULL);
+          scroll_t *scroll = Z_Malloc (sizeof(scroll_t), PU_LEVEL);
           memcpy (scroll, save_p, sizeof(scroll_t));
           save_p += sizeof(scroll_t);
           scroll->thinker.function = T_Scroll;
@@ -1315,7 +1315,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_pusher:   // phares 3/22/98: new Push/Pull effect thinkers
         {
-          pusher_t *pusher = Z_Malloc (sizeof(pusher_t), PU_LEVEL, NULL);
+          pusher_t *pusher = Z_Malloc (sizeof(pusher_t), PU_LEVEL);
           memcpy (pusher, save_p, sizeof(pusher_t));
           save_p += sizeof(pusher_t);
           pusher->thinker.function = T_Pusher;
@@ -1326,7 +1326,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_friction:
         {
-          friction_t *friction = Z_Malloc (sizeof(friction_t), PU_LEVEL, NULL);
+          friction_t *friction = Z_Malloc (sizeof(friction_t), PU_LEVEL);
           memcpy (friction, save_p, sizeof(friction_t));
           save_p += sizeof(friction_t);
           friction->thinker.function = T_Friction;
@@ -1336,7 +1336,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_light:
         {
-          light_t *light = Z_Malloc(sizeof(*light), PU_LEVEL, NULL);
+          light_t *light = Z_Malloc(sizeof(*light), PU_LEVEL);
           memcpy(light, save_p, sizeof(*light));
           save_p += sizeof(*light);
           light->sector = &sectors[(size_t)light->sector];
@@ -1347,7 +1347,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_phase:
         {
-          phase_t *phase = Z_Malloc(sizeof(*phase), PU_LEVEL, NULL);
+          phase_t *phase = Z_Malloc(sizeof(*phase), PU_LEVEL);
           memcpy(phase, save_p, sizeof(*phase));
           save_p += sizeof(*phase);
           phase->sector = &sectors[(size_t)phase->sector];
@@ -1359,7 +1359,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_acs:
         {
-          acs_t *acs = Z_Malloc(sizeof(*acs), PU_LEVEL, NULL);
+          acs_t *acs = Z_Malloc(sizeof(*acs), PU_LEVEL);
           memcpy(acs, save_p, sizeof(*acs));
           save_p += sizeof(*acs);
           acs->line = (intptr_t) acs->line != -1 ? &lines[(size_t) acs->line] : NULL;
@@ -1370,7 +1370,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_pillar:
         {
-          pillar_t *pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL, NULL);
+          pillar_t *pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
           memcpy(pillar, save_p, sizeof(*pillar));
           save_p += sizeof(*pillar);
           pillar->sector = &sectors[(size_t)pillar->sector];
@@ -1382,7 +1382,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_floor_waggle:
         {
-          planeWaggle_t *waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL, NULL);
+          planeWaggle_t *waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL);
           memcpy(waggle, save_p, sizeof(*waggle));
           save_p += sizeof(*waggle);
           waggle->sector = &sectors[(size_t)waggle->sector];
@@ -1394,7 +1394,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_ceiling_waggle:
         {
-          planeWaggle_t *waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL, NULL);
+          planeWaggle_t *waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL);
           memcpy(waggle, save_p, sizeof(*waggle));
           save_p += sizeof(*waggle);
           waggle->sector = &sectors[(size_t)waggle->sector];
@@ -1406,7 +1406,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_rotate:
         {
-          polyevent_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL, NULL);
+          polyevent_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL);
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_RotatePoly;
@@ -1416,7 +1416,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_move:
         {
-          polyevent_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL, NULL);
+          polyevent_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL);
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_MovePoly;
@@ -1426,7 +1426,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_door:
         {
-          polydoor_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL, NULL);
+          polydoor_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL);
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_PolyDoor;
@@ -1436,7 +1436,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_mobj:
         {
-          mobj_t *mobj = Z_Malloc(sizeof(mobj_t), PU_LEVEL, NULL);
+          mobj_t *mobj = Z_Malloc(sizeof(mobj_t), PU_LEVEL);
 
           // killough 2/14/98 -- insert pointers to thinkers into table, in order:
           mobj_count++;

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -1159,7 +1159,7 @@ void P_TrueUnArchiveThinkers(void) {
     switch (tc) {
       case tc_true_ceiling:
         {
-          ceiling_t *ceiling = Z_Malloc (sizeof(*ceiling), PU_LEVEL);
+          ceiling_t *ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
           memcpy (ceiling, save_p, sizeof(*ceiling));
           save_p += sizeof(*ceiling);
           ceiling->sector = &sectors[(size_t)ceiling->sector];
@@ -1175,7 +1175,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_door:
         {
-          vldoor_t *door = Z_Malloc (sizeof(*door), PU_LEVEL);
+          vldoor_t *door = Z_MallocTag (sizeof(*door), PU_LEVEL);
           memcpy (door, save_p, sizeof(*door));
           save_p += sizeof(*door);
           door->sector = &sectors[(size_t)door->sector];
@@ -1191,7 +1191,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_floor:
         {
-          floormove_t *floor = Z_Malloc (sizeof(*floor), PU_LEVEL);
+          floormove_t *floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
           memcpy (floor, save_p, sizeof(*floor));
           save_p += sizeof(*floor);
           floor->sector = &sectors[(size_t)floor->sector];
@@ -1203,7 +1203,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_plat:
         {
-          plat_t *plat = Z_Malloc (sizeof(*plat), PU_LEVEL);
+          plat_t *plat = Z_MallocTag (sizeof(*plat), PU_LEVEL);
           memcpy (plat, save_p, sizeof(*plat));
           save_p += sizeof(*plat);
           plat->sector = &sectors[(size_t)plat->sector];
@@ -1219,7 +1219,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_flash:
         {
-          lightflash_t *flash = Z_Malloc (sizeof(*flash), PU_LEVEL);
+          lightflash_t *flash = Z_MallocTag (sizeof(*flash), PU_LEVEL);
           memcpy (flash, save_p, sizeof(*flash));
           save_p += sizeof(*flash);
           flash->sector = &sectors[(size_t)flash->sector];
@@ -1231,7 +1231,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_strobe:
         {
-          strobe_t *strobe = Z_Malloc (sizeof(*strobe), PU_LEVEL);
+          strobe_t *strobe = Z_MallocTag (sizeof(*strobe), PU_LEVEL);
           memcpy (strobe, save_p, sizeof(*strobe));
           save_p += sizeof(*strobe);
           strobe->sector = &sectors[(size_t)strobe->sector];
@@ -1243,7 +1243,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_glow:
         {
-          glow_t *glow = Z_Malloc (sizeof(*glow), PU_LEVEL);
+          glow_t *glow = Z_MallocTag (sizeof(*glow), PU_LEVEL);
           memcpy (glow, save_p, sizeof(*glow));
           save_p += sizeof(*glow);
           glow->sector = &sectors[(size_t)glow->sector];
@@ -1255,7 +1255,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_zdoom_glow:
         {
-          zdoom_glow_t *glow = Z_Malloc (sizeof(*glow), PU_LEVEL);
+          zdoom_glow_t *glow = Z_MallocTag (sizeof(*glow), PU_LEVEL);
           memcpy (glow, save_p, sizeof(*glow));
           save_p += sizeof(*glow);
           glow->sector = &sectors[(size_t)glow->sector];
@@ -1267,7 +1267,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_flicker:           // killough 10/4/98
         {
-          fireflicker_t *flicker = Z_Malloc (sizeof(*flicker), PU_LEVEL);
+          fireflicker_t *flicker = Z_MallocTag (sizeof(*flicker), PU_LEVEL);
           memcpy (flicker, save_p, sizeof(*flicker));
           save_p += sizeof(*flicker);
           flicker->sector = &sectors[(size_t)flicker->sector];
@@ -1279,7 +1279,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_zdoom_flicker:
         {
-          zdoom_flicker_t *flicker = Z_Malloc (sizeof(*flicker), PU_LEVEL);
+          zdoom_flicker_t *flicker = Z_MallocTag (sizeof(*flicker), PU_LEVEL);
           memcpy (flicker, save_p, sizeof(*flicker));
           save_p += sizeof(*flicker);
           flicker->sector = &sectors[(size_t)flicker->sector];
@@ -1292,7 +1292,7 @@ void P_TrueUnArchiveThinkers(void) {
         //jff 2/22/98 new case for elevators
       case tc_true_elevator:
         {
-          elevator_t *elevator = Z_Malloc (sizeof(*elevator), PU_LEVEL);
+          elevator_t *elevator = Z_MallocTag (sizeof(*elevator), PU_LEVEL);
           memcpy (elevator, save_p, sizeof(*elevator));
           save_p += sizeof(*elevator);
           elevator->sector = &sectors[(size_t)elevator->sector];
@@ -1305,7 +1305,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_scroll:       // killough 3/7/98: scroll effect thinkers
         {
-          scroll_t *scroll = Z_Malloc (sizeof(scroll_t), PU_LEVEL);
+          scroll_t *scroll = Z_MallocTag (sizeof(scroll_t), PU_LEVEL);
           memcpy (scroll, save_p, sizeof(scroll_t));
           save_p += sizeof(scroll_t);
           scroll->thinker.function = T_Scroll;
@@ -1315,7 +1315,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_pusher:   // phares 3/22/98: new Push/Pull effect thinkers
         {
-          pusher_t *pusher = Z_Malloc (sizeof(pusher_t), PU_LEVEL);
+          pusher_t *pusher = Z_MallocTag (sizeof(pusher_t), PU_LEVEL);
           memcpy (pusher, save_p, sizeof(pusher_t));
           save_p += sizeof(pusher_t);
           pusher->thinker.function = T_Pusher;
@@ -1326,7 +1326,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_friction:
         {
-          friction_t *friction = Z_Malloc (sizeof(friction_t), PU_LEVEL);
+          friction_t *friction = Z_MallocTag (sizeof(friction_t), PU_LEVEL);
           memcpy (friction, save_p, sizeof(friction_t));
           save_p += sizeof(friction_t);
           friction->thinker.function = T_Friction;
@@ -1336,7 +1336,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_light:
         {
-          light_t *light = Z_Malloc(sizeof(*light), PU_LEVEL);
+          light_t *light = Z_MallocTag(sizeof(*light), PU_LEVEL);
           memcpy(light, save_p, sizeof(*light));
           save_p += sizeof(*light);
           light->sector = &sectors[(size_t)light->sector];
@@ -1347,7 +1347,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_phase:
         {
-          phase_t *phase = Z_Malloc(sizeof(*phase), PU_LEVEL);
+          phase_t *phase = Z_MallocTag(sizeof(*phase), PU_LEVEL);
           memcpy(phase, save_p, sizeof(*phase));
           save_p += sizeof(*phase);
           phase->sector = &sectors[(size_t)phase->sector];
@@ -1359,7 +1359,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_acs:
         {
-          acs_t *acs = Z_Malloc(sizeof(*acs), PU_LEVEL);
+          acs_t *acs = Z_MallocTag(sizeof(*acs), PU_LEVEL);
           memcpy(acs, save_p, sizeof(*acs));
           save_p += sizeof(*acs);
           acs->line = (intptr_t) acs->line != -1 ? &lines[(size_t) acs->line] : NULL;
@@ -1370,7 +1370,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_pillar:
         {
-          pillar_t *pillar = Z_Malloc(sizeof(*pillar), PU_LEVEL);
+          pillar_t *pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
           memcpy(pillar, save_p, sizeof(*pillar));
           save_p += sizeof(*pillar);
           pillar->sector = &sectors[(size_t)pillar->sector];
@@ -1382,7 +1382,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_floor_waggle:
         {
-          planeWaggle_t *waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL);
+          planeWaggle_t *waggle = Z_MallocTag(sizeof(*waggle), PU_LEVEL);
           memcpy(waggle, save_p, sizeof(*waggle));
           save_p += sizeof(*waggle);
           waggle->sector = &sectors[(size_t)waggle->sector];
@@ -1394,7 +1394,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_ceiling_waggle:
         {
-          planeWaggle_t *waggle = Z_Malloc(sizeof(*waggle), PU_LEVEL);
+          planeWaggle_t *waggle = Z_MallocTag(sizeof(*waggle), PU_LEVEL);
           memcpy(waggle, save_p, sizeof(*waggle));
           save_p += sizeof(*waggle);
           waggle->sector = &sectors[(size_t)waggle->sector];
@@ -1406,7 +1406,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_rotate:
         {
-          polyevent_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL);
+          polyevent_t *poly = Z_MallocTag(sizeof(*poly), PU_LEVEL);
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_RotatePoly;
@@ -1416,7 +1416,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_move:
         {
-          polyevent_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL);
+          polyevent_t *poly = Z_MallocTag(sizeof(*poly), PU_LEVEL);
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_MovePoly;
@@ -1426,7 +1426,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_door:
         {
-          polydoor_t *poly = Z_Malloc(sizeof(*poly), PU_LEVEL);
+          polydoor_t *poly = Z_MallocTag(sizeof(*poly), PU_LEVEL);
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_PolyDoor;
@@ -1436,7 +1436,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_mobj:
         {
-          mobj_t *mobj = Z_Malloc(sizeof(mobj_t), PU_LEVEL);
+          mobj_t *mobj = Z_MallocTag(sizeof(mobj_t), PU_LEVEL);
 
           // killough 2/14/98 -- insert pointers to thinkers into table, in order:
           mobj_count++;

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -1159,7 +1159,7 @@ void P_TrueUnArchiveThinkers(void) {
     switch (tc) {
       case tc_true_ceiling:
         {
-          ceiling_t *ceiling = Z_MallocTag (sizeof(*ceiling), PU_LEVEL);
+          ceiling_t *ceiling = Z_MallocLevel (sizeof(*ceiling));
           memcpy (ceiling, save_p, sizeof(*ceiling));
           save_p += sizeof(*ceiling);
           ceiling->sector = &sectors[(size_t)ceiling->sector];
@@ -1175,7 +1175,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_door:
         {
-          vldoor_t *door = Z_MallocTag (sizeof(*door), PU_LEVEL);
+          vldoor_t *door = Z_MallocLevel (sizeof(*door));
           memcpy (door, save_p, sizeof(*door));
           save_p += sizeof(*door);
           door->sector = &sectors[(size_t)door->sector];
@@ -1191,7 +1191,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_floor:
         {
-          floormove_t *floor = Z_MallocTag (sizeof(*floor), PU_LEVEL);
+          floormove_t *floor = Z_MallocLevel (sizeof(*floor));
           memcpy (floor, save_p, sizeof(*floor));
           save_p += sizeof(*floor);
           floor->sector = &sectors[(size_t)floor->sector];
@@ -1203,7 +1203,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_plat:
         {
-          plat_t *plat = Z_MallocTag (sizeof(*plat), PU_LEVEL);
+          plat_t *plat = Z_MallocLevel (sizeof(*plat));
           memcpy (plat, save_p, sizeof(*plat));
           save_p += sizeof(*plat);
           plat->sector = &sectors[(size_t)plat->sector];
@@ -1219,7 +1219,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_flash:
         {
-          lightflash_t *flash = Z_MallocTag (sizeof(*flash), PU_LEVEL);
+          lightflash_t *flash = Z_MallocLevel (sizeof(*flash));
           memcpy (flash, save_p, sizeof(*flash));
           save_p += sizeof(*flash);
           flash->sector = &sectors[(size_t)flash->sector];
@@ -1231,7 +1231,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_strobe:
         {
-          strobe_t *strobe = Z_MallocTag (sizeof(*strobe), PU_LEVEL);
+          strobe_t *strobe = Z_MallocLevel (sizeof(*strobe));
           memcpy (strobe, save_p, sizeof(*strobe));
           save_p += sizeof(*strobe);
           strobe->sector = &sectors[(size_t)strobe->sector];
@@ -1243,7 +1243,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_glow:
         {
-          glow_t *glow = Z_MallocTag (sizeof(*glow), PU_LEVEL);
+          glow_t *glow = Z_MallocLevel (sizeof(*glow));
           memcpy (glow, save_p, sizeof(*glow));
           save_p += sizeof(*glow);
           glow->sector = &sectors[(size_t)glow->sector];
@@ -1255,7 +1255,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_zdoom_glow:
         {
-          zdoom_glow_t *glow = Z_MallocTag (sizeof(*glow), PU_LEVEL);
+          zdoom_glow_t *glow = Z_MallocLevel (sizeof(*glow));
           memcpy (glow, save_p, sizeof(*glow));
           save_p += sizeof(*glow);
           glow->sector = &sectors[(size_t)glow->sector];
@@ -1267,7 +1267,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_flicker:           // killough 10/4/98
         {
-          fireflicker_t *flicker = Z_MallocTag (sizeof(*flicker), PU_LEVEL);
+          fireflicker_t *flicker = Z_MallocLevel (sizeof(*flicker));
           memcpy (flicker, save_p, sizeof(*flicker));
           save_p += sizeof(*flicker);
           flicker->sector = &sectors[(size_t)flicker->sector];
@@ -1279,7 +1279,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_zdoom_flicker:
         {
-          zdoom_flicker_t *flicker = Z_MallocTag (sizeof(*flicker), PU_LEVEL);
+          zdoom_flicker_t *flicker = Z_MallocLevel (sizeof(*flicker));
           memcpy (flicker, save_p, sizeof(*flicker));
           save_p += sizeof(*flicker);
           flicker->sector = &sectors[(size_t)flicker->sector];
@@ -1292,7 +1292,7 @@ void P_TrueUnArchiveThinkers(void) {
         //jff 2/22/98 new case for elevators
       case tc_true_elevator:
         {
-          elevator_t *elevator = Z_MallocTag (sizeof(*elevator), PU_LEVEL);
+          elevator_t *elevator = Z_MallocLevel (sizeof(*elevator));
           memcpy (elevator, save_p, sizeof(*elevator));
           save_p += sizeof(*elevator);
           elevator->sector = &sectors[(size_t)elevator->sector];
@@ -1305,7 +1305,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_scroll:       // killough 3/7/98: scroll effect thinkers
         {
-          scroll_t *scroll = Z_MallocTag (sizeof(scroll_t), PU_LEVEL);
+          scroll_t *scroll = Z_MallocLevel (sizeof(scroll_t));
           memcpy (scroll, save_p, sizeof(scroll_t));
           save_p += sizeof(scroll_t);
           scroll->thinker.function = T_Scroll;
@@ -1315,7 +1315,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_pusher:   // phares 3/22/98: new Push/Pull effect thinkers
         {
-          pusher_t *pusher = Z_MallocTag (sizeof(pusher_t), PU_LEVEL);
+          pusher_t *pusher = Z_MallocLevel (sizeof(pusher_t));
           memcpy (pusher, save_p, sizeof(pusher_t));
           save_p += sizeof(pusher_t);
           pusher->thinker.function = T_Pusher;
@@ -1326,7 +1326,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_friction:
         {
-          friction_t *friction = Z_MallocTag (sizeof(friction_t), PU_LEVEL);
+          friction_t *friction = Z_MallocLevel (sizeof(friction_t));
           memcpy (friction, save_p, sizeof(friction_t));
           save_p += sizeof(friction_t);
           friction->thinker.function = T_Friction;
@@ -1336,7 +1336,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_light:
         {
-          light_t *light = Z_MallocTag(sizeof(*light), PU_LEVEL);
+          light_t *light = Z_MallocLevel(sizeof(*light));
           memcpy(light, save_p, sizeof(*light));
           save_p += sizeof(*light);
           light->sector = &sectors[(size_t)light->sector];
@@ -1347,7 +1347,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_phase:
         {
-          phase_t *phase = Z_MallocTag(sizeof(*phase), PU_LEVEL);
+          phase_t *phase = Z_MallocLevel(sizeof(*phase));
           memcpy(phase, save_p, sizeof(*phase));
           save_p += sizeof(*phase);
           phase->sector = &sectors[(size_t)phase->sector];
@@ -1359,7 +1359,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_acs:
         {
-          acs_t *acs = Z_MallocTag(sizeof(*acs), PU_LEVEL);
+          acs_t *acs = Z_MallocLevel(sizeof(*acs));
           memcpy(acs, save_p, sizeof(*acs));
           save_p += sizeof(*acs);
           acs->line = (intptr_t) acs->line != -1 ? &lines[(size_t) acs->line] : NULL;
@@ -1370,7 +1370,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_pillar:
         {
-          pillar_t *pillar = Z_MallocTag(sizeof(*pillar), PU_LEVEL);
+          pillar_t *pillar = Z_MallocLevel(sizeof(*pillar));
           memcpy(pillar, save_p, sizeof(*pillar));
           save_p += sizeof(*pillar);
           pillar->sector = &sectors[(size_t)pillar->sector];
@@ -1382,7 +1382,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_floor_waggle:
         {
-          planeWaggle_t *waggle = Z_MallocTag(sizeof(*waggle), PU_LEVEL);
+          planeWaggle_t *waggle = Z_MallocLevel(sizeof(*waggle));
           memcpy(waggle, save_p, sizeof(*waggle));
           save_p += sizeof(*waggle);
           waggle->sector = &sectors[(size_t)waggle->sector];
@@ -1394,7 +1394,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_ceiling_waggle:
         {
-          planeWaggle_t *waggle = Z_MallocTag(sizeof(*waggle), PU_LEVEL);
+          planeWaggle_t *waggle = Z_MallocLevel(sizeof(*waggle));
           memcpy(waggle, save_p, sizeof(*waggle));
           save_p += sizeof(*waggle);
           waggle->sector = &sectors[(size_t)waggle->sector];
@@ -1406,7 +1406,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_rotate:
         {
-          polyevent_t *poly = Z_MallocTag(sizeof(*poly), PU_LEVEL);
+          polyevent_t *poly = Z_MallocLevel(sizeof(*poly));
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_RotatePoly;
@@ -1416,7 +1416,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_move:
         {
-          polyevent_t *poly = Z_MallocTag(sizeof(*poly), PU_LEVEL);
+          polyevent_t *poly = Z_MallocLevel(sizeof(*poly));
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_MovePoly;
@@ -1426,7 +1426,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_poly_door:
         {
-          polydoor_t *poly = Z_MallocTag(sizeof(*poly), PU_LEVEL);
+          polydoor_t *poly = Z_MallocLevel(sizeof(*poly));
           memcpy(poly, save_p, sizeof(*poly));
           save_p += sizeof(*poly);
           poly->thinker.function = T_PolyDoor;
@@ -1436,7 +1436,7 @@ void P_TrueUnArchiveThinkers(void) {
 
       case tc_true_mobj:
         {
-          mobj_t *mobj = Z_MallocTag(sizeof(mobj_t), PU_LEVEL);
+          mobj_t *mobj = Z_MallocLevel(sizeof(mobj_t));
 
           // killough 2/14/98 -- insert pointers to thinkers into table, in order:
           mobj_count++;

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -242,7 +242,7 @@ static dboolean CheckForIdentifier(int lumpnum, const byte *id, size_t length)
 
   if (W_LumpLength(lumpnum) >= length)
   {
-    const char *data = W_CacheLumpNum(lumpnum);
+    const char *data = W_LumpByNum(lumpnum);
 
     if (!memcmp(data, id, length))
       result = true;
@@ -378,7 +378,7 @@ static void P_LoadVertexes (int lump)
 
   // Load data into cache.
   // cph 2006/07/29 - cast to mapvertex_t here, making the loop below much neater
-  data = (const mapvertex_t *)W_CacheLumpNum(lump);
+  data = (const mapvertex_t *)W_LumpByNum(lump);
 
   // Copy and convert vertex coordinates,
   // internal representation as fixed.
@@ -410,7 +410,7 @@ static void P_LoadVertexes2(int lump, int gllump)
 
   if (gllump >= 0)  // check for glVertices
   {
-    gldata = W_CacheLumpNum(gllump);
+    gldata = W_LumpByNum(gllump);
 
     if (nodesVersion == 2) // 32 bit GL_VERT format (16.16 fixed)
     {
@@ -442,7 +442,7 @@ static void P_LoadVertexes2(int lump, int gllump)
     }
   }
 
-  ml = (const mapvertex_t*) W_CacheLumpNum(lump);
+  ml = (const mapvertex_t*) W_LumpByNum(lump);
 
   for (i=0; i < firstglvertex; i++)
   {
@@ -506,7 +506,7 @@ static void P_LoadSegs (int lump)
 
   numsegs = W_LumpLength(lump) / sizeof(mapseg_t);
   segs = calloc_IfSameLevel(segs, numsegs, sizeof(seg_t));
-  data = (const mapseg_t *)W_CacheLumpNum(lump); // cph - wad lump handling updated
+  data = (const mapseg_t *)W_LumpByNum(lump); // cph - wad lump handling updated
 
   if ((!data) || (!numsegs))
     I_Error("P_LoadSegs: no segs in level");
@@ -646,7 +646,7 @@ static void P_LoadSegs_V4(int lump)
 
   numsegs = W_LumpLength(lump) / sizeof(mapseg_v4_t);
   segs = calloc_IfSameLevel(segs, numsegs, sizeof(seg_t));
-  data = (const mapseg_v4_t *)W_CacheLumpNum(lump);
+  data = (const mapseg_v4_t *)W_LumpByNum(lump);
 
   if ((!data) || (!numsegs))
     I_Error("P_LoadSegs_V4: no segs in level");
@@ -776,7 +776,7 @@ static void P_LoadGLSegs(int lump)
   numsegs = W_LumpLength(lump) / sizeof(glseg_t);
   segs = malloc_IfSameLevel(segs, numsegs * sizeof(seg_t));
   memset(segs, 0, numsegs * sizeof(seg_t));
-  ml = (const glseg_t*)W_CacheLumpNum(lump);
+  ml = (const glseg_t*)W_LumpByNum(lump);
 
   if ((!ml) || (!numsegs))
     I_Error("P_LoadGLSegs: no glsegs in level");
@@ -832,7 +832,7 @@ static void P_LoadSubsectors (int lump)
 
   numsubsectors = W_LumpLength (lump) / sizeof(mapsubsector_t);
   subsectors = calloc_IfSameLevel(subsectors, numsubsectors, sizeof(subsector_t));
-  data = (const mapsubsector_t *)W_CacheLumpNum(lump);
+  data = (const mapsubsector_t *)W_LumpByNum(lump);
 
   if ((!data) || (!numsubsectors))
     I_Error("P_LoadSubsectors: no subsectors in level");
@@ -853,7 +853,7 @@ static void P_LoadSubsectors_V4(int lump)
 
   numsubsectors = W_LumpLength (lump) / sizeof(mapsubsector_v4_t);
   subsectors = calloc_IfSameLevel(subsectors, numsubsectors, sizeof(subsector_t));
-  data = (const mapsubsector_v4_t *)W_CacheLumpNum(lump);
+  data = (const mapsubsector_v4_t *)W_LumpByNum(lump);
 
   if ((!data) || (!numsubsectors))
     I_Error("P_LoadSubsectors_V4: no subsectors in level");
@@ -878,7 +878,7 @@ static void P_LoadSectors (int lump)
 
   numsectors = W_LumpLength (lump) / sizeof(mapsector_t);
   sectors = calloc_IfSameLevel(sectors, numsectors, sizeof(sector_t));
-  data = W_CacheLumpNum (lump); // cph - wad lump handling updated
+  data = W_LumpByNum (lump); // cph - wad lump handling updated
 
   for (i=0; i<numsectors; i++)
     {
@@ -946,7 +946,7 @@ static void P_LoadNodes (int lump)
 
   numnodes = W_LumpLength (lump) / sizeof(mapnode_t);
   nodes = malloc_IfSameLevel(nodes, numnodes * sizeof(node_t));
-  data = W_CacheLumpNum (lump); // cph - wad lump handling updated
+  data = W_LumpByNum (lump); // cph - wad lump handling updated
 
   if ((!data) || (!numnodes))
   {
@@ -1008,7 +1008,7 @@ static void P_LoadNodes_V4(int lump)
 
   numnodes = (W_LumpLength (lump) - 8) / sizeof(mapnode_v4_t);
   nodes = malloc_IfSameLevel(nodes, numnodes * sizeof(node_t));
-  data = W_CacheLumpNum (lump); // cph - wad lump handling updated
+  data = W_LumpByNum (lump); // cph - wad lump handling updated
 
   // skip header
   data = data + 8;
@@ -1147,7 +1147,7 @@ static void P_LoadZNodes(int lump, int glnodes, int compressed)
   byte *output;
 #endif
 
-  data = W_CacheLumpNum(lump);
+  data = W_LumpByNum(lump);
   len =  W_LumpLength(lump);
 
   if (compressed == ZDOOM_ZNOD_NODES)
@@ -1383,7 +1383,7 @@ static void P_LoadThings (int lump)
   mobj_t **mobjlist;
 
   numthings = W_LumpLength (lump) / map_format.mapthing_size;
-  data = W_CacheLumpNum(lump);
+  data = W_LumpByNum(lump);
   doom_data = (const doom_mapthing_t*) data;
   mobjlist = malloc(numthings * sizeof(mobjlist[0]));
 
@@ -1606,7 +1606,7 @@ static void P_LoadLineDefs (int lump)
 
   numlines = W_LumpLength (lump) / map_format.maplinedef_size;
   lines = calloc_IfSameLevel(lines, numlines, sizeof(line_t));
-  data = W_CacheLumpNum (lump); // cph - wad lump handling updated
+  data = W_LumpByNum (lump); // cph - wad lump handling updated
 
   for (i=0; i<numlines; i++)
     {
@@ -1972,7 +1972,7 @@ void P_PostProcessZDoomSidedefSpecial(side_t *sd, const mapsidedef_t *msd, secto
 
 static void P_LoadSideDefs2(int lump)
 {
-  const byte *data = W_CacheLumpNum(lump); // cph - const*, wad lump handling updated
+  const byte *data = W_LumpByNum(lump); // cph - const*, wad lump handling updated
   int  i;
 
   for (i=0; i<numsides; i++)
@@ -2403,7 +2403,7 @@ static void P_LoadBlockMap (int lump)
   {
     long i;
     // cph - const*, wad lump handling updated
-    const short *wadblockmaplump = W_CacheLumpNum(lump);
+    const short *wadblockmaplump = W_LumpByNum(lump);
     blockmaplump = malloc_IfSameLevel(blockmaplump, sizeof(*blockmaplump) * count);
 
     // killough 3/1/98: Expand wad blockmap into larger internal one,
@@ -2463,7 +2463,7 @@ static void P_LoadBlockMap (int lump)
 static void P_LoadReject(int lumpnum, int totallines)
 {
   rejectlump = lumpnum + ML_REJECT;
-  rejectmatrix = W_CacheLumpNum(rejectlump);
+  rejectmatrix = W_LumpByNum(rejectlump);
 
   //e6y: check for overflow
   RejectOverrun(rejectlump, &rejectmatrix, totallines);

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2526,7 +2526,7 @@ static int P_GroupLines (void)
   }
 
   {  // allocate line tables for each sector
-    line_t **linebuffer = Z_MallocTag(total*sizeof(line_t *), PU_LEVEL);
+    line_t **linebuffer = Z_MallocLevel(total*sizeof(line_t *));
     // e6y: REJECT overrun emulation code
     // moved to P_LoadReject
 
@@ -2945,7 +2945,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
   // Make sure all sounds are stopped before Z_FreeTag.
   S_Start();
 
-  Z_FreeTag(PU_LEVEL);
+  Z_FreeLevel();
   rejectlump = -1;
 
   P_InitThinkers();

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -246,8 +246,6 @@ static dboolean CheckForIdentifier(int lumpnum, const byte *id, size_t length)
 
     if (!memcmp(data, id, length))
       result = true;
-
-    W_UnlockLumpNum(lumpnum);
   }
 
   return result;
@@ -389,9 +387,6 @@ static void P_LoadVertexes (int lump)
       vertexes[i].x = LittleShort(data[i].x)<<FRACBITS;
       vertexes[i].y = LittleShort(data[i].y)<<FRACBITS;
     }
-
-  // Free buffer memory.
-  W_UnlockLumpNum(lump);
 }
 
 /*******************************************
@@ -445,7 +440,6 @@ static void P_LoadVertexes2(int lump, int gllump)
         ml++;
       }
     }
-    W_UnlockLumpNum(gllump);
   }
 
   ml = (const mapvertex_t*) W_CacheLumpNum(lump);
@@ -456,7 +450,6 @@ static void P_LoadVertexes2(int lump, int gllump)
     vertexes[i].y = LittleShort(ml->y)<<FRACBITS;
     ml++;
   }
-  W_UnlockLumpNum(lump);
 }
 
 
@@ -644,8 +637,6 @@ static void P_LoadSegs (int lump)
       // of DV.wad, map 5
       li->offset = GetOffset(li->v1, (ml->side ? ldef->v2 : ldef->v1));
     }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 static void P_LoadSegs_V4(int lump)
@@ -766,8 +757,6 @@ static void P_LoadSegs_V4(int lump)
     // of DV.wad, map 5
     li->offset = GetOffset(li->v1, (ml->side ? ldef->v2 : ldef->v1));
   }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 
@@ -828,7 +817,6 @@ static void P_LoadGLSegs(int lump)
     }
     ml++;
   }
-  W_UnlockLumpNum(lump);
 }
 
 //
@@ -855,8 +843,6 @@ static void P_LoadSubsectors (int lump)
     subsectors[i].numlines  = (unsigned short)LittleShort(data[i].numsegs );
     subsectors[i].firstline = (unsigned short)LittleShort(data[i].firstseg);
   }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 static void P_LoadSubsectors_V4(int lump)
@@ -878,8 +864,6 @@ static void P_LoadSubsectors_V4(int lump)
     subsectors[i].numlines = (unsigned short)LittleShort(data[i].numsegs);
     subsectors[i].firstline = LittleLong(data[i].firstseg);
   }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 //
@@ -947,8 +931,6 @@ static void P_LoadSectors (int lump)
       // zdoom
       ss->gravity = GRAVITY;
     }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 
@@ -1017,8 +999,6 @@ static void P_LoadNodes (int lump)
             no->bbox[j][k] = LittleShort(mn->bbox[j][k])<<FRACBITS;
         }
     }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 static void P_LoadNodes_V4(int lump)
@@ -1063,8 +1043,6 @@ static void P_LoadNodes_V4(int lump)
             no->bbox[j][k] = LittleShort(mn->bbox[j][k])<<FRACBITS;
         }
     }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 static void CheckZNodesOverflow(int *size, int count)
@@ -1221,8 +1199,6 @@ static void P_LoadZNodes(int lump, int glnodes, int compressed)
 	if (inflateEnd(zstream) != Z_OK)
 	    I_Error("P_LoadZNodes: Error during ZDoom nodes decompression shut-down!");
 
-	// release the original data lump
-	W_UnlockLumpNum(lump);
 	free(zstream);
 #else
 	I_Error("P_LoadZNodes: Compressed ZDoom nodes are not supported!");
@@ -1372,9 +1348,7 @@ static void P_LoadZNodes(int lump, int glnodes, int compressed)
 #ifdef HAVE_LIBZ
   if (compressed == ZDOOM_ZNOD_NODES)
     Z_Free(output);
-  else
 #endif
-  W_UnlockLumpNum(lump); // cph - release the data
 }
 
 #ifdef GL_DOOM
@@ -1476,8 +1450,6 @@ static void P_LoadThings (int lump)
   {
     P_InitCreatureCorpseQueue(false);   // false = do NOT scan for corpses
   }
-
-  W_UnlockLumpNum(lump); // cph - release the data
 
 #ifdef GL_DOOM
   if (V_IsOpenGLMode())
@@ -1767,8 +1739,6 @@ static void P_LoadLineDefs (int lump)
       if (ld->sidenum[0] != NO_INDEX && ld->special)
         sides[*ld->sidenum].special = ld->special;
     }
-
-  W_UnlockLumpNum(lump); // cph - release the lump
 }
 
 void P_PostProcessCompatibleLineSpecial(line_t *ld)
@@ -2025,8 +1995,6 @@ static void P_LoadSideDefs2(int lump)
 
     map_format.post_process_sidedef_special(sd, msd, sec, i);
   }
-
-  W_UnlockLumpNum(lump); // cph - release the lump
 }
 
 //
@@ -2454,8 +2422,6 @@ static void P_LoadBlockMap (int lump)
       blockmaplump[i] = t == -1 ? -1l : (long) t & 0xffff;
     }
 
-    W_UnlockLumpNum(lump); // cph - unlock the lump
-
     bmaporgx = blockmaplump[0]<<FRACBITS;
     bmaporgy = blockmaplump[1]<<FRACBITS;
     bmapwidth = blockmaplump[2];
@@ -2496,9 +2462,6 @@ static void P_LoadBlockMap (int lump)
 
 static void P_LoadReject(int lumpnum, int totallines)
 {
-  // dump any old cached reject lump, then cache the new one
-  if (rejectlump != -1)
-    W_UnlockLumpNum(rejectlump);
   rejectlump = lumpnum + ML_REJECT;
   rejectmatrix = W_CacheLumpNum(rejectlump);
 
@@ -2983,10 +2946,7 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
   S_Start();
 
   Z_FreeTag(PU_LEVEL);
-  if (rejectlump != -1) { // cph - unlock the reject table
-    W_UnlockLumpNum(rejectlump);
-    rejectlump = -1;
-  }
+  rejectlump = -1;
 
   P_InitThinkers();
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1181,7 +1181,7 @@ static void P_LoadZNodes(int lump, int glnodes, int compressed)
 	// first estimate for compression rate:
 	// output buffer size == 2.5 * input size
 	outlen = 2.5 * len;
-	output = Z_Malloc(outlen, PU_STATIC, 0);
+	output = Z_Malloc(outlen, PU_STATIC);
 
 	// initialize stream state for decompression
 	zstream = malloc(sizeof(*zstream));
@@ -2563,7 +2563,7 @@ static int P_GroupLines (void)
   }
 
   {  // allocate line tables for each sector
-    line_t **linebuffer = Z_Malloc(total*sizeof(line_t *), PU_LEVEL, 0);
+    line_t **linebuffer = Z_Malloc(total*sizeof(line_t *), PU_LEVEL);
     // e6y: REJECT overrun emulation code
     // moved to P_LoadReject
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1159,7 +1159,7 @@ static void P_LoadZNodes(int lump, int glnodes, int compressed)
 	// first estimate for compression rate:
 	// output buffer size == 2.5 * input size
 	outlen = 2.5 * len;
-	output = Z_Malloc(outlen, PU_STATIC);
+	output = Z_Malloc(outlen);
 
 	// initialize stream state for decompression
 	zstream = malloc(sizeof(*zstream));
@@ -2526,7 +2526,7 @@ static int P_GroupLines (void)
   }
 
   {  // allocate line tables for each sector
-    line_t **linebuffer = Z_Malloc(total*sizeof(line_t *), PU_LEVEL);
+    line_t **linebuffer = Z_MallocTag(total*sizeof(line_t *), PU_LEVEL);
     // e6y: REJECT overrun emulation code
     // moved to P_LoadReject
 
@@ -2977,11 +2977,6 @@ void P_SetupLevel(int episode, int map, int playermask, skill_t skill)
 
   // figgi 10/19/00 -- check for gl lumps and load them
   P_GetNodesVersion(lumpnum,gl_lumpnum);
-
-  // e6y: speedup of level reloading
-  // Most of level's structures now are allocated with PU_STATIC instead of PU_LEVEL
-  // It is important for OpenGL, because in case of the same data in memory
-  // we can skip recalculation of much stuff
 
   samelevel =
     (map == current_map) &&

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -247,7 +247,6 @@ void P_InitPicAnims (void)
     lastanim++;
   }
 
-  if (lump != -1) W_UnlockLumpNum(lump);
   MarkAnimatedTextures();//e6y
 }
 

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -3148,7 +3148,7 @@ void P_UpdateSpecials (void)
 static void Add_Scroller(int type, fixed_t dx, fixed_t dy,
                          int control, int affectee, int accel)
 {
-  scroll_t *s = Z_Malloc(sizeof *s, PU_LEVEL, 0);
+  scroll_t *s = Z_Malloc(sizeof *s, PU_LEVEL);
   s->thinker.function = T_Scroll;
   s->type = type;
   s->dx = dx;
@@ -4214,7 +4214,7 @@ static void P_SpawnScrollers(void)
 
 static void Add_Friction(int friction, int movefactor, int affectee)
 {
-    friction_t *f = Z_Malloc(sizeof *f, PU_LEVEL, 0);
+    friction_t *f = Z_Malloc(sizeof *f, PU_LEVEL);
 
     f->thinker.function/*.acp1*/ = /*(actionf_p1) */T_Friction;
     f->friction = friction;
@@ -4471,7 +4471,7 @@ static void P_SpawnFriction(void)
 
 static void Add_Pusher(int type, int x_mag, int y_mag, mobj_t* source, int affectee)
 {
-    pusher_t *p = Z_Malloc(sizeof *p, PU_LEVEL, 0);
+    pusher_t *p = Z_Malloc(sizeof *p, PU_LEVEL);
 
     p->thinker.function = T_Pusher;
     p->source = source;
@@ -5082,7 +5082,7 @@ void P_InitTerrainTypes(void)
     if (!raven) return;
 
     size = (numflats + 1) * sizeof(int);
-    TerrainTypes = Z_Malloc(size, PU_STATIC, 0);
+    TerrainTypes = Z_Malloc(size, PU_STATIC);
     memset(TerrainTypes, 0, size);
     for (i = 0; TerrainTypeDefs[hexen][i].type != -1; i++)
     {

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -3147,7 +3147,7 @@ void P_UpdateSpecials (void)
 static void Add_Scroller(int type, fixed_t dx, fixed_t dy,
                          int control, int affectee, int accel)
 {
-  scroll_t *s = Z_MallocTag(sizeof *s, PU_LEVEL);
+  scroll_t *s = Z_MallocLevel(sizeof *s);
   s->thinker.function = T_Scroll;
   s->type = type;
   s->dx = dx;
@@ -4213,7 +4213,7 @@ static void P_SpawnScrollers(void)
 
 static void Add_Friction(int friction, int movefactor, int affectee)
 {
-    friction_t *f = Z_MallocTag(sizeof *f, PU_LEVEL);
+    friction_t *f = Z_MallocLevel(sizeof *f);
 
     f->thinker.function/*.acp1*/ = /*(actionf_p1) */T_Friction;
     f->friction = friction;
@@ -4470,7 +4470,7 @@ static void P_SpawnFriction(void)
 
 static void Add_Pusher(int type, int x_mag, int y_mag, mobj_t* source, int affectee)
 {
-    pusher_t *p = Z_MallocTag(sizeof *p, PU_LEVEL);
+    pusher_t *p = Z_MallocLevel(sizeof *p);
 
     p->thinker.function = T_Pusher;
     p->source = source;

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -3147,7 +3147,7 @@ void P_UpdateSpecials (void)
 static void Add_Scroller(int type, fixed_t dx, fixed_t dy,
                          int control, int affectee, int accel)
 {
-  scroll_t *s = Z_Malloc(sizeof *s, PU_LEVEL);
+  scroll_t *s = Z_MallocTag(sizeof *s, PU_LEVEL);
   s->thinker.function = T_Scroll;
   s->type = type;
   s->dx = dx;
@@ -4213,7 +4213,7 @@ static void P_SpawnScrollers(void)
 
 static void Add_Friction(int friction, int movefactor, int affectee)
 {
-    friction_t *f = Z_Malloc(sizeof *f, PU_LEVEL);
+    friction_t *f = Z_MallocTag(sizeof *f, PU_LEVEL);
 
     f->thinker.function/*.acp1*/ = /*(actionf_p1) */T_Friction;
     f->friction = friction;
@@ -4470,7 +4470,7 @@ static void P_SpawnFriction(void)
 
 static void Add_Pusher(int type, int x_mag, int y_mag, mobj_t* source, int affectee)
 {
-    pusher_t *p = Z_Malloc(sizeof *p, PU_LEVEL);
+    pusher_t *p = Z_MallocTag(sizeof *p, PU_LEVEL);
 
     p->thinker.function = T_Pusher;
     p->source = source;
@@ -5081,7 +5081,7 @@ void P_InitTerrainTypes(void)
     if (!raven) return;
 
     size = (numflats + 1) * sizeof(int);
-    TerrainTypes = Z_Malloc(size, PU_STATIC);
+    TerrainTypes = Z_Malloc(size);
     memset(TerrainTypes, 0, size);
     for (i = 0; TerrainTypeDefs[hexen][i].type != -1; i++)
     {

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -202,7 +202,7 @@ void P_InitPicAnims (void)
   {
     lump = W_GetNumForName("ANIMATED"); // cph - new wad lump handling
     //jff 3/23/98 read from predefined or wad lump instead of table
-    animdefs = (const animdef_t *)W_CacheLumpNum(lump);
+    animdefs = (const animdef_t *)W_LumpByNum(lump);
   }
 
   lastanim = anims;

--- a/prboom2/src/p_switch.c
+++ b/prboom2/src/p_switch.c
@@ -119,7 +119,7 @@ void P_InitSwitchList(void)
     lump = W_GetNumForName("SWITCHES"); // cph - new wad lump handling
 
     //jff 3/23/98 read the switch table from a predefined lump
-    alphSwitchList = (const switchlist_t *)W_CacheLumpNum(lump);
+    alphSwitchList = (const switchlist_t *)W_LumpByNum(lump);
   }
 
   for (i=0;;i++)

--- a/prboom2/src/p_switch.c
+++ b/prboom2/src/p_switch.c
@@ -157,7 +157,6 @@ void P_InitSwitchList(void)
 
   numswitches = index / 2;
   switchlist[index] = -1;
-  if (lump != -1) W_UnlockLumpNum(lump);
 }
 
 //

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -194,8 +194,8 @@ static void R_InitTextures (void)
   // killough 4/9/98: make column offsets 32-bit;
   // clean up malloc-ing to use sizeof
 
-  textures = Z_Malloc(numtextures*sizeof*textures, PU_STATIC, 0);
-  textureheight = Z_Malloc(numtextures*sizeof*textureheight, PU_STATIC, 0);
+  textures = Z_Malloc(numtextures*sizeof*textures, PU_STATIC);
+  textureheight = Z_Malloc(numtextures*sizeof*textureheight, PU_STATIC);
 
   for (i=0 ; i<numtextures ; i++, directory++)
     {
@@ -217,7 +217,7 @@ static void R_InitTextures (void)
       texture = textures[i] =
         Z_Malloc(sizeof(texture_t) +
                  sizeof(texpatch_t)*(LittleShort(mtexture->patchcount)-1),
-                 PU_STATIC, 0);
+                 PU_STATIC);
 
       texture->width = LittleShort(mtexture->width);
       texture->height = LittleShort(mtexture->height);
@@ -317,8 +317,7 @@ static void R_InitTextures (void)
   // killough 4/9/98: make column offsets 32-bit;
   // clean up malloc-ing to use sizeof
 
-  texturetranslation =
-    Z_Malloc((numtextures+1)*sizeof*texturetranslation, PU_STATIC, 0);
+  texturetranslation = Z_Malloc((numtextures+1)*sizeof*texturetranslation, PU_STATIC);
 
   for (i=0 ; i<numtextures ; i++)
     texturetranslation[i] = i;
@@ -349,8 +348,7 @@ static void R_InitFlats(void)
   // killough 4/9/98: make column offsets 32-bit;
   // clean up malloc-ing to use sizeof
 
-  flattranslation =
-    Z_Malloc((numflats+1)*sizeof(*flattranslation), PU_STATIC, 0);
+  flattranslation = Z_Malloc((numflats+1)*sizeof(*flattranslation), PU_STATIC);
 
   for (i=0 ; i<numflats ; i++)
     flattranslation[i] = i;
@@ -394,7 +392,7 @@ static void R_InitColormaps(void)
     lastcolormaplump  = W_GetNumForName("C_END");
     numcolormaps = lastcolormaplump - firstcolormaplump;
   }
-  colormaps = Z_Malloc(sizeof(*colormaps) * numcolormaps, PU_STATIC, 0);
+  colormaps = Z_Malloc(sizeof(*colormaps) * numcolormaps, PU_STATIC);
   colormaps[0] = (const lighttable_t *)W_CacheLumpName("COLORMAP");
   for (i=1; i<numcolormaps; i++)
     colormaps[i] = (const lighttable_t *)W_CacheLumpNum(i+firstcolormaplump);
@@ -452,7 +450,7 @@ void R_InitTranMap(int progress)
       doom_snprintf(fname, fnlen+1, "%s/tranmap.dat", I_DoomExeDir());
       cachefp = fopen(fname, "rb");
 
-      main_tranmap = my_tranmap = Z_Malloc(256*256, PU_STATIC, 0);  // killough 4/11/98
+      main_tranmap = my_tranmap = Z_Malloc(256*256, PU_STATIC);  // killough 4/11/98
 
       // Use cached translucency filter if it's available
 

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -166,7 +166,6 @@ static void R_InitTextures (void)
             lprintf(LO_WARN,"\nWarning: patch %.8s, index %d does not exist",name,i);
         }
     }
-  W_UnlockLumpNum(names_lump); // cph - release the lump
 
   // Load the map texture definitions from textures.lmp.
   // The data is contained in one or two lumps,
@@ -284,10 +283,6 @@ static void R_InitTextures (void)
     }
 
   free(patchlookup);         // killough
-
-  for (i=0; i<2; i++) // cph - release the TEXTUREx lumps
-    if (maptex_lump[i] != -1)
-      W_UnlockLumpNum(maptex_lump[i]);
 
   if (errors)
   {
@@ -532,8 +527,6 @@ void R_InitTranMap(int progress)
         fclose(cachefp);
 
       free(fname);
-
-      W_UnlockLumpName("PLAYPAL");
     }
 }
 
@@ -649,7 +642,7 @@ int PUREFUNC R_SafeTextureNumForName(const char *name, int snum)
 
 static inline void precache_lump(int l)
 {
-  W_CacheLumpNum(l); W_UnlockLumpNum(l);
+  W_CacheLumpNum(l);
 }
 
 void R_PrecacheLevel(void)

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -140,7 +140,7 @@ static void R_InitTextures (void)
 
   // Load the patch names from pnames.lmp.
   name[8] = 0;
-  names = W_CacheLumpNum(names_lump = W_GetNumForName("PNAMES"));
+  names = W_LumpByNum(names_lump = W_GetNumForName("PNAMES"));
   nummappatches = LittleLong(*((const int *)names));
   name_p = names+4;
   patchlookup = malloc(nummappatches*sizeof(*patchlookup));  // killough
@@ -171,14 +171,14 @@ static void R_InitTextures (void)
   // The data is contained in one or two lumps,
   //  TEXTURE1 for shareware, plus TEXTURE2 for commercial.
 
-  maptex = maptex1 = W_CacheLumpNum(maptex_lump[0] = W_GetNumForName("TEXTURE1"));
+  maptex = maptex1 = W_LumpByNum(maptex_lump[0] = W_GetNumForName("TEXTURE1"));
   numtextures1 = LittleLong(*maptex);
   maxoff = W_LumpLength(maptex_lump[0]);
   directory = maptex+1;
 
   if (W_CheckNumForName("TEXTURE2") != -1)
     {
-      maptex2 = W_CacheLumpNum(maptex_lump[1] = W_GetNumForName("TEXTURE2"));
+      maptex2 = W_LumpByNum(maptex_lump[1] = W_GetNumForName("TEXTURE2"));
       numtextures2 = LittleLong(*maptex2);
       maxoff2 = W_LumpLength(maptex_lump[1]);
     }
@@ -387,9 +387,9 @@ static void R_InitColormaps(void)
     numcolormaps = lastcolormaplump - firstcolormaplump;
   }
   colormaps = Z_Malloc(sizeof(*colormaps) * numcolormaps, PU_STATIC);
-  colormaps[0] = (const lighttable_t *)W_CacheLumpName("COLORMAP");
+  colormaps[0] = (const lighttable_t *)W_LumpByName("COLORMAP");
   for (i=1; i<numcolormaps; i++)
-    colormaps[i] = (const lighttable_t *)W_CacheLumpNum(i+firstcolormaplump);
+    colormaps[i] = (const lighttable_t *)W_LumpByNum(i+firstcolormaplump);
   // cph - always lock
 }
 
@@ -425,10 +425,10 @@ void R_InitTranMap(int progress)
   // If a tranlucency filter map lump is present, use it
 
   if (lump != -1)  // Set a pointer to the translucency filter maps.
-    main_tranmap = W_CacheLumpNum(lump);   // killough 4/11/98
+    main_tranmap = W_LumpByNum(lump);   // killough 4/11/98
   else if (W_CheckNumForName("PLAYPAL")!=-1) // can be called before WAD loaded
     {   // Compose a default transparent filter map based on PLAYPAL.
-      const byte *playpal = W_CacheLumpName("PLAYPAL");
+      const byte *playpal = W_LumpByName("PLAYPAL");
       byte       *my_tranmap;
 
       char *fname;
@@ -641,7 +641,7 @@ int PUREFUNC R_SafeTextureNumForName(const char *name, int snum)
 
 static inline void precache_lump(int l)
 {
-  W_CacheLumpNum(l);
+  W_LumpByNum(l);
 }
 
 void R_PrecacheLevel(void)

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -301,7 +301,6 @@ static void R_InitTextures (void)
     {
       // proff - This is for the new renderer now
       R_CacheTextureCompositePatchNum(i);
-      R_UnlockTextureCompositePatchNum(i);
     }
   }
 
@@ -739,7 +738,6 @@ void R_SetPatchNum(patchnum_t *patchnum, const char *name)
   patchnum->leftoffset = patch->leftoffset;
   patchnum->topoffset = patch->topoffset;
   patchnum->lumpnum = W_GetNumForName(name);
-  R_UnlockPatchName(name);
 }
 
 void R_SetSpriteByNum(patchnum_t *patchnum, int lump)
@@ -750,7 +748,6 @@ void R_SetSpriteByNum(patchnum_t *patchnum, int lump)
   patchnum->leftoffset = patch->leftoffset;
   patchnum->topoffset = patch->topoffset;
   patchnum->lumpnum = lump;
-  R_UnlockPatchNum(lump);
 }
 
 int R_SetSpriteByIndex(patchnum_t *patchnum, spritenum_t item)

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -300,7 +300,7 @@ static void R_InitTextures (void)
     for (i=0 ; i<numtextures ; i++)
     {
       // proff - This is for the new renderer now
-      R_CacheTextureCompositePatchNum(i);
+      R_TextureCompositePatchByNum(i);
     }
   }
 
@@ -732,7 +732,7 @@ void R_PrecacheLevel(void)
 // Proff - Added for OpenGL
 void R_SetPatchNum(patchnum_t *patchnum, const char *name)
 {
-  const rpatch_t *patch = R_CachePatchName(name);
+  const rpatch_t *patch = R_PatchByName(name);
   patchnum->width = patch->width;
   patchnum->height = patch->height;
   patchnum->leftoffset = patch->leftoffset;
@@ -742,7 +742,7 @@ void R_SetPatchNum(patchnum_t *patchnum, const char *name)
 
 void R_SetSpriteByNum(patchnum_t *patchnum, int lump)
 {
-  const rpatch_t *patch = R_CachePatchNum(lump);
+  const rpatch_t *patch = R_PatchByNum(lump);
   patchnum->width = patch->width;
   patchnum->height = patch->height;
   patchnum->leftoffset = patch->leftoffset;

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -193,8 +193,8 @@ static void R_InitTextures (void)
   // killough 4/9/98: make column offsets 32-bit;
   // clean up malloc-ing to use sizeof
 
-  textures = Z_Malloc(numtextures*sizeof*textures, PU_STATIC);
-  textureheight = Z_Malloc(numtextures*sizeof*textureheight, PU_STATIC);
+  textures = Z_Malloc(numtextures*sizeof*textures);
+  textureheight = Z_Malloc(numtextures*sizeof*textureheight);
 
   for (i=0 ; i<numtextures ; i++, directory++)
     {
@@ -214,9 +214,7 @@ static void R_InitTextures (void)
       mtexture = (const maptexture_t *) ( (const byte *)maptex + offset);
 
       texture = textures[i] =
-        Z_Malloc(sizeof(texture_t) +
-                 sizeof(texpatch_t)*(LittleShort(mtexture->patchcount)-1),
-                 PU_STATIC);
+        Z_Malloc(sizeof(texture_t) + sizeof(texpatch_t)*(LittleShort(mtexture->patchcount)-1));
 
       texture->width = LittleShort(mtexture->width);
       texture->height = LittleShort(mtexture->height);
@@ -311,7 +309,7 @@ static void R_InitTextures (void)
   // killough 4/9/98: make column offsets 32-bit;
   // clean up malloc-ing to use sizeof
 
-  texturetranslation = Z_Malloc((numtextures+1)*sizeof*texturetranslation, PU_STATIC);
+  texturetranslation = Z_Malloc((numtextures+1)*sizeof*texturetranslation);
 
   for (i=0 ; i<numtextures ; i++)
     texturetranslation[i] = i;
@@ -342,7 +340,7 @@ static void R_InitFlats(void)
   // killough 4/9/98: make column offsets 32-bit;
   // clean up malloc-ing to use sizeof
 
-  flattranslation = Z_Malloc((numflats+1)*sizeof(*flattranslation), PU_STATIC);
+  flattranslation = Z_Malloc((numflats+1)*sizeof(*flattranslation));
 
   for (i=0 ; i<numflats ; i++)
     flattranslation[i] = i;
@@ -386,7 +384,7 @@ static void R_InitColormaps(void)
     lastcolormaplump  = W_GetNumForName("C_END");
     numcolormaps = lastcolormaplump - firstcolormaplump;
   }
-  colormaps = Z_Malloc(sizeof(*colormaps) * numcolormaps, PU_STATIC);
+  colormaps = Z_Malloc(sizeof(*colormaps) * numcolormaps);
   colormaps[0] = (const lighttable_t *)W_LumpByName("COLORMAP");
   for (i=1; i<numcolormaps; i++)
     colormaps[i] = (const lighttable_t *)W_LumpByNum(i+firstcolormaplump);
@@ -444,7 +442,7 @@ void R_InitTranMap(int progress)
       doom_snprintf(fname, fnlen+1, "%s/tranmap.dat", I_DoomExeDir());
       cachefp = fopen(fname, "rb");
 
-      main_tranmap = my_tranmap = Z_Malloc(256*256, PU_STATIC);  // killough 4/11/98
+      main_tranmap = my_tranmap = Z_Malloc(256*256);  // killough 4/11/98
 
       // Use cached translucency filter if it's available
 

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -106,7 +106,7 @@ int LoadDemo(const char *name, const byte **buffer, int *length, int *lump)
   }
   else
   {
-    buf = W_CacheLumpNum(num);
+    buf = W_LumpByNum(num);
     len = W_LumpLength(num);
   }
 
@@ -325,7 +325,7 @@ void R_DemoEx_ShowComment(void)
   if (count <= 0)
     return;
 
-  ch = W_CacheLumpNum(lump);
+  ch = W_LumpByNum(lump);
 
   for ( ; count ; count-- )
   {
@@ -376,7 +376,7 @@ angle_t R_DemoEx_ReadMLook(void)
       mlook_lump.lump = W_CheckNumForName(mlook_lump.name);
       if (mlook_lump.lump != -1)
       {
-        const unsigned char *data = W_CacheLumpName(mlook_lump.name);
+        const unsigned char *data = W_LumpByName(mlook_lump.name);
         int size = W_LumpLength(mlook_lump.lump);
 
         mlook_lump.maxtick = size / sizeof(mlook_lump.data[0]);
@@ -437,7 +437,7 @@ static int R_DemoEx_GetVersion(void)
     if (size > 0)
     {
       size_t len = MIN(size, sizeof(str_ver) - 1);
-      data = W_CacheLumpNum(lump);
+      data = W_LumpByNum(lump);
       strncpy(str_ver, data, len);
       str_ver[len] = 0;
 
@@ -472,7 +472,7 @@ static void R_DemoEx_GetParams(const byte *pwad_p, waddata_t *waddata)
   if (!str)
     return;
 
-  data = W_CacheLumpNum(lump);
+  data = W_LumpByNum(lump);
   strncpy(str, data, size);
 
   M_ParseCmdLine(str, NULL, NULL, &paramscount, &i);
@@ -1094,7 +1094,7 @@ static int G_ReadDemoFooter(const char *filename)
         //add demoex.wad to the wads list
         D_AddFile(demoex_filename, source_auto_load);
 
-        //cache demoex.wad for immediately getting its data with W_CacheLumpName
+        //cache demoex.wad for immediately getting its data with W_LumpByName
         W_Init();
 
         WadDataInit(&waddata);

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -354,8 +354,6 @@ void R_DemoEx_ShowComment(void)
     V_DrawNumPatch(cx, cy, 0, hu_font[c].lumpnum, CR_DEFAULT, VPT_STRETCH);
     cx += w;
   }
-
-  W_UnlockLumpNum(lump);
 }
 
 angle_t R_DemoEx_ReadMLook(void)
@@ -448,7 +446,6 @@ static int R_DemoEx_GetVersion(void)
         result = ver;
       }
     }
-    W_UnlockLumpNum(lump);
   }
 
   return result;
@@ -627,7 +624,6 @@ static void R_DemoEx_GetParams(const byte *pwad_p, waddata_t *waddata)
     free(params);
   }
 
-  W_UnlockLumpNum(lump);
   free(str);
 }
 

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -417,7 +417,7 @@ void R_InitTranslationTables (void)
 
     for (i = 0; i < 3 * (g_maxplayers - 1); i++)
     {
-        const byte* transLump = W_CacheLumpNum(lumpnum + i);
+        const byte* transLump = W_LumpByNum(lumpnum + i);
         memcpy(translationtables + i * 256, transLump, 256);
     }
 

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -410,7 +410,7 @@ void R_InitTranslationTables (void)
   if (hexen)
   {
     int lumpnum = W_GetNumForName("trantbl0");
-    translationtables = Z_Malloc(256 * 3 * (g_maxplayers - 1), PU_STATIC, 0);
+    translationtables = Z_Malloc(256 * 3 * (g_maxplayers - 1), PU_STATIC);
 
     for (i = 0; i < g_maxplayers; i++)
       playernumtotrans[i] = i;
@@ -429,7 +429,7 @@ void R_InitTranslationTables (void)
   // Remove dependency of colormaps aligned on 256-byte boundary
 
   if (translationtables == NULL) // CPhipps - allow multiple calls
-    translationtables = Z_Malloc(256*MAXTRANS, PU_STATIC, 0);
+    translationtables = Z_Malloc(256*MAXTRANS, PU_STATIC);
 
   for (i=0; i<MAXTRANS; i++) transtocolour[i] = 255;
 

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -419,7 +419,6 @@ void R_InitTranslationTables (void)
     {
         const byte* transLump = W_CacheLumpNum(lumpnum + i);
         memcpy(translationtables + i * 256, transLump, 256);
-        W_UnlockLumpNum(lumpnum + i);
     }
 
     return;

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -410,7 +410,7 @@ void R_InitTranslationTables (void)
   if (hexen)
   {
     int lumpnum = W_GetNumForName("trantbl0");
-    translationtables = Z_Malloc(256 * 3 * (g_maxplayers - 1), PU_STATIC);
+    translationtables = Z_Malloc(256 * 3 * (g_maxplayers - 1));
 
     for (i = 0; i < g_maxplayers; i++)
       playernumtotrans[i] = i;
@@ -428,7 +428,7 @@ void R_InitTranslationTables (void)
   // Remove dependency of colormaps aligned on 256-byte boundary
 
   if (translationtables == NULL) // CPhipps - allow multiple calls
-    translationtables = Z_Malloc(256*MAXTRANS, PU_STATIC);
+    translationtables = Z_Malloc(256*MAXTRANS);
 
   for (i=0; i<MAXTRANS; i++) transtocolour[i] = 255;
 

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -453,7 +453,7 @@ static void createPatch(int id) {
 
   // allocate our data chunk
   dataSize = pixelDataSize + columnsDataSize + postsDataSize;
-  patch->data = (unsigned char*)Z_Malloc(dataSize, PU_CACHE, (void **)&patch->data);
+  patch->data = (unsigned char*) Z_Malloc(dataSize, PU_STATIC);
   memset(patch->data, 0, dataSize);
 
   // set out pixel, column, and post pointers into our data array
@@ -658,7 +658,7 @@ static void createTextureCompositePatch(int id) {
 
   // allocate our data chunk
   dataSize = pixelDataSize + columnsDataSize + postsDataSize;
-  composite_patch->data = (unsigned char*)Z_Malloc(dataSize, PU_LOCKED, (void **)&composite_patch->data);
+  composite_patch->data = (unsigned char*) Z_Malloc(dataSize, PU_LOCKED);
   memset(composite_patch->data, 0, dataSize);
 
   // set out pixel, column, and post pointers into our data array

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -160,7 +160,7 @@ void R_FlushAllPatches(void) {
 //---------------------------------------------------------------------------
 int R_NumPatchWidth(int lump)
 {
-  const rpatch_t *patch = R_CachePatchNum(lump);
+  const rpatch_t *patch = R_PatchByNum(lump);
   int width = patch->width;
   return width;
 }
@@ -168,7 +168,7 @@ int R_NumPatchWidth(int lump)
 //---------------------------------------------------------------------------
 int R_NumPatchHeight(int lump)
 {
-  const rpatch_t *patch = R_CachePatchNum(lump);
+  const rpatch_t *patch = R_PatchByNum(lump);
   int height = patch->height;
   return height;
 }
@@ -823,9 +823,9 @@ static void createTextureCompositePatch(int id) {
 }
 
 //---------------------------------------------------------------------------
-const rpatch_t *R_CachePatchNum(int id) {
+const rpatch_t *R_PatchByNum(int id) {
   if (!patches)
-    I_Error("R_CachePatchNum: Patches not initialized");
+    I_Error("R_PatchByNum: Patches not initialized");
 
 #ifdef RANGECHECK
   if (id >= numlumps)
@@ -839,9 +839,9 @@ const rpatch_t *R_CachePatchNum(int id) {
 }
 
 //---------------------------------------------------------------------------
-const rpatch_t *R_CacheTextureCompositePatchNum(int id) {
+const rpatch_t *R_TextureCompositePatchByNum(int id) {
   if (!texture_composites)
-    I_Error("R_CacheTextureCompositePatchNum: Composite patches not initialized");
+    I_Error("R_TextureCompositePatchByNum: Composite patches not initialized");
 
 #ifdef RANGECHECK
   if (id >= numtextures)

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -447,7 +447,7 @@ static void createPatch(int id) {
 
   // allocate our data chunk
   dataSize = pixelDataSize + columnsDataSize + postsDataSize;
-  patch->data = (unsigned char*) Z_Malloc(dataSize, PU_STATIC);
+  patch->data = (unsigned char*) Z_Malloc(dataSize);
   memset(patch->data, 0, dataSize);
 
   // set out pixel, column, and post pointers into our data array
@@ -649,7 +649,7 @@ static void createTextureCompositePatch(int id) {
 
   // allocate our data chunk
   dataSize = pixelDataSize + columnsDataSize + postsDataSize;
-  composite_patch->data = (unsigned char*) Z_Malloc(dataSize, PU_STATIC);
+  composite_patch->data = (unsigned char*) Z_Malloc(dataSize);
   memset(composite_patch->data, 0, dataSize);
 
   // set out pixel, column, and post pointers into our data array

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -331,7 +331,7 @@ static dboolean CheckIfPatch(int lump)
   if (size < 13)
     return false;
 
-  patch = (const patch_t *)W_CacheLumpNum(lump);
+  patch = (const patch_t *)W_LumpByNum(lump);
 
   width = LittleShort(patch->width);
   height = LittleShort(patch->height);
@@ -399,7 +399,7 @@ static void createPatch(int id) {
       (patchNum < numlumps ? lumpinfo[patchNum].name : NULL));
   }
 
-  oldPatch = (const patch_t*)W_CacheLumpNum(patchNum);
+  oldPatch = (const patch_t*)W_LumpByNum(patchNum);
 
   patch = &patches[id];
   // proff - 2003-02-16 What about endianess?
@@ -624,7 +624,7 @@ static void createTextureCompositePatch(int id) {
   for (i=0; i<texture->patchcount; i++) {
     texpatch = &texture->patches[i];
     patchNum = texpatch->patch;
-    oldPatch = (const patch_t*)W_CacheLumpNum(patchNum);
+    oldPatch = (const patch_t*)W_LumpByNum(patchNum);
 
     for (x=0; x<LittleShort(oldPatch->width); x++) {
       int tx = texpatch->originx + x;
@@ -678,7 +678,7 @@ static void createTextureCompositePatch(int id) {
   for (i=0; i<texture->patchcount; i++) {
     texpatch = &texture->patches[i];
     patchNum = texpatch->patch;
-    oldPatch = (const patch_t*)W_CacheLumpNum(patchNum);
+    oldPatch = (const patch_t*)W_LumpByNum(patchNum);
 
     for (x=0; x<LittleShort(oldPatch->width); x++) {
       int top = -1;

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -162,7 +162,6 @@ int R_NumPatchWidth(int lump)
 {
   const rpatch_t *patch = R_CachePatchNum(lump);
   int width = patch->width;
-  R_UnlockPatchNum(lump);
   return width;
 }
 
@@ -171,7 +170,6 @@ int R_NumPatchHeight(int lump)
 {
   const rpatch_t *patch = R_CachePatchNum(lump);
   int height = patch->height;
-  R_UnlockPatchNum(lump);
   return height;
 }
 
@@ -840,11 +838,6 @@ const rpatch_t *R_CachePatchNum(int id) {
   return &patches[id];
 }
 
-void R_UnlockPatchNum(int id)
-{
-  // No op
-}
-
 //---------------------------------------------------------------------------
 const rpatch_t *R_CacheTextureCompositePatchNum(int id) {
   if (!texture_composites)
@@ -860,11 +853,6 @@ const rpatch_t *R_CacheTextureCompositePatchNum(int id) {
 
   return &texture_composites[id];
 
-}
-
-void R_UnlockTextureCompositePatchNum(int id)
-{
-  // No op
 }
 
 //---------------------------------------------------------------------------

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -361,7 +361,6 @@ static dboolean CheckIfPatch(int lump)
     }
   }
 
-  W_UnlockLumpNum(lump);
   return result;
 }
 
@@ -540,7 +539,6 @@ static void createPatch(int id) {
 
   FillEmptySpace(patch);
 
-  W_UnlockLumpNum(patchNum);
   free(numPostsInColumn);
 }
 
@@ -647,8 +645,6 @@ static void createTextureCompositePatch(int id) {
         oldColumn = (const column_t *)((const byte *)oldColumn + oldColumn->length + 4);
       }
     }
-
-    W_UnlockLumpNum(patchNum);
   }
 
   postsDataSize = numPostsTotal * sizeof(rpost_t);
@@ -789,8 +785,6 @@ static void createTextureCompositePatch(int id) {
         assert(countsInColumn[tx].posts_used <= countsInColumn[tx].posts);
       }
     }
-
-    W_UnlockLumpNum(patchNum);
   }
 
   for (x=0; x<texture->width; x++) {

--- a/prboom2/src/r_patch.h
+++ b/prboom2/src/r_patch.h
@@ -78,7 +78,6 @@ typedef struct {
   rcolumn_t *columns;
   rpost_t *posts;
 
-  unsigned int locks;
   unsigned int flags;//e6y
 } rpatch_t;
 

--- a/prboom2/src/r_patch.h
+++ b/prboom2/src/r_patch.h
@@ -83,13 +83,9 @@ typedef struct {
 
 
 const rpatch_t *R_CachePatchNum(int id);
-void R_UnlockPatchNum(int id);
 #define R_CachePatchName(name) R_CachePatchNum(W_GetNumForName(name))
-#define R_UnlockPatchName(name) R_UnlockPatchNum(W_GetNumForName(name))
 
 const rpatch_t *R_CacheTextureCompositePatchNum(int id);
-void R_UnlockTextureCompositePatchNum(int id);
-
 
 // Size query funcs
 int R_NumPatchWidth(int lump) ;

--- a/prboom2/src/r_patch.h
+++ b/prboom2/src/r_patch.h
@@ -82,10 +82,10 @@ typedef struct {
 } rpatch_t;
 
 
-const rpatch_t *R_CachePatchNum(int id);
-#define R_CachePatchName(name) R_CachePatchNum(W_GetNumForName(name))
+const rpatch_t *R_PatchByNum(int id);
+#define R_PatchByName(name) R_PatchByNum(W_GetNumForName(name))
 
-const rpatch_t *R_CacheTextureCompositePatchNum(int id);
+const rpatch_t *R_TextureCompositePatchByNum(int id);
 
 // Size query funcs
 int R_NumPatchWidth(int lump) ;

--- a/prboom2/src/r_plane.c
+++ b/prboom2/src/r_plane.c
@@ -581,7 +581,7 @@ static void R_DoDrawPlane(visplane_t *pl)
       // old code: dcvars.iscale = FRACUNIT*200/viewheight;
       dcvars.iscale = skyiscale;
 
-      tex_patch = R_CacheTextureCompositePatchNum(texture);
+      tex_patch = R_TextureCompositePatchByNum(texture);
 
   // killough 10/98: Use sky scrolling offset, and possibly flip picture
         for (x = pl->minx; (dcvars.x = x) <= pl->maxx; x++)

--- a/prboom2/src/r_plane.c
+++ b/prboom2/src/r_plane.c
@@ -593,8 +593,6 @@ static void R_DoDrawPlane(visplane_t *pl)
               colfunc(&dcvars);
             }
 
-      R_UnlockTextureCompositePatchNum(texture);
-
     } else {     // regular flat
 
       int stop, light;

--- a/prboom2/src/r_plane.c
+++ b/prboom2/src/r_plane.c
@@ -598,7 +598,7 @@ static void R_DoDrawPlane(visplane_t *pl)
       int stop, light;
       draw_span_vars_t dsvars;
 
-      dsvars.source = W_CacheLumpNum(firstflat + flattranslation[pl->picnum]);
+      dsvars.source = W_LumpByNum(firstflat + flattranslation[pl->picnum]);
 
       if (map_format.hexen)
       {

--- a/prboom2/src/r_plane.c
+++ b/prboom2/src/r_plane.c
@@ -706,8 +706,6 @@ static void R_DoDrawPlane(visplane_t *pl)
       for (x = pl->minx ; x <= stop ; x++)
          R_MakeSpans(x,pl->top[x-1],pl->bottom[x-1],
                      pl->top[x],pl->bottom[x], &dsvars);
-
-      W_UnlockLumpNum(firstflat + flattranslation[pl->picnum]);
     }
   }
 }

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -390,8 +390,6 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
         maskedtexturecol[dcvars.x] = INT_MAX; // dropoff overflow
       }
 
-  R_UnlockTextureCompositePatchNum(texnum);
-
   curline = NULL; /* cph 2001/11/18 - must clear curline now we're done with it, so R_ColourMap doesn't try using it for other things */
 }
 
@@ -510,7 +508,6 @@ static void R_RenderSegLoop (void)
           dcvars.nextsource = R_GetTextureColumn(tex_patch, texturecolumn+1);
           dcvars.texheight = midtexheight;
           colfunc(&dcvars);
-          R_UnlockTextureCompositePatchNum(midtexture);
           tex_patch = NULL;
           ceilingclip[rw_x] = viewheight;
           floorclip[rw_x] = -1;
@@ -539,7 +536,6 @@ static void R_RenderSegLoop (void)
                   dcvars.nextsource = R_GetTextureColumn(tex_patch,texturecolumn+1);
                   dcvars.texheight = toptexheight;
                   colfunc(&dcvars);
-                  R_UnlockTextureCompositePatchNum(toptexture);
                   tex_patch = NULL;
                   ceilingclip[rw_x] = mid;
                 }
@@ -573,7 +569,6 @@ static void R_RenderSegLoop (void)
                   dcvars.nextsource = R_GetTextureColumn(tex_patch, texturecolumn+1);
                   dcvars.texheight = bottomtexheight;
                   colfunc(&dcvars);
-                  R_UnlockTextureCompositePatchNum(bottomtexture);
                   tex_patch = NULL;
                   floorclip[rw_x] = mid;
                 }

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -318,7 +318,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
     dcvars.nextcolormap = dcvars.colormap; // for filtering -- POPE
   }
 
-  patch = R_CacheTextureCompositePatchNum(texnum);
+  patch = R_TextureCompositePatchByNum(texnum);
 
   // draw the columns
   for (dcvars.x = x1 ; dcvars.x <= x2 ; dcvars.x++, spryscale += rw_scalestep)
@@ -502,7 +502,7 @@ static void R_RenderSegLoop (void)
           dcvars.yl = yl;     // single sided line
           dcvars.yh = yh;
           dcvars.texturemid = rw_midtexturemid;
-          tex_patch = R_CacheTextureCompositePatchNum(midtexture);
+          tex_patch = R_TextureCompositePatchByNum(midtexture);
           dcvars.source = R_GetTextureColumn(tex_patch, texturecolumn);
           dcvars.prevsource = R_GetTextureColumn(tex_patch, texturecolumn-1);
           dcvars.nextsource = R_GetTextureColumn(tex_patch, texturecolumn+1);
@@ -530,7 +530,7 @@ static void R_RenderSegLoop (void)
                   dcvars.yl = yl;
                   dcvars.yh = mid;
                   dcvars.texturemid = rw_toptexturemid;
-                  tex_patch = R_CacheTextureCompositePatchNum(toptexture);
+                  tex_patch = R_TextureCompositePatchByNum(toptexture);
                   dcvars.source = R_GetTextureColumn(tex_patch,texturecolumn);
                   dcvars.prevsource = R_GetTextureColumn(tex_patch,texturecolumn-1);
                   dcvars.nextsource = R_GetTextureColumn(tex_patch,texturecolumn+1);
@@ -563,7 +563,7 @@ static void R_RenderSegLoop (void)
                   dcvars.yl = mid;
                   dcvars.yh = yh;
                   dcvars.texturemid = rw_bottomtexturemid;
-                  tex_patch = R_CacheTextureCompositePatchNum(bottomtexture);
+                  tex_patch = R_TextureCompositePatchByNum(bottomtexture);
                   dcvars.source = R_GetTextureColumn(tex_patch, texturecolumn);
                   dcvars.prevsource = R_GetTextureColumn(tex_patch, texturecolumn-1);
                   dcvars.nextsource = R_GetTextureColumn(tex_patch, texturecolumn+1);

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -390,10 +390,6 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
         maskedtexturecol[dcvars.x] = INT_MAX; // dropoff overflow
       }
 
-  // Except for main_tranmap, mark others purgable at this point
-  if (curline->linedef->tranlump > 0)
-    W_UnlockLumpNum(curline->linedef->tranlump-1); // cph - unlock it
-
   R_UnlockTextureCompositePatchNum(texnum);
 
   curline = NULL; /* cph 2001/11/18 - must clear curline now we're done with it, so R_ColourMap doesn't try using it for other things */

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -273,7 +273,7 @@ void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2)
       colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_TRANSLUCENT, drawvars.filterwall, drawvars.filterz);
       tranmap = main_tranmap;
       if (curline->linedef->tranlump > 0)
-        tranmap = W_CacheLumpNum(curline->linedef->tranlump-1);
+        tranmap = W_LumpByNum(curline->linedef->tranlump-1);
     }
   // killough 4/11/98: end translucent 2s normal code
 

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -236,7 +236,7 @@ static void R_InitSpriteDefs(const char * const * namelist)
   if (!numentries || !*namelist)
     return;
 
-  sprites = Z_Calloc(num_sprites, sizeof(*sprites), PU_STATIC, NULL);
+  sprites = Z_Calloc(num_sprites, sizeof(*sprites), PU_STATIC);
 
   // Create hash table based on just the first four letters of each sprite
   // killough 1/31/98
@@ -374,7 +374,7 @@ static void R_InitSpriteDefs(const char * const * namelist)
 
               // allocate space for the frames present and copy sprtemp to it
               sprites[i].spriteframes =
-                Z_Malloc (maxframe * sizeof(spriteframe_t), PU_STATIC, NULL);
+                Z_Malloc (maxframe * sizeof(spriteframe_t), PU_STATIC);
               memcpy (sprites[i].spriteframes, sprtemp,
                       maxframe*sizeof(spriteframe_t));
             }

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -629,7 +629,6 @@ static void R_DrawVisSprite(vissprite_t *vis)
         R_GetPatchColumnClamped(patch, texturecolumn+1)
       );
     }
-  R_UnlockPatchNum(vis->patch+firstspritelump); // cph - release lump
 }
 
 int r_near_clip_plane = MINZ;
@@ -793,7 +792,6 @@ static void R_ProjectSprite (mobj_t* thing, int lightlevel)
     gzt = fz + (patch->topoffset << FRACBITS);
     gzb = gzt - (patch->height << FRACBITS);
     width = patch->width;
-    R_UnlockPatchNum(lump+firstspritelump);
   }
 
   // off the side?
@@ -1128,7 +1126,6 @@ static void R_DrawPSprite (pspdef_t *psp)
 
     width = patch->width;
     topoffset = patch->topoffset<<FRACBITS;
-    R_UnlockPatchNum(lump+firstspritelump);
   }
 
   // off the side

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -236,7 +236,7 @@ static void R_InitSpriteDefs(const char * const * namelist)
   if (!numentries || !*namelist)
     return;
 
-  sprites = Z_Calloc(num_sprites, sizeof(*sprites), PU_STATIC);
+  sprites = Z_Calloc(num_sprites, sizeof(*sprites));
 
   // Create hash table based on just the first four letters of each sprite
   // killough 1/31/98
@@ -374,7 +374,7 @@ static void R_InitSpriteDefs(const char * const * namelist)
 
               // allocate space for the frames present and copy sprtemp to it
               sprites[i].spriteframes =
-                Z_Malloc (maxframe * sizeof(spriteframe_t), PU_STATIC);
+                Z_Malloc (maxframe * sizeof(spriteframe_t));
               memcpy (sprites[i].spriteframes, sprtemp,
                       maxframe*sizeof(spriteframe_t));
             }

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -515,7 +515,7 @@ static void R_DrawVisSprite(vissprite_t *vis)
 {
   int      texturecolumn;
   fixed_t  frac;
-  const rpatch_t *patch = R_CachePatchNum(vis->patch+firstspritelump);
+  const rpatch_t *patch = R_PatchByNum(vis->patch+firstspritelump);
   R_DrawColumn_f colfunc;
   draw_column_vars_t dcvars;
   enum draw_filter_type_e filter;
@@ -773,7 +773,7 @@ static void R_ProjectSprite (mobj_t* thing, int lightlevel)
     }
 
   {
-    const rpatch_t* patch = R_CachePatchNum(lump+firstspritelump);
+    const rpatch_t* patch = R_PatchByNum(lump+firstspritelump);
     thing->patch_width = patch->width;
 
     /* calculate edges of the shape
@@ -1113,7 +1113,7 @@ static void R_DrawPSprite (pspdef_t *psp)
   }
 
   {
-    const rpatch_t* patch = R_CachePatchNum(lump+firstspritelump);
+    const rpatch_t* patch = R_PatchByNum(lump+firstspritelump);
     // calculate edges of the shape
     fixed_t       tx;
     tx = psp_sx-160*FRACUNIT;

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -209,7 +209,7 @@ void S_Init(void)
     max_snd_dist = length;
     dist_adjust = max_snd_dist / 10;
 
-    soundCurve = Z_Malloc(max_snd_dist, PU_STATIC);
+    soundCurve = Z_Malloc(max_snd_dist);
     memcpy(soundCurve, (const byte *) W_LumpByNum(lump), max_snd_dist);
   }
 }

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -209,7 +209,7 @@ void S_Init(void)
     max_snd_dist = length;
     dist_adjust = max_snd_dist / 10;
 
-    soundCurve = Z_Malloc(max_snd_dist, PU_STATIC, NULL);
+    soundCurve = Z_Malloc(max_snd_dist, PU_STATIC);
     memcpy(soundCurve, (const byte *) W_CacheLumpNum(lump), max_snd_dist);
     W_UnlockLumpNum(lump);
   }

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -210,7 +210,7 @@ void S_Init(void)
     dist_adjust = max_snd_dist / 10;
 
     soundCurve = Z_Malloc(max_snd_dist, PU_STATIC);
-    memcpy(soundCurve, (const byte *) W_CacheLumpNum(lump), max_snd_dist);
+    memcpy(soundCurve, (const byte *) W_LumpByNum(lump), max_snd_dist);
   }
 }
 
@@ -595,7 +595,7 @@ void S_ChangeMusic(int musicnum, int looping)
     music->lumpnum = dsda_MusicIndexToLumpNum(musicnum);
 
   // load & register it
-  music->data = W_CacheLumpNum(music->lumpnum);
+  music->data = W_LumpByNum(music->lumpnum);
   music->handle = I_RegisterSong(music->data, W_LumpLength(music->lumpnum));
 
   // play it
@@ -657,7 +657,7 @@ void S_ChangeMusInfoMusic(int lumpnum, int looping)
   music->lumpnum = lumpnum;
 
   // load & register it
-  music->data = W_CacheLumpNum(music->lumpnum);
+  music->data = W_LumpByNum(music->lumpnum);
   music->handle = I_RegisterSong(music->data, W_LumpLength(music->lumpnum));
 
   // play it

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -211,7 +211,6 @@ void S_Init(void)
 
     soundCurve = Z_Malloc(max_snd_dist, PU_STATIC);
     memcpy(soundCurve, (const byte *) W_CacheLumpNum(lump), max_snd_dist);
-    W_UnlockLumpNum(lump);
   }
 }
 
@@ -682,8 +681,6 @@ void S_StopMusic(void)
 
       I_StopSong(mus_playing->handle);
       I_UnRegisterSong(mus_playing->handle);
-      if (mus_playing->lumpnum >= 0)
-  W_UnlockLumpNum(mus_playing->lumpnum); // cph - release the music data
 
       mus_playing->data = 0;
       mus_playing = 0;

--- a/prboom2/src/sc_man.c
+++ b/prboom2/src/sc_man.c
@@ -133,7 +133,6 @@ void SC_Close(void)
 {
   if (ScriptOpen)
   {
-    W_UnlockLumpNum(ScriptLump);
     ScriptOpen = false;
   }
 }

--- a/prboom2/src/sc_man.c
+++ b/prboom2/src/sc_man.c
@@ -89,7 +89,7 @@ void SC_OpenLumpByNum(int lump)
 
 static void OpenScript(void)
 {
-  ScriptBuffer = W_CacheLumpNum(ScriptLump);
+  ScriptBuffer = W_LumpByNum(ScriptLump);
   ScriptSize = W_LumpLength(ScriptLump);
 
   ScriptPtr = ScriptBuffer;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -678,14 +678,12 @@ static void FUNC_V_DrawNumPatch(int x, int y, int scrn, int lump,
          int cm, enum patch_translation_e flags)
 {
   V_DrawMemPatch(x, y, scrn, R_CachePatchNum(lump), cm, flags);
-  R_UnlockPatchNum(lump);
 }
 
 static void FUNC_V_DrawNumPatchPrecise(float x, float y, int scrn, int lump,
          int cm, enum patch_translation_e flags)
 {
   V_DrawMemPatch((int)x, (int)y, scrn, R_CachePatchNum(lump), cm, flags);
-  R_UnlockPatchNum(lump);
 }
 
 static int currentPaletteIndex = 0;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -203,7 +203,7 @@ void V_InitColorTranslation(void)
   register const crdef_t *p;
   for (p=crdefs; p->name; p++)
   {
-    *p->map = W_CacheLumpName(p->name);
+    *p->map = W_LumpByName(p->name);
     if (p - crdefs == CR_DEFAULT)
       continue;
     if (gamemission == chex || gamemission == hacx)
@@ -309,7 +309,7 @@ static void FUNC_V_FillFlat(int lump, int scrn, int x, int y, int width, int hei
   lump += firstflat;
 
   // killough 4/17/98:
-  data = W_CacheLumpNum(lump);
+  data = W_LumpByNum(lump);
 
   {
     const byte *src, *src_p;
@@ -1136,7 +1136,7 @@ const unsigned char* V_GetPlaypal(void)
   {
     int lump = W_GetNumForName(playpal_data->lump_name);
     int len = W_LumpLength(lump);
-    const byte *data = W_CacheLumpNum(lump);
+    const byte *data = W_LumpByNum(lump);
     playpal_data->lump = malloc(len);
     memcpy(playpal_data->lump, data, len);
   }
@@ -1467,7 +1467,7 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
     }
   }
 
-  raw = (const byte *) W_CacheLumpName(lump_name) + source_offset;
+  raw = (const byte *) W_LumpByName(lump_name) + source_offset;
 
   x_factor = (float)SCREENWIDTH / 320;
   y_factor = (float)SCREENHEIGHT / 200;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -336,8 +336,6 @@ static void FUNC_V_FillFlat(int lump, int scrn, int x, int y, int width, int hei
       }
     }
   }
-
-  W_UnlockLumpNum(lump);
 }
 
 static void FUNC_V_FillPatch(int lump, int scrn, int x, int y, int width, int height, enum patch_translation_e flags)
@@ -1143,7 +1141,6 @@ const unsigned char* V_GetPlaypal(void)
     const byte *data = W_CacheLumpNum(lump);
     playpal_data->lump = malloc(len);
     memcpy(playpal_data->lump, data, len);
-    W_UnlockLumpNum(lump);
   }
 
   return playpal_data->lump;
@@ -1494,8 +1491,6 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
 
       V_FillRect(0, x_offset + x, y, width, height, *raw);
     }
-
-  W_UnlockLumpName(lump_name);
 }
 
 void V_DrawShadowedNumPatch(int x, int y, int lump)

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -677,13 +677,13 @@ static void V_DrawMemPatch(int x, int y, int scrn, const rpatch_t *patch,
 static void FUNC_V_DrawNumPatch(int x, int y, int scrn, int lump,
          int cm, enum patch_translation_e flags)
 {
-  V_DrawMemPatch(x, y, scrn, R_CachePatchNum(lump), cm, flags);
+  V_DrawMemPatch(x, y, scrn, R_PatchByNum(lump), cm, flags);
 }
 
 static void FUNC_V_DrawNumPatchPrecise(float x, float y, int scrn, int lump,
          int cm, enum patch_translation_e flags)
 {
-  V_DrawMemPatch((int)x, (int)y, scrn, R_CachePatchNum(lump), cm, flags);
+  V_DrawMemPatch((int)x, (int)y, scrn, R_PatchByNum(lump), cm, flags);
 }
 
 static int currentPaletteIndex = 0;

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -82,8 +82,11 @@ const void *W_CacheLumpNum(int lump)
     I_Error ("W_CacheLumpNum: %i >= numlumps",lump);
 #endif
 
-  if (!cachelump[lump].cache)      // read the lump in
-    W_ReadLump(lump, Z_Malloc(W_LumpLength(lump), PU_CACHE, &cachelump[lump].cache));
+  // read the lump in
+  if (!cachelump[lump].cache) {
+    cachelump[lump].cache = Z_Malloc(W_LumpLength(lump), PU_STATIC);
+    W_ReadLump(lump, cachelump[lump].cache);
+  }
 
   /* cph - if wasn't locked but now is, tell z_zone to hold it */
   if (!cachelump[lump].locks && locks) {

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -93,14 +93,3 @@ const void *W_LockLumpNum(int lump)
 {
   return W_CacheLumpNum(lump);
 }
-
-/*
- * W_UnlockLumpNum
- *
- * CPhipps - this changes (should reduce) the number of locks on a lump
- */
-
-void W_UnlockLumpNum(int lump)
-{
-  // No op
-}

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -80,7 +80,7 @@ const void *W_LumpByNum(int lump)
 
   // read the lump in
   if (!lump_data[lump]) {
-    lump_data[lump] = Z_Malloc(W_LumpLength(lump), PU_STATIC);
+    lump_data[lump] = Z_Malloc(W_LumpLength(lump));
     W_ReadLump(lump, lump_data[lump]);
   }
 

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -67,17 +67,17 @@ void W_DoneCache(void)
 {
 }
 
-/* W_CacheLumpNum
+/* W_LumpByNum
  * killough 4/25/98: simplified
  * CPhipps - modified for new lump locking scheme
  *           returns a const*
  */
 
-const void *W_CacheLumpNum(int lump)
+const void *W_LumpByNum(int lump)
 {
 #ifdef RANGECHECK
   if ((unsigned)lump >= (unsigned)numlumps)
-    I_Error ("W_CacheLumpNum: %i >= numlumps",lump);
+    I_Error ("W_LumpByNum: %i >= numlumps",lump);
 #endif
 
   // read the lump in
@@ -91,5 +91,5 @@ const void *W_CacheLumpNum(int lump)
 
 const void *W_LockLumpNum(int lump)
 {
-  return W_CacheLumpNum(lump);
+  return W_LumpByNum(lump);
 }

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -47,9 +47,7 @@
 #include "z_zone.h"
 #include "lprintf.h"
 
-static struct {
-  void *cache;
-} *cachelump;
+static void **lump_data;
 
 /* W_InitCache
  *
@@ -58,9 +56,9 @@ static struct {
 void W_InitCache(void)
 {
   // set up caching
-  cachelump = calloc(sizeof *cachelump, numlumps);
-  if (!cachelump)
-    I_Error ("W_Init: Couldn't allocate lumpcache");
+  lump_data = calloc(sizeof *lump_data, numlumps);
+  if (!lump_data)
+    I_Error ("W_Init: Couldn't allocate lump data");
 }
 
 void W_DoneCache(void)
@@ -81,12 +79,12 @@ const void *W_LumpByNum(int lump)
 #endif
 
   // read the lump in
-  if (!cachelump[lump].cache) {
-    cachelump[lump].cache = Z_Malloc(W_LumpLength(lump), PU_STATIC);
-    W_ReadLump(lump, cachelump[lump].cache);
+  if (!lump_data[lump]) {
+    lump_data[lump] = Z_Malloc(W_LumpLength(lump), PU_STATIC);
+    W_ReadLump(lump, lump_data[lump]);
   }
 
-  return cachelump[lump].cache;
+  return lump_data[lump];
 }
 
 const void *W_LockLumpNum(int lump)

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -49,7 +49,6 @@
 
 static struct {
   void *cache;
-  unsigned int locks;
 } *cachelump;
 
 /* W_InitCache
@@ -76,7 +75,6 @@ void W_DoneCache(void)
 
 const void *W_CacheLumpNum(int lump)
 {
-  const int locks = 1;
 #ifdef RANGECHECK
   if ((unsigned)lump >= (unsigned)numlumps)
     I_Error ("W_CacheLumpNum: %i >= numlumps",lump);
@@ -87,12 +85,6 @@ const void *W_CacheLumpNum(int lump)
     cachelump[lump].cache = Z_Malloc(W_LumpLength(lump), PU_STATIC);
     W_ReadLump(lump, cachelump[lump].cache);
   }
-
-  /* cph - if wasn't locked but now is, tell z_zone to hold it */
-  if (!cachelump[lump].locks && locks) {
-    Z_ChangeTag(cachelump[lump].cache, PU_LOCKED);
-  }
-  cachelump[lump].locks += locks;
 
   return cachelump[lump].cache;
 }
@@ -110,11 +102,5 @@ const void *W_LockLumpNum(int lump)
 
 void W_UnlockLumpNum(int lump)
 {
-  const int unlocks = 1;
-  cachelump[lump].locks -= unlocks;
-  /* cph - Note: must only tell z_zone to make purgeable if currently locked,
-   * else it might already have been purged
-   */
-  if (unlocks && !cachelump[lump].locks)
-    Z_ChangeTag(cachelump[lump].cache, PU_CACHE);
+  // No op
 }

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -57,9 +57,7 @@
 
 #include "e6y.h"//e6y
 
-static struct {
-  void *cache;
-} *cachelump;
+static void **lump_data;
 
 #ifdef _WIN32
 typedef struct {
@@ -75,9 +73,9 @@ void W_DoneCache(void)
 {
   size_t i;
 
-  if (cachelump) {
-    free(cachelump);
-    cachelump = NULL;
+  if (lump_data) {
+    free(lump_data);
+    lump_data = NULL;
   }
 
   if (!mapped_wad)
@@ -110,9 +108,9 @@ void W_InitCache(void)
   W_DoneCache();
 
   // set up caching
-  cachelump = calloc(numlumps, sizeof *cachelump);
-  if (!cachelump)
-    I_Error ("W_Init: Couldn't allocate lumpcache");
+  lump_data = calloc(numlumps, sizeof *lump_data);
+  if (!lump_data)
+    I_Error ("W_Init: Couldn't allocate lump data");
 
   mapped_wad = calloc(numwadfiles,sizeof(mmap_info_t));
   memset(mapped_wad,0,sizeof(mmap_info_t)*numwadfiles);
@@ -183,9 +181,9 @@ void W_InitCache(void)
 {
   int maxfd = 0;
   // set up caching
-  cachelump = calloc(numlumps, sizeof *cachelump);
-  if (!cachelump)
-    I_Error ("W_Init: Couldn't allocate lumpcache");
+  lump_data = calloc(numlumps, sizeof *lump_data);
+  if (!lump_data)
+    I_Error ("W_Init: Couldn't allocate lump data");
 
   {
     int i;
@@ -255,10 +253,10 @@ const void* W_LockLumpNum(int lump)
   const void *data = W_LumpByNum(lump);
 
   // read the lump in
-  if (!cachelump[lump].cache) {
-    cachelump[lump].cache = Z_Malloc(len, PU_STATIC);
-    memcpy(cachelump[lump].cache, data, len);
+  if (!lump_data[lump]) {
+    lump_data[lump] = Z_Malloc(len, PU_STATIC);
+    memcpy(lump_data[lump], data, len);
   }
 
-  return cachelump[lump].cache;
+  return lump_data[lump];
 }

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -254,7 +254,7 @@ const void* W_LockLumpNum(int lump)
 
   // read the lump in
   if (!lump_data[lump]) {
-    lump_data[lump] = Z_Malloc(len, PU_STATIC);
+    lump_data[lump] = Z_Malloc(len);
     memcpy(lump_data[lump], data, len);
   }
 

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -258,9 +258,9 @@ const void* W_LockLumpNum(int lump)
   size_t len = W_LumpLength(lump);
   const void *data = W_CacheLumpNum(lump);
 
+  // read the lump in
   if (!cachelump[lump].cache) {
-    // read the lump in
-    Z_Malloc(len, PU_CACHE, &cachelump[lump].cache);
+    cachelump[lump].cache = Z_Malloc(len, PU_STATIC);
     memcpy(cachelump[lump].cache, data, len);
   }
 

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -161,14 +161,14 @@ void W_InitCache(void)
   }
 }
 
-const void* W_CacheLumpNum(int lump)
+const void* W_LumpByNum(int lump)
 {
   int wad_index = (int)(lumpinfo[lump].wadfile-wadfiles);
 #ifdef RANGECHECK
   if ((wad_index<0)||((size_t)wad_index>=numwadfiles))
-    I_Error("W_CacheLumpNum: wad_index out of range");
+    I_Error("W_LumpByNum: wad_index out of range");
   if ((unsigned)lump >= (unsigned)numlumps)
-    I_Error ("W_CacheLumpNum: %i >= numlumps",lump);
+    I_Error ("W_LumpByNum: %i >= numlumps",lump);
 #endif
   if (!lumpinfo[lump].wadfile)
     return NULL;
@@ -225,11 +225,11 @@ void W_DoneCache(void)
   mapped_wad = NULL;
 }
 
-const void* W_CacheLumpNum(int lump)
+const void* W_LumpByNum(int lump)
 {
 #ifdef RANGECHECK
   if ((unsigned)lump >= (unsigned)numlumps)
-    I_Error ("W_CacheLumpNum: %i >= numlumps",lump);
+    I_Error ("W_LumpByNum: %i >= numlumps",lump);
 #endif
   if (!lumpinfo[lump].wadfile)
     return NULL;
@@ -252,7 +252,7 @@ const void* W_CacheLumpNum(int lump)
 const void* W_LockLumpNum(int lump)
 {
   size_t len = W_LumpLength(lump);
-  const void *data = W_CacheLumpNum(lump);
+  const void *data = W_LumpByNum(lump);
 
   // read the lump in
   if (!cachelump[lump].cache) {

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -262,7 +262,3 @@ const void* W_LockLumpNum(int lump)
 
   return cachelump[lump].cache;
 }
-
-void W_UnlockLumpNum(int lump) {
-  // No op
-}

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -155,14 +155,10 @@ void    W_ReadLump (int lump, void *dest);
 // CPhipps - modified for 'new' lump locking
 const void* W_CacheLumpNum (int lump);
 const void* W_LockLumpNum(int lump);
-void    W_UnlockLumpNum(int lump);
 
 // CPhipps - convenience macros
 //#define W_CacheLumpNum(num) (W_CacheLumpNum)((num),1)
 #define W_CacheLumpName(name) W_CacheLumpNum (W_GetNumForName(name))
-
-//#define W_UnlockLumpNum(num) (W_UnlockLumpNum)((num),1)
-#define W_UnlockLumpName(name) W_UnlockLumpNum (W_GetNumForName(name))
 
 char *AddDefaultExtension(char *, const char *);  // killough 1/18/98
 void ExtractFileBase(const char *, char *);       // killough

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -153,12 +153,12 @@ const lumpinfo_t* W_GetLumpInfoByNum(int lump);
 int     W_LumpLength (int lump);
 void    W_ReadLump (int lump, void *dest);
 // CPhipps - modified for 'new' lump locking
-const void* W_CacheLumpNum (int lump);
+const void* W_LumpByNum (int lump);
 const void* W_LockLumpNum(int lump);
 
 // CPhipps - convenience macros
-//#define W_CacheLumpNum(num) (W_CacheLumpNum)((num),1)
-#define W_CacheLumpName(name) W_CacheLumpNum (W_GetNumForName(name))
+//#define W_LumpByNum(num) (W_LumpByNum)((num),1)
+#define W_LumpByName(name) W_LumpByNum (W_GetNumForName(name))
 
 char *AddDefaultExtension(char *, const char *);  // killough 1/18/98
 void ExtractFileBase(const char *, char *);       // killough

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -611,7 +611,7 @@ WI_drawOnLnode  // draw stuff at a location by episode/map#
     int            top;
     int            right;
     int            bottom;
-    const rpatch_t* patch = R_CachePatchName(c[i]);
+    const rpatch_t* patch = R_PatchByName(c[i]);
 
     left = lnodes[wbs->epsd][n].x - patch->leftoffset;
     top = lnodes[wbs->epsd][n].y - patch->topoffset;

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -617,7 +617,6 @@ WI_drawOnLnode  // draw stuff at a location by episode/map#
     top = lnodes[wbs->epsd][n].y - patch->topoffset;
     right = left + patch->width;
     bottom = top + patch->height;
-    R_UnlockPatchName(c[i]);
 
     if (left >= 0
        && right < 320

--- a/prboom2/src/z_bmalloc.c
+++ b/prboom2/src/z_bmalloc.c
@@ -87,8 +87,8 @@ void* Z_BMalloc(struct block_memory_alloc_s *pzone)
 
     // CPhipps: Allocate new memory, initialised to 0
 
-    *pool = newpool = Z_CallocTag(sizeof(*newpool) + (sizeof(byte) + pzone->size)*(pzone->perpool),
-             1,  PU_LEVEL);
+    *pool = newpool =
+      Z_CallocLevel(sizeof(*newpool) + (sizeof(byte) + pzone->size)*(pzone->perpool), 1);
     newpool->nextpool = NULL; // NULL = (void*)0 so this is redundant
 
     // Return element 0 from this pool to satisfy the request

--- a/prboom2/src/z_bmalloc.c
+++ b/prboom2/src/z_bmalloc.c
@@ -87,8 +87,8 @@ void* Z_BMalloc(struct block_memory_alloc_s *pzone)
 
     // CPhipps: Allocate new memory, initialised to 0
 
-    *pool = newpool = Z_Calloc(sizeof(*newpool) + (sizeof(byte) + pzone->size)*(pzone->perpool),
-             1,  pzone->tag);
+    *pool = newpool = Z_CallocTag(sizeof(*newpool) + (sizeof(byte) + pzone->size)*(pzone->perpool),
+             1,  PU_LEVEL);
     newpool->nextpool = NULL; // NULL = (void*)0 so this is redundant
 
     // Return element 0 from this pool to satisfy the request

--- a/prboom2/src/z_bmalloc.c
+++ b/prboom2/src/z_bmalloc.c
@@ -88,7 +88,7 @@ void* Z_BMalloc(struct block_memory_alloc_s *pzone)
     // CPhipps: Allocate new memory, initialised to 0
 
     *pool = newpool = Z_Calloc(sizeof(*newpool) + (sizeof(byte) + pzone->size)*(pzone->perpool),
-             1,  pzone->tag, NULL);
+             1,  pzone->tag);
     newpool->nextpool = NULL; // NULL = (void*)0 so this is redundant
 
     // Return element 0 from this pool to satisfy the request

--- a/prboom2/src/z_bmalloc.h
+++ b/prboom2/src/z_bmalloc.h
@@ -38,13 +38,12 @@ struct block_memory_alloc_s {
   void  *firstpool;
   size_t size;
   size_t perpool;
-  int    tag;
   const char *desc;
 };
 
 #define DECLARE_BLOCK_MEMORY_ALLOC_ZONE(name) extern struct block_memory_alloc_s name
-#define IMPLEMENT_BLOCK_MEMORY_ALLOC_ZONE(name, size, tag, num, desc) \
-struct block_memory_alloc_s name = { NULL, size, num, tag, desc}
+#define IMPLEMENT_BLOCK_MEMORY_ALLOC_ZONE(name, size, num, desc) \
+struct block_memory_alloc_s name = { NULL, size, num, desc}
 #define NULL_BLOCK_MEMORY_ALLOC_ZONE(name) name.firstpool = NULL
 
 void* Z_BMalloc(struct block_memory_alloc_s *pzone);

--- a/prboom2/src/z_zone.c
+++ b/prboom2/src/z_zone.c
@@ -83,7 +83,7 @@ static memblock_t *blockbytag[PU_MAX];
  * free all the stuff we just pass on the way.
  */
 
-void *Z_Malloc(size_t size, int tag)
+void *Z_MallocTag(size_t size, int tag)
 {
   memblock_t *block = NULL;
 
@@ -159,9 +159,9 @@ void Z_FreeTag(int tag)
   }
 }
 
-void *Z_Realloc(void *ptr, size_t n, int tag)
+void *Z_ReallocTag(void *ptr, size_t n, int tag)
 {
-  void *p = Z_Malloc(n, tag);
+  void *p = Z_MallocTag(n, tag);
   if (ptr)
     {
       memblock_t *block = (memblock_t *)((char *) ptr - HEADER_SIZE);
@@ -171,13 +171,29 @@ void *Z_Realloc(void *ptr, size_t n, int tag)
   return p;
 }
 
-void *Z_Calloc(size_t n1, size_t n2, int tag)
+void *Z_CallocTag(size_t n1, size_t n2, int tag)
 {
   return
-    (n1*=n2) ? memset(Z_Malloc(n1, tag), 0, n1) : NULL;
+    (n1*=n2) ? memset(Z_MallocTag(n1, tag), 0, n1) : NULL;
 }
 
-char *Z_Strdup(const char *s, int tag)
+char *Z_StrdupTag(const char *s, int tag)
 {
-  return strcpy(Z_Malloc(strlen(s)+1, tag), s);
+  return strcpy(Z_MallocTag(strlen(s)+1, tag), s);
+}
+
+void *Z_Malloc(size_t size) {
+  return Z_MallocTag(size, PU_STATIC);
+}
+
+void *Z_Calloc(size_t n, size_t n2) {
+  return Z_CallocTag(n, n2, PU_STATIC);
+}
+
+void *Z_Realloc(void *p, size_t n) {
+  return Z_ReallocTag(p, n, PU_STATIC);
+}
+
+char *Z_Strdup(const char *s) {
+  return Z_StrdupTag(s, PU_STATIC);
 }

--- a/prboom2/src/z_zone.c
+++ b/prboom2/src/z_zone.c
@@ -159,45 +159,6 @@ void Z_FreeTag(int tag)
   }
 }
 
-void Z_ChangeTag(void *ptr, int tag)
-{
-  memblock_t *block = (memblock_t *)((char *) ptr - HEADER_SIZE);
-
-  // proff - added sanity check, this can happen when an empty lump is locked
-  if (!ptr)
-    return;
-
-  // proff - do nothing if tag doesn't differ
-  if (tag == block->tag)
-    return;
-
-  if (block->signature != ZONE_SIGNATURE)
-    I_Error ("Z_ChangeTag: freed a non-zone pointer");
-
-  if (block == block->next)
-    blockbytag[block->tag] = NULL;
-  else
-    if (blockbytag[block->tag] == block)
-      blockbytag[block->tag] = block->next;
-  block->prev->next = block->next;
-  block->next->prev = block->prev;
-
-  if (!blockbytag[tag])
-  {
-    blockbytag[tag] = block;
-    block->next = block->prev = block;
-  }
-  else
-  {
-    blockbytag[tag]->prev->next = block;
-    block->prev = blockbytag[tag]->prev;
-    block->next = blockbytag[tag];
-    blockbytag[tag]->prev = block;
-  }
-
-  block->tag = tag;
-}
-
 void *Z_Realloc(void *ptr, size_t n, int tag)
 {
   void *p = Z_Malloc(n, tag);

--- a/prboom2/src/z_zone.h
+++ b/prboom2/src/z_zone.h
@@ -59,9 +59,7 @@
 
 enum {
   PU_STATIC,
-  PU_LOCKED,
   PU_LEVEL,
-  PU_CACHE,
   /* Must always be last -- killough */
   PU_MAX
 };
@@ -69,7 +67,6 @@ enum {
 void *Z_Malloc(size_t size, int tag);
 void Z_Free(void *ptr);
 void Z_FreeTag(int tag);
-void Z_ChangeTag(void *ptr, int tag);
 void *Z_Calloc(size_t n, size_t n2, int tag);
 void *Z_Realloc(void *p, size_t n, int tag);
 char *Z_Strdup(const char *s, int tag);

--- a/prboom2/src/z_zone.h
+++ b/prboom2/src/z_zone.h
@@ -64,12 +64,17 @@ enum {
   PU_MAX
 };
 
-void *Z_Malloc(size_t size, int tag);
 void Z_Free(void *ptr);
+void *Z_Malloc(size_t size);
+void *Z_Calloc(size_t n, size_t n2);
+void *Z_Realloc(void *p, size_t n);
+char *Z_Strdup(const char *s);
+
 void Z_FreeTag(int tag);
-void *Z_Calloc(size_t n, size_t n2, int tag);
-void *Z_Realloc(void *p, size_t n, int tag);
-char *Z_Strdup(const char *s, int tag);
+void *Z_MallocTag(size_t size, int tag);
+void *Z_CallocTag(size_t n, size_t n2, int tag);
+void *Z_ReallocTag(void *p, size_t n, int tag);
+char *Z_StrdupTag(const char *s, int tag);
 
 /* cphipps 2001/11/18 -
  * If we're using memory mapped file access to WADs, we won't need to maintain
@@ -80,18 +85,16 @@ char *Z_Strdup(const char *s, int tag);
 
 // Remove all definitions before including system definitions
 
-#undef malloc
 #undef free
+#undef malloc
 #undef realloc
 #undef calloc
 #undef strdup
 
-#define malloc(n)          Z_Malloc(n,PU_STATIC)
 #define free(p)            Z_Free(p)
-#define realloc(p,n)       Z_Realloc(p,n,PU_STATIC)
-#define calloc(n1,n2)      Z_Calloc(n1,n2,PU_STATIC)
-#define strdup(s)          Z_Strdup(s,PU_STATIC)
-
-void Z_ZoneHistory(char *);
+#define malloc(n)          Z_Malloc(n)
+#define realloc(p,n)       Z_Realloc(p,n)
+#define calloc(n1,n2)      Z_Calloc(n1,n2)
+#define strdup(s)          Z_Strdup(s)
 
 #endif

--- a/prboom2/src/z_zone.h
+++ b/prboom2/src/z_zone.h
@@ -66,13 +66,13 @@ enum {
   PU_MAX
 };
 
-void *Z_Malloc(size_t size, int tag, void **ptr);
+void *Z_Malloc(size_t size, int tag);
 void Z_Free(void *ptr);
 void Z_FreeTag(int tag);
 void Z_ChangeTag(void *ptr, int tag);
-void *Z_Calloc(size_t n, size_t n2, int tag, void **user);
-void *Z_Realloc(void *p, size_t n, int tag, void **user);
-char *Z_Strdup(const char *s, int tag, void **user);
+void *Z_Calloc(size_t n, size_t n2, int tag);
+void *Z_Realloc(void *p, size_t n, int tag);
+char *Z_Strdup(const char *s, int tag);
 
 /* cphipps 2001/11/18 -
  * If we're using memory mapped file access to WADs, we won't need to maintain
@@ -89,11 +89,11 @@ char *Z_Strdup(const char *s, int tag, void **user);
 #undef calloc
 #undef strdup
 
-#define malloc(n)          Z_Malloc(n,PU_STATIC,0)
+#define malloc(n)          Z_Malloc(n,PU_STATIC)
 #define free(p)            Z_Free(p)
-#define realloc(p,n)       Z_Realloc(p,n,PU_STATIC,0)
-#define calloc(n1,n2)      Z_Calloc(n1,n2,PU_STATIC,0)
-#define strdup(s)          Z_Strdup(s,PU_STATIC,0)
+#define realloc(p,n)       Z_Realloc(p,n,PU_STATIC)
+#define calloc(n1,n2)      Z_Calloc(n1,n2,PU_STATIC)
+#define strdup(s)          Z_Strdup(s,PU_STATIC)
 
 void Z_ZoneHistory(char *);
 

--- a/prboom2/src/z_zone.h
+++ b/prboom2/src/z_zone.h
@@ -54,34 +54,18 @@
 #include <string.h>
 #include <assert.h>
 
-// ZONE MEMORY
-// PU - purge tags.
-
-enum {
-  PU_STATIC,
-  PU_LEVEL,
-  /* Must always be last -- killough */
-  PU_MAX
-};
-
 void Z_Free(void *ptr);
+void Z_FreeLevel(void);
+
 void *Z_Malloc(size_t size);
 void *Z_Calloc(size_t n, size_t n2);
 void *Z_Realloc(void *p, size_t n);
 char *Z_Strdup(const char *s);
 
-void Z_FreeTag(int tag);
-void *Z_MallocTag(size_t size, int tag);
-void *Z_CallocTag(size_t n, size_t n2, int tag);
-void *Z_ReallocTag(void *p, size_t n, int tag);
-char *Z_StrdupTag(const char *s, int tag);
-
-/* cphipps 2001/11/18 -
- * If we're using memory mapped file access to WADs, we won't need to maintain
- * our own heap. So we *could* let "normal" malloc users use the libc malloc
- * directly, for efficiency. Except we do need a wrapper to handle out of memory
- * errors... damn, ok, we'll leave it for now.
- */
+void *Z_MallocLevel(size_t size);
+void *Z_CallocLevel(size_t n, size_t n2);
+void *Z_ReallocLevel(void *p, size_t n);
+char *Z_StrdupLevel(const char *s);
 
 // Remove all definitions before including system definitions
 


### PR DESCRIPTION
This PR does a few things:

1) Remove data locks
Data that gets "unlocked" is not freed (despite many comments mentioning that this happens). That's because unlocked data is just marked as being unimportant, in case we _run out of memory completely_. If we somehow run out of memory completely, then something catastrophic has happened. So, in all other cases, all the locking / unlocking code doesn't actually do anything.

2) Remove zone users
The zone user pointer was used to change the "owner" of the data to NULL when unlocked data was purged. Since data locking no longer exists, this functionality is obsolete.

3) Change the wording everywhere away from "cache" for the associated data.
There was no data cache so this was misleading.

4) Hide zone tags
The zone interface was a bit too low-level. Any given file doesn't need to know about zone tagging or how the internals work. There are currently two uses for zone memory: regular malloc with error handling (doesn't care about tags), and level-scoped data allocation / deletion (doesn't care about tags). Since neither of these cases needs to specify tags, we can scrub them out of the outer code base entirely.