### PR TITLE
PortMidi: Send "reset all controllers" when song loops

### DIFF
--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -623,7 +623,10 @@ static void pm_render (void *vdest, unsigned bufflen)
               eventpos = 0;
               // prevent hanging notes (doom2.wad MAP14, MAP22)
               for (int i = 0; i < 16; i++)
+              {
                 writeevent (when, 0xB0, i, 0x7B, 0x00); // all notes off
+                writeevent (when, 0xB0, i, 0x79, 0x00); // reset all controllers
+              }
               continue;
             }
             pm_stop();


### PR DESCRIPTION
Matches Vanilla Doom behavior and prevents hanging notes (NIN.WAD E1M8). Fixes a very old PrBoom+ bug: https://github.com/coelckers/prboom-plus/issues/559