### PR TITLE
Fix weapon bobbing interpolation

### DIFF
--- a/prboom2/src/p_pspr.h
+++ b/prboom2/src/p_pspr.h
@@ -80,6 +80,8 @@ typedef struct
   int     tics;
   fixed_t sx;
   fixed_t sy;
+  fixed_t sx2;
+  fixed_t sy2;
 } pspdef_t;
 
 enum

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1015,8 +1015,8 @@ static void R_DrawPSprite (pspdef_t *psp)
   vissprite_t   avis;
   int           width;
   fixed_t       topoffset;
-  fixed_t       psp_sx = psp->sx;
-  fixed_t       psp_sy = psp->sy;
+  fixed_t       psp_sx = psp->sx2;
+  fixed_t       psp_sy = psp->sy2;
 
   // decide which patch to use
 
@@ -1063,7 +1063,7 @@ static void R_DrawPSprite (pspdef_t *psp)
 
       if (state != winfo->downstate && state != winfo->upstate)
       {
-        last_sy = psp->sy;
+        last_sy = psp_sy;
         psp_sy = 32 * FRACUNIT;
       }
       else if (state == winfo->downstate)


### PR DESCRIPTION
This uses an implementation similar to Crispy Doom to decouple weapon bob update rate from sprite timing. A smoother version is drawn on the screen while the original values are safely retained. Some related discussion [here](https://www.doomworld.com/forum/topic/121183-which-of-these-chainsaw-animations-is-the-correct-one/?tab=comments#comment-2292505).

https://user-images.githubusercontent.com/56656010/216520408-1f4ecc26-0c1c-47ea-9e2b-bf0e60507c11.mp4

