### PR TITLE
Purge demoex file

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -192,10 +192,6 @@ static void I_EssentialQuit (void)
 static void I_Quit (void)
 {
   M_SaveDefaults ();
-
-  // This function frees all WAD data as a side effect (!!!)
-  // You MUST NOT call this function before any code that touches lump data (e.g., music shutdown)
-  I_DemoExShutdown();
 }
 
 //

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1439,6 +1439,27 @@ static void HandleClass(void)
   randomclass = dsda_Flag(dsda_arg_randclass);
 }
 
+static void HandlePlayback(void)
+{
+  const char* name;
+
+  name = dsda_ParsePlaybackOptions();
+
+  if (name)
+  {
+    char *file = Z_Malloc(strlen(name) + 4 + 1); // cph - localised
+    strcpy(file, name);
+    AddDefaultExtension(file, ".lmp");     // killough
+    D_AddFile (file, source_lmp);
+    //jff 9/3/98 use logical output routine
+    lprintf(LO_INFO, "Playing demo %s\n", file);
+    Z_Free(file);
+
+    //e6y
+    G_CheckDemoEx();
+  }
+}
+
 const char* doomverstr = NULL;
 
 static void EvaluateDoomVerStr(void)
@@ -1662,25 +1683,7 @@ static void D_DoomMainSetup(void)
     }
   }
 
-  {
-    const char* name;
-
-    name = dsda_ParsePlaybackOptions();
-
-    if (name)
-    {
-      char *file = Z_Malloc(strlen(name) + 4 + 1); // cph - localised
-      strcpy(file, name);
-      AddDefaultExtension(file, ".lmp");     // killough
-      D_AddFile (file, source_lmp);
-      //jff 9/3/98 use logical output routine
-      lprintf(LO_INFO, "Playing demo %s\n", file);
-      Z_Free(file);
-    }
-  }
-
-  //e6y
-  G_CheckDemoEx();
+  HandlePlayback();
 
   // add wad files from autoload PWAD directories
   if (autoload)

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1439,12 +1439,75 @@ static void HandleClass(void)
   randomclass = dsda_Flag(dsda_arg_randclass);
 }
 
+const char* doomverstr = NULL;
+
+static void EvaluateDoomVerStr(void)
+{
+  switch ( gamemode )
+  {
+    case retail:
+      switch (gamemission)
+      {
+        case chex:
+          doomverstr = "Chex(R) Quest";
+          break;
+        default:
+          doomverstr = "The Ultimate DOOM";
+          break;
+      }
+      break;
+    case shareware:
+      doomverstr = "DOOM Shareware";
+      break;
+    case registered:
+      doomverstr = "DOOM Registered";
+      break;
+    case commercial:  // Ty 08/27/98 - fixed gamemode vs gamemission
+      switch (gamemission)
+      {
+        case pack_plut:
+          doomverstr = "Final DOOM - The Plutonia Experiment";
+          break;
+        case pack_tnt:
+          doomverstr = "Final DOOM - TNT: Evilution";
+          break;
+        case hacx:
+          doomverstr = "HACX - Twitch 'n Kill";
+          break;
+        default:
+          doomverstr = "DOOM 2: Hell on Earth";
+          break;
+      }
+      break;
+    default:
+      doomverstr = "Public DOOM";
+      break;
+  }
+
+  if (bfgedition)
+  {
+    char *tempverstr;
+    const char bfgverstr[]=" (BFG Edition)";
+    tempverstr = Z_Malloc(sizeof(char) * (strlen(doomverstr)+strlen(bfgverstr)+1));
+    strcpy (tempverstr, doomverstr);
+    strcat (tempverstr, bfgverstr);
+    doomverstr = Z_Strdup (tempverstr);
+    Z_Free (tempverstr);
+  }
+
+  /* cphipps - the main display. This shows the build date, copyright, and game type */
+  lprintf(LO_INFO,PACKAGE_NAME" (built %s), playing: %s\n"
+    PACKAGE_NAME" is released under the GNU General Public license v2.0.\n"
+    "You are welcome to redistribute it under certain conditions.\n"
+    "It comes with ABSOLUTELY NO WARRANTY. See the file COPYING for details.\n",
+    version_date, doomverstr);
+}
+
 //
 // D_DoomMainSetup
 //
 // CPhipps - the old contents of D_DoomMain, but moved out of the main
 //  line of execution so its stack space can be freed
-const char* doomverstr = NULL;
 
 static void D_DoomMainSetup(void)
 {
@@ -1487,66 +1550,7 @@ static void D_DoomMainSetup(void)
   else if (dsda_Flag(dsda_arg_deathmatch))
     deathmatch = 1;
 
-  {
-    switch ( gamemode )
-    {
-      case retail:
-        switch (gamemission)
-        {
-          case chex:
-            doomverstr = "Chex(R) Quest";
-            break;
-          default:
-            doomverstr = "The Ultimate DOOM";
-            break;
-        }
-        break;
-      case shareware:
-        doomverstr = "DOOM Shareware";
-        break;
-      case registered:
-        doomverstr = "DOOM Registered";
-        break;
-      case commercial:  // Ty 08/27/98 - fixed gamemode vs gamemission
-        switch (gamemission)
-        {
-          case pack_plut:
-            doomverstr = "Final DOOM - The Plutonia Experiment";
-            break;
-          case pack_tnt:
-            doomverstr = "Final DOOM - TNT: Evilution";
-            break;
-          case hacx:
-            doomverstr = "HACX - Twitch 'n Kill";
-            break;
-          default:
-            doomverstr = "DOOM 2: Hell on Earth";
-            break;
-        }
-        break;
-      default:
-        doomverstr = "Public DOOM";
-        break;
-    }
-
-    if (bfgedition)
-    {
-      char *tempverstr;
-      const char bfgverstr[]=" (BFG Edition)";
-      tempverstr = Z_Malloc(sizeof(char) * (strlen(doomverstr)+strlen(bfgverstr)+1));
-      strcpy (tempverstr, doomverstr);
-      strcat (tempverstr, bfgverstr);
-      doomverstr = Z_Strdup (tempverstr);
-      Z_Free (tempverstr);
-    }
-
-    /* cphipps - the main display. This shows the build date, copyright, and game type */
-    lprintf(LO_INFO,PACKAGE_NAME" (built %s), playing: %s\n"
-      PACKAGE_NAME" is released under the GNU General Public license v2.0.\n"
-      "You are welcome to redistribute it under certain conditions.\n"
-      "It comes with ABSOLUTELY NO WARRANTY. See the file COPYING for details.\n",
-      version_date, doomverstr);
-  }
+  EvaluateDoomVerStr();
 
   if (devparm)
     //jff 9/3/98 use logical output routine

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1658,6 +1658,8 @@ static void D_DoomMainSetup(void)
 
   D_AddFile(port_wad_file, source_auto_load);
 
+  HandlePlayback(); // must come before autoload: may detect iwad in footer
+
   // add wad files from autoload directory before wads from -file parameter
   if (autoload)
     D_AutoloadIWadDir();
@@ -1692,8 +1694,6 @@ static void D_DoomMainSetup(void)
       Z_Free(file);
     }
   }
-
-  HandlePlayback();
 
   // add wad files from autoload PWAD directories
   if (autoload)

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1676,7 +1676,7 @@ static void D_DoomMainSetup(void)
   }
 
   //e6y
-  CheckDemoExDemo();
+  G_CheckDemoEx();
 
   // add wad files from autoload PWAD directories
   if (autoload)

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -791,6 +791,16 @@ void D_AddFile (const char *file, wad_source_t source)
   char *gwa_filename=NULL;
   int len;
 
+  // There can only be one iwad source!
+  if (source == source_iwad)
+  {
+    int i;
+
+    for (i = 0; i < numwadfiles; ++i)
+      if (wadfiles[i].src == source_iwad)
+        wadfiles[i].src = source_skip;
+  }
+
   wadfiles = Z_Realloc(wadfiles, sizeof(*wadfiles)*(numwadfiles+1));
   wadfiles[numwadfiles].name =
     AddDefaultExtension(strcpy(Z_Malloc(strlen(file)+5), file), ".wad");

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -813,7 +813,7 @@ void D_AddFile (const char *file, wad_source_t source)
     ext[1] = 'g'; ext[2] = 'w'; ext[3] = 'a';
     wadfiles = Z_Realloc(wadfiles, sizeof(*wadfiles)*(numwadfiles+1));
     wadfiles[numwadfiles].name = gwa_filename;
-    wadfiles[numwadfiles].src = source; // Ty 08/29/98
+    wadfiles[numwadfiles].src = source_pwad; // Ty 08/29/98
     wadfiles[numwadfiles].handle = 0;
     numwadfiles++;
   }

--- a/prboom2/src/r_demo.c
+++ b/prboom2/src/r_demo.c
@@ -366,7 +366,12 @@ static void R_DemoEx_GetParams(const wadinfo_t *header)
             {
               filename = Z_Strdup(params[p]);
             }
-            D_AddFile(filename, files[i].source);
+
+            if (files[i].source == source_iwad)
+              AddIWAD(filename);
+            else
+              D_AddFile(filename, files[i].source);
+
             Z_Free(filename);
           }
         }

--- a/prboom2/src/r_demo.h
+++ b/prboom2/src/r_demo.h
@@ -35,15 +35,9 @@
 #ifndef __R_DEMO__
 #define __R_DEMO__
 
-#include "doomdef.h"
 #include "doomtype.h"
 #include "tables.h"
 #include "d_player.h"
-#include "w_wad.h"
-
-//
-// Smooth playing stuff
-//
 
 #define SMOOTH_PLAYING_MAXFACTOR 16
 
@@ -55,34 +49,8 @@ void R_SmoothPlaying_Add(int delta);
 angle_t R_SmoothPlaying_Get(player_t *player);
 void R_ResetAfterTeleport(player_t *player);
 
-//
-// DemoEx stuff
-//
-
-typedef struct
-{
-  wadinfo_t header;
-  filelump_t *lumps;
-  char* data;
-  int datasize;
-} wadtbl_t;
-
-typedef struct
-{
-  wadfile_info_t *wadfiles;
-  size_t numwadfiles;
-} waddata_t;
-
-int WadDataInit(waddata_t *waddata);
-int WadDataAddItem(waddata_t *waddata, const char *filename, wad_source_t source, int handle);
-void WadDataFree(waddata_t *wadfiles);
-
-int CheckDemoExDemo(void);
-void WadDataToWadFiles(waddata_t *waddata);
-
-byte* G_GetDemoFooter(const char *filename, const byte **footer, size_t *size);
+void G_CheckDemoEx(void);
 void G_WriteDemoFooter(void);
-void I_DemoExShutdown(void);
 
 int LoadDemo(const char *name, const byte **buffer, int *length);
 

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -527,31 +527,6 @@ void W_Init(void)
   V_FreePlaypal();
 }
 
-void W_ReleaseAllWads(void)
-{
-  size_t i;
-
-  W_DoneCache();
-
-  for (i = 0; i < numwadfiles; i++)
-  {
-    if (wadfiles[i].handle > 0)
-    {
-      close(wadfiles[i].handle);
-      wadfiles[i].handle = 0;
-    }
-  }
-
-  numwadfiles = 0;
-  Z_Free(wadfiles);
-  wadfiles = NULL;
-  numlumps = 0;
-  Z_Free(lumpinfo);
-  lumpinfo = NULL;
-
-  V_FreePlaypal();
-}
-
 //
 // W_LumpLength
 // Returns the buffer size needed to load the given lump.

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -142,6 +142,11 @@ static void W_AddFile(wadfile_info_t *wadfile)
   filelump_t  singleinfo;
   int         flags = 0;
 
+  if (wadfile->src == source_skip)
+  {
+    return;
+  }
+
   // Close any existing handle
   if (wadfile->handle > 0)
   {

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -68,7 +68,7 @@ typedef struct
 // CPhipps - defined enum in wider scope
 // Ty 08/29/98 - add source field to identify where this lump came from
 typedef enum {
-  // CPhipps - define elements in order of 'how new/unusual'
+  source_skip = -1,
   source_iwad=0,    // iwad file load
   source_pre,       // predefined lump
   source_auto_load, // lump auto-loaded by config file

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -97,7 +97,6 @@ extern wadfile_info_t *wadfiles;
 extern size_t numwadfiles; // CPhipps - size of the wadfiles array
 
 void W_Init(void); // CPhipps - uses the above array
-void W_ReleaseAllWads(void); // Proff - Added for iwad switching
 void W_InitCache(void);
 void W_DoneCache(void);
 


### PR DESCRIPTION
Previously, loading the demo footer involved these steps:

- Load the demo file
- Locate the end marker
- Check for the pwad signature
- Copy the demo footer as a pwad into a temporary file
- Add the temporary file to the wad list
- Load _all_ wad files
- Read the necessary lump from the demo ex pwad
- Unload _all_ wad files
- Unload the demo

This PR changes it to instead read the demo footer in memory directly.

There is another quirk of the startup procedure:

- The port tries to guess the IWAD (defaults to doom2 if it finds it)
- The demo footer can add an IWAD (-iwad DOOM.WAD for instance)
- Now the wad file list has multiple iwads, and the autoload may load wads for the wrong iwad

This PR marks obsoleted IWADs to be skipped, which causes them to be ignored for autoload as well as when loading the wad files themselves in W_Init.