### PR TITLE
Fix unknown type name ‘uint64_t’ error.

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1124,7 +1124,7 @@ struct deh_flag_s {
   uint_64_t value;
 };
 
-static uint_64_t deh_translate_bits(uint64_t value, const struct deh_flag_s *flags)
+static uint_64_t deh_translate_bits(uint_64_t value, const struct deh_flag_s *flags)
 {
   int i;
   uint_64_t result = 0;


### PR DESCRIPTION
## Description

This error would happen in docker containers such as `ubuntu:latest`.

This was first noticed in https://github.com/Homebrew/homebrew-core/pull/108013 when running the CI.

## Alternative solution

Another solution could be to include `stdint.h` if preferred.