### PR TITLE
Abstract sfx params into sfx_params_t struct

### DIFF
--- a/prboom2/src/i_pcsound.c
+++ b/prboom2/src/i_pcsound.c
@@ -135,12 +135,7 @@ static dboolean CachePCSLump(int sound_id)
     return true;
 }
 
-int I_PCS_StartSound(int id,
-                     int channel,
-                     int vol,
-                     int sep,
-                     int pitch,
-                     int priority)
+int I_PCS_StartSound(int id, int channel, sfx_params_t *params)
 {
     int result;
 

--- a/prboom2/src/i_pcsound.h
+++ b/prboom2/src/i_pcsound.h
@@ -26,12 +26,9 @@
 #ifndef __I_PCSOUND_H__
 #define __I_PCSOUND_H__
 
-int I_PCS_StartSound(int id,
-                     int channel,
-                     int vol,
-                     int sep,
-                     int pitch,
-                     int priority);
+#include "sounds.h"
+
+int I_PCS_StartSound(int id, int channel, sfx_params_t *params);
 void I_PCS_StopSound(int handle);
 int I_PCS_SoundIsPlaying(int handle);
 void I_PCS_InitSound(void);

--- a/prboom2/src/i_sound.h
+++ b/prboom2/src/i_sound.h
@@ -63,7 +63,7 @@ void I_SetChannels(void);
 int I_GetSfxLumpNum (sfxinfo_t *sfxinfo);
 
 // Starts a sound in a particular sound channel.
-int I_StartSound(int id, int channel, int vol, int sep, int pitch, int priority);
+int I_StartSound(int id, int channel, sfx_params_t *params);
 
 // Stops a sound channel.
 void I_StopSound(int handle);
@@ -78,7 +78,7 @@ dboolean I_AnySoundStillPlaying(void);
 
 // Updates the volume, separation,
 //  and pitch of a sound channel.
-void I_UpdateSoundParams(int handle, int vol, int sep, int pitch);
+void I_UpdateSoundParams(int handle, sfx_params_t *params);
 
 // NSM sound capture routines
 // silences sound output, and instead allows sound capture to work

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -40,6 +40,13 @@
 #define SFXF_VOLUME   0x04
 #define SFXF_OLDLINK (SFXF_PRIORITY|SFXF_PITCH|SFXF_VOLUME)
 
+typedef struct {
+  int volume;
+  int separation;
+  int pitch;
+  int priority;
+} sfx_params_t;
+
 //
 // SoundFX struct.
 //


### PR DESCRIPTION
This creates a simple and consistent interface in the sound parameter code, and allows adjusting the parameter data without editing the interfaces in the future (e.g., to introduce priority handling in doom).