### PR TITLE
Fixes and addition about macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /prboom2/ICONS/icons.aps
 /prboom2/release
 /build*
+/release*
 /dependencies*
 
 # spec files
@@ -8,3 +9,6 @@ analysis.txt
 levelstat.txt
 /spec/support/wads/*
 !/spec/support/wads/analysis_test.wad
+
+# macOS
+.DS_Store

--- a/docs/guides/building_on_macos.md
+++ b/docs/guides/building_on_macos.md
@@ -1,7 +1,7 @@
-# Building DSDA-Doom on MacOS
-This is a basic guide for building DSDA-Doom for a x86_64 or arm64 MacOS target using brew. 
+# Building DSDA-Doom on macOS
+This is a basic guide for building DSDA-Doom for a x86_64 or arm64 macOS target using brew. 
 ## Configure brew
-[brew](https://brew.sh) is a package manager for MacOS and Linux. we will use it to download everything we need to build DSDA-Doom.
+[brew](https://brew.sh) is a package manager for macOS and Linux. we will use it to download everything we need to build DSDA-Doom.
 
 To install it we need to run:
 ```
@@ -13,12 +13,12 @@ On arm64 machines, brew will be installed in `/opt/homebrew`.
 ## Install Build Dependencies
 Install cmake, SDL2 and additional dependencies for DSDA-Doom:
 ```
-brew install cmake pcre sdl2 sdl2_image sdl2_mixer fluid-synth portmidi libmad dumb libvorbis
+brew install cmake pcre sdl2 sdl2_image sdl2_mixer fluid-synth portmidi mad dumb libvorbis
 ```
 ## Build DSDA-Doom
 Make a clone of the DSDA-Doom Git repository:
 ```
-git clone https://github.com/kraflab/dsda-doom
+git clone https://github.com/kraflab/dsda-doom.git
 ```
 Prepare the build folder, generate the build system, and compile:
 ```
@@ -50,7 +50,6 @@ cd ./release
 dylibbundler -od -b -x ./dsda-doom -d ./libs/ -p @executable_path/libs
 ```
 
-
 ## Final Steps
 
 Since this is a release build, it's customary to remove symbols from the binaries (and since we are changing the binary file, we will need to codesign it again):
@@ -61,5 +60,5 @@ codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runt
 ```
 Finally, add the files to an archive with today's date:
 ```
-zip -j ~/dsda-doom-$(date +"%Y%m%d")-mac.zip .
+zip -j -r ./dsda-doom-$(date +"%Y%m%d")-mac.zip . -x .\*
 ```

--- a/docs/guides/building_on_macos.md
+++ b/docs/guides/building_on_macos.md
@@ -60,5 +60,5 @@ codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runt
 ```
 Finally, add the files to an archive with today's date:
 ```
-zip -j -r ./dsda-doom-$(date +"%Y%m%d")-mac.zip . -x .\*
+zip -r ./dsda-doom-$(date +"%Y%m%d")-mac.zip . -x .\*
 ```


### PR DESCRIPTION
- In the macOS guide:
  - Changed the brew formula relative to libmad (alias for mad package)
  - Fixed the options in zip command (--recurse-paths to include the .dylib files and --exclude .\* for Desktop files from the compressed archive).
- Ignore .DS_Store and /release*

Cc: @Pedro-Beirao 