### PR TITLE
Fix translucent sprites in indexed lightmode

### DIFF
--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -321,8 +321,16 @@ void glsl_SetFuzzShaderInactive()
 {
   if (active_shader == sh_fuzz)
   {
-    GLEXT_glUseProgramObjectARB(0);
-    active_shader = NULL;
+    if (V_IsWorldLightmodeIndexed())
+    {
+      GLEXT_glUseProgramObjectARB(sh_indexed->hShader);
+      active_shader = sh_indexed;
+    }
+    else
+    {
+      GLEXT_glUseProgramObjectARB(sh_main->hShader);
+      active_shader = sh_main;
+    }
   }
 }
 


### PR DESCRIPTION
Fix translucent sprites rendering in red color (discussed in this thread: https://github.com/kraflab/dsda-doom/issues/152)