### PR TITLE
Add setting for showing BFG tracers

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -196,6 +196,9 @@ void dsda_TrackConfigFeatures(void) {
   if (dsda_IntConfig(dsda_config_gl_health_bar))
     dsda_TrackFeature(uf_healthbar);
 
+  if (dsda_IntConfig(dsda_config_gl_bfg_tracers))
+    dsda_TrackFeature(uf_bfg_tracers);
+
   if (dsda_IntConfig(dsda_config_movement_strafe50))
     dsda_TrackFeature(uf_alwayssr50);
 
@@ -613,6 +616,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_gl_health_bar] = {
     "gl_health_bar", dsda_config_gl_health_bar,
+    CONF_BOOL(0), NULL, STRICT_INT(0)
+  },
+  [dsda_config_gl_bfg_tracers] = {
+    "gl_bfg_tracers", dsda_config_gl_bfg_tracers,
     CONF_BOOL(0), NULL, STRICT_INT(0)
   },
   [dsda_config_use_mouse] = {

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -123,6 +123,7 @@ typedef enum {
   dsda_config_gl_render_fov,
   dsda_config_gl_lightmode,
   dsda_config_gl_health_bar,
+  dsda_config_gl_bfg_tracers,
   dsda_config_use_mouse,
   dsda_config_mouse_sensitivity_horiz,
   dsda_config_mouse_sensitivity_vert,

--- a/prboom2/src/dsda/features.c
+++ b/prboom2/src/dsda/features.c
@@ -57,6 +57,7 @@ static const char* feature_names[64] = {
   [uf_bonuspalette] = "Disable Bonus Palette",
   [uf_powerpalette] = "Disable Power Palette",
   [uf_healthbar] = "Show Health Bars",
+  [uf_bfg_tracers] = "Show BFG Tracers",
   [uf_alwayssr50] = "Always SR50",
   [uf_maxplayercorpse] = "Edit Corpse Limit",
   [uf_hideweapon] = "Hide Weapon",

--- a/prboom2/src/dsda/features.h
+++ b/prboom2/src/dsda/features.h
@@ -82,7 +82,7 @@ typedef enum {
   uf_join,
   uf_free_analog,
   uf_ghost,
-  // 62
+  uf_bfg_tracers,
   // 63
 } dsda_feature_flag_t;
 

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -231,6 +231,10 @@ dboolean dsda_ShowHealthBars(void) {
   return dsda_IntConfig(dsda_config_gl_health_bar);
 }
 
+dboolean dsda_ShowBFGTracers(void) {
+  return dsda_IntConfig(dsda_config_gl_bfg_tracers);
+}
+
 dboolean dsda_WipeAtFullSpeed(void) {
   return dsda_IntConfig(dsda_config_wipe_at_full_speed);
 }

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -49,6 +49,7 @@ dboolean dsda_ShowFPS(void);
 dboolean dsda_ShowLevelSplits(void);
 dboolean dsda_ShowDemoAttempts(void);
 dboolean dsda_ShowHealthBars(void);
+dboolean dsda_ShowBFGTracers(void);
 dboolean dsda_MapPointCoordinates(void);
 dboolean dsda_PainPalette(void);
 dboolean dsda_BonusPalette(void);

--- a/prboom2/src/dsda/utility.h
+++ b/prboom2/src/dsda/utility.h
@@ -49,6 +49,20 @@ typedef struct {
   size_t size;
 } dsda_string_t;
 
+typedef struct {
+  fixed_t src_x;
+  fixed_t src_y;
+  fixed_t src_z;
+
+  fixed_t dst_x[40];
+  fixed_t dst_y[40];
+  fixed_t dst_z[40];
+
+  dboolean hit[40];
+  dboolean show;
+  int start_tick;
+} dsda_bfg_tracers_t;
+
 void dsda_InitString(dsda_string_t* dest, const char* value);
 void dsda_FreeString(dsda_string_t* dest);
 void dsda_StringCat(dsda_string_t* dest, const char* source);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -107,6 +107,7 @@
 #include "dsda/skip.h"
 #include "dsda/time.h"
 #include "dsda/split_tracker.h"
+#include "dsda/utility.h"
 
 struct
 {
@@ -136,6 +137,8 @@ struct
 // of need to savegame format change from one minor version to another.
 // The old format is still supported.
 #define NEWFORMATSIG "\xff\xff\xff\xff"
+
+extern dsda_bfg_tracers_t dsda_bfg_tracers;
 
 static const byte *demobuffer;   /* cph - only used for playback */
 static int demolength; // check for overrun (missing DEMOMARKER)
@@ -2949,6 +2952,9 @@ void G_InitNew(skill_t skill, int episode, int map, dboolean prepare)
   dsda_InitSky();
 
   G_DoLoadLevel ();
+
+  // hide all BFG tracers
+  dsda_bfg_tracers.show = false;
 }
 
 //

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3042,6 +3042,7 @@ setup_menu_t demo_settings[] = {
   { "Casual Play Settings", S_SKIP | S_TITLE, m_null, G_X, G_Y + 12 * 8 },
   { "Allow Jumping", S_YESNO, m_conf, G_X, G_Y + 13 * 8, dsda_config_allow_jumping },
   { "OpenGL Show Health Bars", S_YESNO, m_conf, G_X, G_Y + 14 * 8, dsda_config_gl_health_bar },
+  { "OpenGL Show BFG Tracers", S_YESNO, m_conf, G_X, G_Y + 15 * 8, dsda_config_gl_bfg_tracers },
 
   PREV_PAGE(KB_PREV, KB_Y + 20 * 8, mapping_settings),
   NEXT_PAGE(KB_NEXT, KB_Y + 20 * 8, tas_settings),

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -257,6 +257,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_gl_skymode),
   MIGRATED_SETTING(dsda_config_gl_usegamma),
   MIGRATED_SETTING(dsda_config_gl_health_bar),
+  MIGRATED_SETTING(dsda_config_gl_bfg_tracers),
 
   SETTING_HEADING("Mouse settings"),
   MIGRATED_SETTING(dsda_config_use_mouse),


### PR DESCRIPTION
BFG tracers is quite complicated mechanism and difficult to properly learn.
This new option and new TAS setting (only for OpenGL) to show BFG tracers (and if they hit), which will make learning usage of BFG much more easier.