### PR TITLE
Fix Raw screens (e.g. Heretic titlepic) in indexed lightmode

### DIFF
--- a/prboom2/src/doomtype.h
+++ b/prboom2/src/doomtype.h
@@ -163,6 +163,7 @@ enum patch_translation_e {
   VPT_FLIP    = 256, // Flip image horizontally
   VPT_TRANS   = 512, // Translate image via a translation table
   VPT_NOOFFSET = 1024,
+  VPT_STRETCH_REAL       = 2048, // [XA] VPT_STRETCH in gld_fillRect means "tile", rather than "stretch"... these flags probably need a rename.
 };
 
 #define arrlen(array) (sizeof(array) / sizeof(*array))

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -378,8 +378,12 @@ GLTexture *gld_RegisterTexture(int texture_num, dboolean mipmap, dboolean force,
 void gld_BindTexture(GLTexture *gltexture, unsigned int flags);
 GLTexture *gld_RegisterPatch(int lump, int cm, dboolean is_sprite, dboolean indexed);
 void gld_BindPatch(GLTexture *gltexture, int cm);
-GLTexture *gld_RegisterFlat(int lump, dboolean mipmap, dboolean indexed);
-void gld_BindFlat(GLTexture *gltexture, unsigned int flags);
+GLTexture *gld_RegisterRaw(int lump, int width, int height, dboolean mipmap, dboolean indexed);
+void gld_BindRaw(GLTexture *gltexture, unsigned int flags);
+#define gld_RegisterFlat(lump, mipmap, indexed) \
+  gld_RegisterRaw((firstflat+lump), 64, 64, (mipmap), (indexed))
+#define gld_BindFlat(gltexture, flags) \
+  gld_BindRaw((gltexture), (flags))
 GLTexture *gld_RegisterSkyTexture(int texture_num, dboolean force);
 void gld_BindSkyTexture(GLTexture *gltexture);
 GLTexture *gld_RegisterColormapTexture(int palette_index, int gamma_level);

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -711,7 +711,7 @@ void gld_DrawNumPatch(int x, int y, int lump, int cm, enum patch_translation_e f
   gld_DrawNumPatch_f((float)x, (float)y, lump, cm, flags);
 }
 
-void gld_FillFlat(int lump, int x, int y, int width, int height, enum patch_translation_e flags)
+void gld_FillRaw(int lump, int x, int y, int src_width, int src_height, int dst_width, int dst_height, enum patch_translation_e flags)
 {
   GLTexture *gltexture;
   float fU1, fU2, fV1, fV2;
@@ -720,8 +720,8 @@ void gld_FillFlat(int lump, int x, int y, int width, int height, enum patch_tran
   int saved_boom_cm = boom_cm;
   boom_cm = 0;
 
-  gltexture = gld_RegisterFlat(lump, false, V_IsUILightmodeIndexed());
-  gld_BindFlat(gltexture, 0);
+  gltexture = gld_RegisterRaw(lump, src_width, src_height, false, V_IsUILightmodeIndexed());
+  gld_BindRaw(gltexture, 0);
 
   //e6y
   boom_cm = saved_boom_cm;
@@ -733,20 +733,20 @@ void gld_FillFlat(int lump, int x, int y, int width, int height, enum patch_tran
   {
     x = x * SCREENWIDTH / 320;
     y = y * SCREENHEIGHT / 200;
-    width = width * SCREENWIDTH / 320;
-    height = height * SCREENHEIGHT / 200;
+    dst_width = dst_width * SCREENWIDTH / 320;
+    dst_height = dst_height * SCREENHEIGHT / 200;
   }
 
   fU1 = 0;
   fV1 = 0;
-  fU2 = (float)width / (float)gltexture->realtexwidth;
-  fV2 = (float)height / (float)gltexture->realtexheight;
+  fU2 = (float)dst_width / (float)gltexture->realtexwidth;
+  fV2 = (float)dst_height / (float)gltexture->realtexheight;
 
   glBegin(GL_TRIANGLE_STRIP);
     glTexCoord2f(fU1, fV1); glVertex2f((float)(x),(float)(y));
-    glTexCoord2f(fU1, fV2); glVertex2f((float)(x),(float)(y + height));
-    glTexCoord2f(fU2, fV1); glVertex2f((float)(x + width),(float)(y));
-    glTexCoord2f(fU2, fV2); glVertex2f((float)(x + width),(float)(y + height));
+    glTexCoord2f(fU1, fV2); glVertex2f((float)(x),(float)(y + dst_height));
+    glTexCoord2f(fU2, fV1); glVertex2f((float)(x + dst_width),(float)(y));
+    glTexCoord2f(fU2, fV2); glVertex2f((float)(x + dst_width),(float)(y + dst_height));
   glEnd();
 }
 

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -729,6 +729,7 @@ void gld_FillRaw(int lump, int x, int y, int src_width, int src_height, int dst_
   if (!gltexture)
     return;
 
+  // [XA] NOTE: this flag actually means "tile", not stretch...
   if (flags & VPT_STRETCH)
   {
     x = x * SCREENWIDTH / 320;
@@ -739,8 +740,18 @@ void gld_FillRaw(int lump, int x, int y, int src_width, int src_height, int dst_
 
   fU1 = 0;
   fV1 = 0;
-  fU2 = (float)dst_width / (float)gltexture->realtexwidth;
-  fV2 = (float)dst_height / (float)gltexture->realtexheight;
+
+  // [XA] ...this flag means "stretch". welp.
+  if (flags & VPT_STRETCH_REAL)
+  {
+    fU2 = 1.0f;
+    fV2 = 1.0f;
+  }
+  else
+  {
+    fU2 = (float)dst_width / (float)gltexture->realtexwidth;
+    fV2 = (float)dst_height / (float)gltexture->realtexheight;
+  }
 
   glBegin(GL_TRIANGLE_STRIP);
     glTexCoord2f(fU1, fV1); glVertex2f((float)(x),(float)(y));

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -90,7 +90,12 @@ void gld_EndAutomapDraw(void);
 void gld_DrawNumPatch(int x, int y, int lump, int cm, enum patch_translation_e flags);
 void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translation_e flags);
 
-void gld_FillFlat(int lump, int x, int y, int width, int height, enum patch_translation_e flags);
+void gld_FillRaw(int lump, int x, int y, int src_width, int src_height, int dst_width, int dst_height, enum patch_translation_e flags);
+#define gld_FillRawName(name, x, y, src_width, src_height, dst_width, dst_height, flags) \
+  gld_FillRaw(W_GetNumForName(name), (x), (y), (src_width), (src_height), (dst_width), (dst_height), (flags))
+
+#define gld_FillFlat(lump, x, y, width, height, flags) \
+  gld_FillRaw((firstflat+lump), (x), (y), 64, 64, (width), (height), (flags))
 #define gld_FillFlatName(flatname, x, y, width, height, flags) \
   gld_FillFlat(R_FlatNumForName(flatname), (x), (y), (width), (height), (flags))
 


### PR DESCRIPTION
See title -- this partially addresses #161, but I haven't yet covered the general V_FillRect case just yet (got another train of thought on how to fix that which I need to play with).

Nice bonus: this fix actually uses the shader, rather than disabling it, so gamma works for the titlepic:
![2022-12-21 00_07_31-dsda-doom 0 24 3](https://user-images.githubusercontent.com/4601589/208841843-cef8066a-06fa-490b-a609-36a947463593.png)

Heretic's E2 endscreen and E3 scroller are working with this new method, BTW -- still no gamma in intermission screens but that's a separate thing to address; if nothing else, it's consistent. ;)
