### PR TITLE
Fix sound attenuation when distance overflows

### DIFF
--- a/prboom2/src/m_fixed.h
+++ b/prboom2/src/m_fixed.h
@@ -49,6 +49,7 @@
 #define FRACUNIT (1<<FRACBITS)
 
 typedef int fixed_t;
+typedef unsigned int ufixed_t;
 
 /*
  * Absolute Value

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -727,7 +727,8 @@ void S_StopChannel(int cnum)
 int S_AdjustSoundParams(mobj_t *listener, mobj_t *source,
                         int *vol, int *sep, int *pitch)
 {
-  fixed_t adx, ady,approx_dist;
+  fixed_t adx, ady;
+  ufixed_t approx_dist;
   angle_t angle;
 
   //jff 1/22/98 return if sound is not enabled
@@ -773,9 +774,7 @@ int S_AdjustSoundParams(mobj_t *listener, mobj_t *source,
       return *vol > 0;
     }
 
-  // Sound emitter is too far away from listener.
-  // The <= 0 check is done in case the approx_dist overflows to a negative value.
-  if (approx_dist > S_CLIPPING_DIST || approx_dist <= 0)
+  if (approx_dist > S_CLIPPING_DIST)
     return 0;
 
   // angle of source to listener

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -773,7 +773,9 @@ int S_AdjustSoundParams(mobj_t *listener, mobj_t *source,
       return *vol > 0;
     }
 
-  if (approx_dist > S_CLIPPING_DIST)
+  // Sound emitter is too far away from listener.
+  // The <= 0 check is done in case the approx_dist overflows to a negative value.
+  if (approx_dist > S_CLIPPING_DIST || approx_dist <= 0)
     return 0;
 
   // angle of source to listener


### PR DESCRIPTION
Sound emitters play their sounds at full volume when the listener-to-sound distance approximation is greater than 32,767 due to the value overflowing to a negative one. An example where this can happen is in large maps where enemies are awake in faraway out of bounds teleporter closets.