### PR TITLE
Fix IDDIT/IDDKT not being repeatable with only one item/monster

### DIFF
--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -646,7 +646,6 @@ static void cheat_reveal_secret()
   }
 }
 
-// TODO function doesn't work if there's only one item/monster
 static void cheat_cycle_mobj(mobj_t **last_mobj, int *last_count, int flags, int alive)
 {
   extern int init_thinkers_count;
@@ -673,12 +672,11 @@ static void cheat_cycle_mobj(mobj_t **last_mobj, int *last_count, int flags, int
     {
       mobj_t *mobj;
 
-      dsda_UpdateIntConfig(dsda_config_automap_follow, false, true);
-
       mobj = (mobj_t *) th;
 
       if ((!alive || mobj->health > 0) && mobj->flags & flags)
       {
+        dsda_UpdateIntConfig(dsda_config_automap_follow, false, true);
         AM_SetMapCenter(mobj->x, mobj->y);
         P_SetTarget(last_mobj, mobj);
         break;

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -646,6 +646,7 @@ static void cheat_reveal_secret()
   }
 }
 
+// TODO function doesn't work if there's only one item/monster
 static void cheat_cycle_mobj(mobj_t **last_mobj, int *last_count, int flags, int alive)
 {
   extern int init_thinkers_count;
@@ -665,8 +666,9 @@ static void cheat_cycle_mobj(mobj_t **last_mobj, int *last_count, int flags, int
 
   start_th = th;
 
-  for (th = th->next; th != start_th; th = th->next)
+  do
   {
+    th = th->next;
     if (th->function == P_MobjThinker)
     {
       mobj_t *mobj;
@@ -682,7 +684,7 @@ static void cheat_cycle_mobj(mobj_t **last_mobj, int *last_count, int flags, int
         break;
       }
     }
-  }
+  } while (th != start_th);
 }
 
 static void cheat_reveal_kill()


### PR DESCRIPTION
This fixes a bug where the IDDIT and IDDKT (but not IDDST) cheat codes would only work once if there were only one item/monster remaining (the cheat would work the first time, but subsequent times would not recenter the automap on the item/monster).

Also made it so that follow mode isn't turned off if there are no items/monsters remaining, like how IDDST behaves with no secrets remaining.