### PR TITLE
CMake: Set _FILE_OFFSET_BITS=64 on Linux

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -50,6 +50,10 @@ if(NOT HAVE_STRNICMP)
     add_definitions("-Dstrnicmp=strncasecmp")
 endif()
 
+if(UNIX AND NOT APPLE)
+    add_definitions("-D_FILE_OFFSET_BITS=64")
+endif()
+
 check_symbol_exists(getopt "unistd.h" HAVE_GETOPT)
 check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
 check_symbol_exists(CreateFileMapping "windows.h" HAVE_CREATE_FILE_MAPPING)


### PR DESCRIPTION
By default without _GNU_SOURCE, off64_t is not defined. This breaks
MUSIC/dumbplayer.c workaround for making off_t 64-bit. Even 64-bit Linux
is affected.

Define _FILE_OFFSET_BITS=64 explicitly so that off_t is defined as a
64-bit type. This also skips the workaround in dumbplayer.c source file.

The `UNIX AND NOT APPLE` is assumed to mean `Linux`, though it might
trigger on non-Linux systems as well.

---

I only tested this on my Gentoo x86-64 machine, building both in 32-bit and 64-bit mode.

The idea of adding `_GNU_SOURCE` came to me by comparing the compiler flags while building dsda-doom and coelckers/prboom-plus. In the latter, there is an unrelated change that adds `_GNU_SOURCE`:

https://github.com/coelckers/prboom-plus/commit/c87abe0fc10e3a3c9d5a94db3f7881b086dad971