### PR TITLE
Do not count inaudible sounds toward parallel sound limit

### DIFF
--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -301,8 +301,6 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume)
 
   sfx = &S_sfx[sfx_id];
 
-  if (dsda_BlockSFX(sfx)) return;
-
   // Initialize sound parameters
   if (sfx->flags & SFXF_PRIORITY)
     priority = sfx->priority;
@@ -339,6 +337,8 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume)
       if ( origin->x == players[displayplayer].mo->x &&
            origin->y == players[displayplayer].mo->y)
         sep = NORM_SEP;
+
+  if (dsda_BlockSFX(sfx)) return;
 
   // hacks to vary the sfx pitches
   if (sfx_id >= sfx_sawup && sfx_id <= sfx_sawhit)


### PR DESCRIPTION
Placing the dsda_BlockSFX call after S_AdjustSoundParams prevents sounds that are too far away to be heard from counting toward the parallel sound limit.

The effect of this can be heard in the test map created for [this Doomworld post](https://www.doomworld.com/forum/topic/118074-dsda-doom-source-port-v0243/?page=37&tab=comments#comment-2451596). Without this change, waking up the revenants from the player start location produces no sound, while doing so from the other side produces the loud revenant cries that one would expect. With this change, the revenant wake-up is audible from both sides. It's not perfect (the sound is noticeably quieter from the player start location), but this should prevent the most jarring effects of the parallel sound limit.