### PR TITLE
New death use action to restart demo/level

### DIFF
--- a/prboom2/src/dsda/death.c
+++ b/prboom2/src/dsda/death.c
@@ -32,12 +32,16 @@ typedef enum {
   death_use_default,
   death_use_nothing,
   death_use_reload,
+  death_use_restart
 } death_use_action_t;
 
 int dsda_death_use_action;
 
 static int dsda_DeathUseAction(void)
 {
+  if (!demoplayback && demorecording && dsda_death_use_action == death_use_restart)
+    return death_use_restart;
+
   if (demorecording || demoplayback)
     return death_use_default;
 
@@ -86,6 +90,9 @@ void dsda_DeathUse(player_t* player) {
         if (slot >= 0)
           G_LoadGame(slot);
       }
+      break;
+    case death_use_restart:
+      G_ReloadLevel();
       break;
   }
 }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3263,7 +3263,7 @@ static const char *gen_compstrings[] =
   NULL
 };
 
-static const char *death_use_strings[] = { "default", "nothing", "reload", NULL };
+static const char *death_use_strings[] = { "default", "nothing", "reload", "restart", NULL };
 
 static const char *renderfilters[] = { "none", "point", "linear", "rounded" };
 static const char *edgetypes[] = { "jagged", "sloped" };

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -823,7 +823,7 @@ default_t defaults[] =
   { "dsda_show_split_data", { &dsda_show_split_data }, { 1 }, 0, 1, def_bool, ss_stat },
   { "dsda_player_name", { 0, &dsda_player_name }, { 0, "Anonymous" }, UL, UL, def_str, ss_none },
   { "dsda_quickstart_cache_tics", { &dsda_quickstart_cache_tics }, { 0 }, 0, 35, def_int, ss_stat },
-  { "dsda_death_use_action", { &dsda_death_use_action }, { 0 }, 0, 2, def_int, ss_none },
+  { "dsda_death_use_action", { &dsda_death_use_action }, { 0 }, 0, 3, def_int, ss_none },
   { "dsda_mute_sfx", { (int *) &dsda_setting[dsda_mute_sfx] }, { 0 }, 0, 1, def_bool, ss_stat },
   { "dsda_mute_music", { (int *) &dsda_setting[dsda_mute_music] }, { 0 }, 0, 1, def_bool, ss_stat },
   { "dsda_cheat_codes", { (int *) &dsda_setting[dsda_cheat_codes] }, { 1 }, 0, 1, def_bool, ss_stat },


### PR DESCRIPTION
This adds a death use action that fully restarts the demo/level, like the "Restart Demo"/"Restart Level" button does.

That button is super helpful, but I have been doing nightmare runs, which involves a lot of dying. It's easy in the heat of the moment to press "use" instead of "restart" after dying and not realizing you're still recording in the old demo. Or sometimes you try to open a door or something at the same time you die, and you forget to restart for a new demo. The "nothing" action works but it breaks the flow a bit.

When the "death use action" is set to "restart", and a demo isn't being played back, the death use action will restart the demo if recording, or the level if not, just like the button usually does. Another advantage is that since it's a full restart, you start with the same rng everytime, unlike the regular respawn.