### PR TITLE
Add separate install option for `dsda-doom.wad`

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -135,6 +135,7 @@ set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_PREV})
 set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_PREV})
 
 set(DOOMWADDIR "${CMAKE_INSTALL_PREFIX}/share/games/doom" CACHE PATH "Path to look for WAD files")
+set(DSDAPWADDIR "${DOOMWADDIR}" CACHE PATH "Path to install DSDA-Doom internal WAD")
 
 option(SIMPLECHECKS "Enable checks which only impose significant overhead if a posible error is detected" ON)
 

--- a/prboom2/cmake/config.h.cin
+++ b/prboom2/cmake/config.h.cin
@@ -5,6 +5,7 @@
 #cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
 
 #cmakedefine DOOMWADDIR "@DOOMWADDIR@"
+#cmakedefine DSDAPWADDIR "@DSDAPWADDIR@"
 
 #cmakedefine WORDS_BIGENDIAN
 

--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -425,4 +425,4 @@ add_custom_command(
     DEPENDS rdatawad ${WAD_SRC}
 )
 add_custom_target(dsda-doom-wad DEPENDS ${WAD_DATA_PATH})
-install(FILES ${WAD_DATA_PATH} DESTINATION ${DOOMWADDIR} COMPONENT "PrBoom-Plus internal WAD")
+install(FILES ${WAD_DATA_PATH} DESTINATION ${DSDAPWADDIR} COMPONENT "DSDA-Doom internal WAD")

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -412,6 +412,7 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
     {NULL}, // current working directory
     {NULL, NULL, "DOOMWADDIR"}, // run-time $DOOMWADDIR
     {DOOMWADDIR}, // build-time configured DOOMWADDIR
+    {DSDAPWADDIR}, // build-time configured location of dsda-doom.wad
     {NULL, "doom", "HOME"}, // ~/doom
     {NULL, NULL, "HOME"}, // ~
     {"/usr/local/share/games/doom"},


### PR DESCRIPTION
## Description

This is a suggestion from Homebrew/homebrew-core#108013.

This PR adds a CMake cache entry named `EXTRA_DOOMWADDIRS` which consists in a list of additional directories to check for WADs similar to `DOOMWADDIR`.

## Motivation

While working on the Homebrew integration we noticed the following issues:
- When leaving `DOOMWADDIR` to its default (`<prefix>/share/games/doom`), the `games/doom` part gets symlinked into `HOMEBREW_PREFIX`. The issue is that when reinstalling/updating/uninstalling dsda-doom, this folder would get wiped and all your WADs erased.
- When setting `DOOMWADDIR` to `HOMEBREW_PREFIX/share/games/doom`, build fails on macOS due to quarantine as CMake tries to create the missing directories when it doesn't have the privileges to do so.

The current makeshift solution is the following:
- Install step:
  - Leave `DOOMWADDIR` to its default.
  - After CMake install, move `dsda-doom.wad` away. 
- Post-install step:,
  - Create `HOMEBREW_PREFIX/share/games/doom`.
  - Symlink `dsda-doom.wad` into it
  - Symlink `HOMEBREW_PREFIX/share/games/doom` into dsda's prefix.

With this PR, `HOMEBREW_PREFIX/share/games/doom` could be set as an `EXTRA_DOOMWADDIRS` and be searched while not being deleted when dsda gets updated.

It's worth mentioning that `HOMEBREW_PREFIX` is not the same on all platforms and can be chosen by the user, here are the defaults:
- `/opt/homebrew` (M1 mac)
- `/usr/local` (x86_64 mac)
- `/home/linuxbrew/.linuxbrew` (Linux)