### PR TITLE
Migrate special args to ints

### DIFF
--- a/prboom2/src/doomdata.h
+++ b/prboom2/src/doomdata.h
@@ -321,7 +321,7 @@ typedef struct {
   short type;
   int options;
   int special;
-  byte args[5];
+  int special_args[5];
   fixed_t gravity;
   fixed_t health;
 } mapthing_t;

--- a/prboom2/src/doomdata.h
+++ b/prboom2/src/doomdata.h
@@ -321,11 +321,7 @@ typedef struct {
   short type;
   int options;
   int special;
-  byte arg1;
-  byte arg2;
-  byte arg3;
-  byte arg4;
-  byte arg5;
+  byte args[5];
   fixed_t gravity;
   fixed_t health;
 } mapthing_t;

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -219,8 +219,8 @@ extern void P_CompatiblePlayerThrust(player_t* player, angle_t angle, fixed_t mo
 extern void P_HereticPlayerThrust(player_t* player, angle_t angle, fixed_t move);
 extern void P_HexenPlayerThrust(player_t* player, angle_t angle, fixed_t move);
 
-extern dboolean P_ExecuteZDoomLineSpecial(int special, byte * args, line_t * line, int side, mobj_t * mo);
-extern dboolean P_ExecuteHexenLineSpecial(int special, byte * args, line_t * line, int side, mobj_t * mo);
+extern dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int side, mobj_t * mo);
+extern dboolean P_ExecuteHexenLineSpecial(int special, int * args, line_t * line, int side, mobj_t * mo);
 
 extern void T_VerticalCompatibleDoor(vldoor_t *door);
 extern void T_VerticalHexenDoor(vldoor_t *door);

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -53,7 +53,7 @@ typedef struct {
   void (*cross_special_line)(line_t *, int, mobj_t *, dboolean);
   void (*shoot_special_line)(mobj_t *, line_t *);
   dboolean (*test_activate_line)(line_t *, mobj_t *, int, line_activation_t);
-  dboolean (*execute_line_special)(int, byte *, line_t *, int, mobj_t *);
+  dboolean (*execute_line_special)(int, int *, line_t *, int, mobj_t *);
   void (*post_process_line_special)(line_t *);
   void (*post_process_sidedef_special)(side_t *, const mapsidedef_t *, sector_t *, int);
   void (*animate_surfaces)(void);

--- a/prboom2/src/hexen/a_action.c
+++ b/prboom2/src/hexen/a_action.c
@@ -314,6 +314,7 @@ void A_BridgeOrbit(mobj_t * actor)
         P_SetMobjState(actor, HEXEN_S_NULL);
     }
     actor->special_args[0] += 3;
+    actor->special_args[0] &= 0xff;
     actor->x = actor->target->x + orbitTableX[actor->special_args[0]];
     actor->y = actor->target->y + orbitTableY[actor->special_args[0]];
     actor->z = actor->target->z;
@@ -829,6 +830,7 @@ void A_SoAExplode(mobj_t * actor)
     }
     if (actor->special_args[0])
     {                           // Spawn an item
+        // TODO: should this be on or off?
 #if 0 // Checks are not present in version 1.1
         if (!nomonsters
             || !(mobjinfo[TranslateThingType[actor->special_args[0]]].

--- a/prboom2/src/hexen/a_action.c
+++ b/prboom2/src/hexen/a_action.c
@@ -392,12 +392,7 @@ void A_Summon(mobj_t * actor)
             return;
         }
 
-        // Store leveltime into mo->special_args. This must be stored in little-
-        // endian format for Vanilla savegame compatibility.
-        mo->special_args[0] = leveltime & 0xff;
-        mo->special_args[1] = (leveltime >> 8) & 0xff;
-        mo->special_args[2] = (leveltime >> 16) & 0xff;
-        mo->special_args[3] = (leveltime >> 24) & 0xff;
+        mo->special_args[0] = leveltime;
         master = actor->special1.m;
         if (master->flags & MF_CORPSE)
         {                       // Master dead

--- a/prboom2/src/hexen/a_action.c
+++ b/prboom2/src/hexen/a_action.c
@@ -116,14 +116,14 @@ void A_PotteryExplode(mobj_t * actor)
         mo->momy = P_SubRandom() << (FRACBITS - 6);
     }
     S_StartMobjSound(mo, hexen_sfx_pottery_explode);
-    if (actor->args[0])
+    if (actor->special_args[0])
     {                           // Spawn an item
         if (!nomonsters
-            || !(mobjinfo[TranslateThingType[actor->args[0]]].
+            || !(mobjinfo[TranslateThingType[actor->special_args[0]]].
                  flags & MF_COUNTKILL))
         {                       // Only spawn monsters if not -nomonsters
             P_SpawnMobj(actor->x, actor->y, actor->z,
-                        TranslateThingType[actor->args[0]]);
+                        TranslateThingType[actor->special_args[0]]);
         }
     }
     P_RemoveMobj(actor);
@@ -313,9 +313,9 @@ void A_BridgeOrbit(mobj_t * actor)
     {
         P_SetMobjState(actor, HEXEN_S_NULL);
     }
-    actor->args[0] += 3;
-    actor->x = actor->target->x + orbitTableX[actor->args[0]];
-    actor->y = actor->target->y + orbitTableY[actor->args[0]];
+    actor->special_args[0] += 3;
+    actor->x = actor->target->x + orbitTableX[actor->special_args[0]];
+    actor->y = actor->target->y + orbitTableY[actor->special_args[0]];
     actor->z = actor->target->z;
 }
 
@@ -333,15 +333,15 @@ void A_BridgeInit(mobj_t * actor)
 
     // Spawn triad into world
     ball1 = P_SpawnMobj(cx, cy, cz, HEXEN_MT_BRIDGEBALL);
-    ball1->args[0] = startangle;
+    ball1->special_args[0] = startangle;
     P_SetTarget(&ball1->target, actor);
 
     ball2 = P_SpawnMobj(cx, cy, cz, HEXEN_MT_BRIDGEBALL);
-    ball2->args[0] = (startangle + 85) & 255;
+    ball2->special_args[0] = (startangle + 85) & 255;
     P_SetTarget(&ball2->target, actor);
 
     ball3 = P_SpawnMobj(cx, cy, cz, HEXEN_MT_BRIDGEBALL);
-    ball3->args[0] = (startangle + 170) & 255;
+    ball3->special_args[0] = (startangle + 170) & 255;
     P_SetTarget(&ball3->target, actor);
 
     A_BridgeOrbit(ball1);
@@ -391,12 +391,12 @@ void A_Summon(mobj_t * actor)
             return;
         }
 
-        // Store leveltime into mo->args. This must be stored in little-
+        // Store leveltime into mo->special_args. This must be stored in little-
         // endian format for Vanilla savegame compatibility.
-        mo->args[0] = leveltime & 0xff;
-        mo->args[1] = (leveltime >> 8) & 0xff;
-        mo->args[2] = (leveltime >> 16) & 0xff;
-        mo->args[3] = (leveltime >> 24) & 0xff;
+        mo->special_args[0] = leveltime & 0xff;
+        mo->special_args[1] = (leveltime >> 8) & 0xff;
+        mo->special_args[2] = (leveltime >> 16) & 0xff;
+        mo->special_args[3] = (leveltime >> 24) & 0xff;
         master = actor->special1.m;
         if (master->flags & MF_CORPSE)
         {                       // Master dead
@@ -435,7 +435,7 @@ void A_FogSpawn(mobj_t * actor)
     if (actor->special1.i-- > 0)
         return;
 
-    actor->special1.i = actor->args[2];   // Reset frequency count
+    actor->special1.i = actor->special_args[2];   // Reset frequency count
 
     switch (P_Random(pr_hexen) % 3)
     {
@@ -452,37 +452,37 @@ void A_FogSpawn(mobj_t * actor)
 
     if (mo)
     {
-        delta = actor->args[1];
+        delta = actor->special_args[1];
         if (delta == 0)
             delta = 1;
         mo->angle =
             actor->angle + (((P_Random(pr_hexen) % delta) - (delta >> 1)) << 24);
         P_SetTarget(&mo->target, actor);
-        if (actor->args[0] < 1)
-            actor->args[0] = 1;
-        mo->args[0] = (P_Random(pr_hexen) % (actor->args[0])) + 1;      // Random speed
-        mo->args[3] = actor->args[3];   // Set lifetime
-        mo->args[4] = 1;        // Set to moving
+        if (actor->special_args[0] < 1)
+            actor->special_args[0] = 1;
+        mo->special_args[0] = (P_Random(pr_hexen) % (actor->special_args[0])) + 1;      // Random speed
+        mo->special_args[3] = actor->special_args[3];   // Set lifetime
+        mo->special_args[4] = 1;        // Set to moving
         mo->special2.i = P_Random(pr_hexen) & 63;
     }
 }
 
 void A_FogMove(mobj_t * actor)
 {
-    int speed = actor->args[0] << FRACBITS;
+    int speed = actor->special_args[0] << FRACBITS;
     angle_t angle;
     int weaveindex;
 
-    if (!(actor->args[4]))
+    if (!(actor->special_args[4]))
         return;
 
-    if (actor->args[3]-- <= 0)
+    if (actor->special_args[3]-- <= 0)
     {
         P_SetMobjStateNF(actor, actor->info->deathstate);
         return;
     }
 
-    if ((actor->args[3] % 4) == 0)
+    if ((actor->special_args[3] % 4) == 0)
     {
         weaveindex = actor->special2.i;
         actor->z += FloatBobOffsets[weaveindex] >> 1;
@@ -588,11 +588,11 @@ dboolean A_LocalQuake(byte * args, mobj_t * actor)
                                 target->y, target->z, HEXEN_MT_QUAKE_FOCUS);
             if (focus)
             {
-                focus->args[0] = args[0];
-                focus->args[1] = args[1] >> 1;  // decremented every 2 tics
-                focus->args[2] = args[2];
-                focus->args[3] = args[3];
-                focus->args[4] = args[4];
+                focus->special_args[0] = args[0];
+                focus->special_args[1] = args[1] >> 1;  // decremented every 2 tics
+                focus->special_args[2] = args[2];
+                focus->special_args[3] = args[3];
+                focus->special_args[4] = args[4];
                 success = true;
             }
         }
@@ -609,11 +609,11 @@ void A_Quake(mobj_t * actor)
     angle_t an;
     player_t *player;
     mobj_t *victim;
-    int richters = actor->args[0];
+    int richters = actor->special_args[0];
     int playnum;
     fixed_t dist;
 
-    if (actor->args[1]-- > 0)
+    if (actor->special_args[1]-- > 0)
     {
         for (playnum = 0; playnum < g_maxplayers; playnum++)
         {
@@ -625,12 +625,12 @@ void A_Quake(mobj_t * actor)
             dist = P_AproxDistance(actor->x - victim->x,
                                    actor->y - victim->y) >> (FRACBITS + 6);
             // Tested in tile units (64 pixels)
-            if (dist < actor->args[3])  // In tremor radius
+            if (dist < actor->special_args[3])  // In tremor radius
             {
                 localQuakeHappening[playnum] = richters;
             }
             // Check if in damage radius
-            if ((dist < actor->args[2]) && (victim->z <= victim->floorz))
+            if ((dist < actor->special_args[2]) && (victim->z <= victim->floorz))
             {
                 if (P_Random(pr_hexen) < 50)
                 {
@@ -740,7 +740,7 @@ void A_CheckTeleRing(mobj_t * actor)
 void A_ThrustInitUp(mobj_t * actor)
 {
     actor->special2.i = 5;        // Raise speed
-    actor->args[0] = 1;         // Mark as up
+    actor->special_args[0] = 1;         // Mark as up
     actor->floorclip = 0;
     actor->flags = MF_SOLID;
     actor->flags2 = MF2_NOTELEPORT | MF2_FOOTCLIP;
@@ -751,7 +751,7 @@ void A_ThrustInitDn(mobj_t * actor)
 {
     mobj_t *mo;
     actor->special2.i = 5;        // Raise speed
-    actor->args[0] = 0;         // Mark as down
+    actor->special_args[0] = 0;         // Mark as down
     actor->floorclip = actor->info->height;
     actor->flags = 0;
     actor->flags2 = MF2_NOTELEPORT | MF2_FOOTCLIP | MF2_DONTDRAW;
@@ -764,8 +764,8 @@ void A_ThrustRaise(mobj_t * actor)
 {
     if (A_RaiseMobj(actor))
     {                           // Reached it's target height
-        actor->args[0] = 1;
-        if (actor->args[1])
+        actor->special_args[0] = 1;
+        if (actor->special_args[1])
             P_SetMobjStateNF(actor, HEXEN_S_BTHRUSTINIT2_1);
         else
             P_SetMobjStateNF(actor, HEXEN_S_THRUSTINIT2_1);
@@ -788,8 +788,8 @@ void A_ThrustLower(mobj_t * actor)
 {
     if (A_SinkMobj(actor))
     {
-        actor->args[0] = 0;
-        if (actor->args[1])
+        actor->special_args[0] = 0;
+        if (actor->special_args[1])
             P_SetMobjStateNF(actor, HEXEN_S_BTHRUSTINIT1_1);
         else
             P_SetMobjStateNF(actor, HEXEN_S_THRUSTINIT1_1);
@@ -827,16 +827,16 @@ void A_SoAExplode(mobj_t * actor)
         mo->momx = P_SubRandom() << (FRACBITS - 6);
         mo->momy = P_SubRandom() << (FRACBITS - 6);
     }
-    if (actor->args[0])
+    if (actor->special_args[0])
     {                           // Spawn an item
 #if 0 // Checks are not present in version 1.1
         if (!nomonsters
-            || !(mobjinfo[TranslateThingType[actor->args[0]]].
+            || !(mobjinfo[TranslateThingType[actor->special_args[0]]].
                  flags & MF_COUNTKILL))
 #endif
         {                       // Only spawn monsters if not -nomonsters
             P_SpawnMobj(actor->x, actor->y, actor->z,
-                        TranslateThingType[actor->args[0]]);
+                        TranslateThingType[actor->special_args[0]]);
         }
     }
     S_StartMobjSound(mo, hexen_sfx_suitofarmor_break);
@@ -858,7 +858,7 @@ void A_BellReset2(mobj_t * actor)
 
 void A_FlameCheck(mobj_t * actor)
 {
-    if (!actor->args[0]--)      // Called every 8 tics
+    if (!actor->special_args[0]--)      // Called every 8 tics
     {
         P_SetMobjState(actor, HEXEN_S_NULL);
     }
@@ -893,18 +893,18 @@ void A_BatSpawn(mobj_t * actor)
     // Countdown until next spawn
     if (actor->special1.i-- > 0)
         return;
-    actor->special1.i = actor->args[0];   // Reset frequency count
+    actor->special1.i = actor->special_args[0];   // Reset frequency count
 
-    delta = actor->args[1];
+    delta = actor->special_args[1];
     if (delta == 0)
         delta = 1;
     angle = actor->angle + (((P_Random(pr_hexen) % delta) - (delta >> 1)) << 24);
     mo = P_SpawnMissileAngle(actor, HEXEN_MT_BAT, angle, 0);
     if (mo)
     {
-        mo->args[0] = P_Random(pr_hexen) & 63;  // floatbob index
-        mo->args[4] = actor->args[4];   // turn degrees
-        mo->special2.i = actor->args[3] << 3;     // Set lifetime
+        mo->special_args[0] = P_Random(pr_hexen) & 63;  // floatbob index
+        mo->special_args[4] = actor->special_args[4];   // turn degrees
+        mo->special2.i = actor->special_args[3] << 3;     // Set lifetime
         P_SetTarget(&mo->target, actor);
     }
 }
@@ -922,11 +922,11 @@ void A_BatMove(mobj_t * actor)
 
     if (P_Random(pr_hexen) < 128)
     {
-        newangle = actor->angle + ANG1 * actor->args[4];
+        newangle = actor->angle + ANG1 * actor->special_args[4];
     }
     else
     {
-        newangle = actor->angle - ANG1 * actor->args[4];
+        newangle = actor->angle - ANG1 * actor->special_args[4];
     }
 
     // Adjust momentum vector to new direction
@@ -939,8 +939,8 @@ void A_BatMove(mobj_t * actor)
         S_StartMobjSound(actor, hexen_sfx_bat_scream);
 
     // Handle Z movement
-    actor->z = actor->target->z + 2 * FloatBobOffsets[actor->args[0]];
-    actor->args[0] = (actor->args[0] + 3) & 63;
+    actor->z = actor->target->z + 2 * FloatBobOffsets[actor->special_args[0]];
+    actor->special_args[0] = (actor->special_args[0] + 3) & 63;
 }
 
 void A_TreeDeath(mobj_t * actor)

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -190,7 +190,7 @@ acsstore_t ACSStore[MAX_ACS_STORE + 1]; // +1 for termination marker
 static char EvalContext[64];
 static acs_t *ACScript;
 static unsigned int PCodeOffset;
-static byte SpecArgs[8];
+static int SpecArgs[8];
 static int ACStringCount;
 static const char **ACStrings;
 static char PrintBuffer[PRINT_BUFFER_SIZE];

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -1781,11 +1781,11 @@ static int CmdSetLineSpecial(void)
     while ((line = P_FindLine(lineTag, &searcher)) != NULL)
     {
         line->special = special;
-        line->args[0] = arg1;
-        line->args[1] = arg2;
-        line->args[2] = arg3;
-        line->args[3] = arg4;
-        line->args[4] = arg5;
+        line->special_args[0] = arg1;
+        line->special_args[1] = arg2;
+        line->special_args[2] = arg3;
+        line->special_args[3] = arg4;
+        line->special_args[4] = arg5;
     }
     return SCRIPT_CONTINUE;
 }

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -1781,11 +1781,11 @@ static int CmdSetLineSpecial(void)
     while ((line = P_FindLine(lineTag, &searcher)) != NULL)
     {
         line->special = special;
-        line->arg1 = arg1;
-        line->arg2 = arg2;
-        line->arg3 = arg3;
-        line->arg4 = arg4;
-        line->arg5 = arg5;
+        line->args[0] = arg1;
+        line->args[1] = arg2;
+        line->args[2] = arg3;
+        line->args[3] = arg4;
+        line->args[4] = arg5;
     }
     return SCRIPT_CONTINUE;
 }

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -151,16 +151,16 @@ void P_AnimateHexenSurfaces(void)
         switch (line->special)
         {
             case 100:          // Scroll_Texture_Left
-                sides[line->sidenum[0]].textureoffset += line->args[0] << 10;
+                sides[line->sidenum[0]].textureoffset += line->special_args[0] << 10;
                 break;
             case 101:          // Scroll_Texture_Right
-                sides[line->sidenum[0]].textureoffset -= line->args[0] << 10;
+                sides[line->sidenum[0]].textureoffset -= line->special_args[0] << 10;
                 break;
             case 102:          // Scroll_Texture_Up
-                sides[line->sidenum[0]].rowoffset += line->args[0] << 10;
+                sides[line->sidenum[0]].rowoffset += line->special_args[0] << 10;
                 break;
             case 103:          // Scroll_Texture_Down
-                sides[line->sidenum[0]].rowoffset -= line->args[0] << 10;
+                sides[line->sidenum[0]].rowoffset -= line->special_args[0] << 10;
                 break;
         }
     }

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -151,16 +151,16 @@ void P_AnimateHexenSurfaces(void)
         switch (line->special)
         {
             case 100:          // Scroll_Texture_Left
-                sides[line->sidenum[0]].textureoffset += line->arg1 << 10;
+                sides[line->sidenum[0]].textureoffset += line->args[0] << 10;
                 break;
             case 101:          // Scroll_Texture_Right
-                sides[line->sidenum[0]].textureoffset -= line->arg1 << 10;
+                sides[line->sidenum[0]].textureoffset -= line->args[0] << 10;
                 break;
             case 102:          // Scroll_Texture_Up
-                sides[line->sidenum[0]].rowoffset += line->arg1 << 10;
+                sides[line->sidenum[0]].rowoffset += line->args[0] << 10;
                 break;
             case 103:          // Scroll_Texture_Down
-                sides[line->sidenum[0]].rowoffset -= line->arg1 << 10;
+                sides[line->sidenum[0]].rowoffset -= line->args[0] << 10;
                 break;
         }
     }

--- a/prboom2/src/hexen/p_things.c
+++ b/prboom2/src/hexen/p_things.c
@@ -357,11 +357,11 @@ static dboolean ActivateThing(mobj_t * mobj)
             break;
         case HEXEN_MT_THRUSTFLOOR_UP:
         case HEXEN_MT_THRUSTFLOOR_DOWN:
-            if (mobj->args[0] == 0)
+            if (mobj->special_args[0] == 0)
             {
                 S_StartMobjSound(mobj, hexen_sfx_thrustspike_lower);
                 mobj->flags2 &= ~MF2_DONTDRAW;
-                if (mobj->args[1])
+                if (mobj->special_args[1])
                     P_SetMobjState(mobj, HEXEN_S_BTHRUSTRAISE1);
                 else
                     P_SetMobjState(mobj, HEXEN_S_THRUSTRAISE1);
@@ -425,10 +425,10 @@ static dboolean DeactivateThing(mobj_t * mobj)
             break;
         case HEXEN_MT_THRUSTFLOOR_UP:
         case HEXEN_MT_THRUSTFLOOR_DOWN:
-            if (mobj->args[0] == 1)
+            if (mobj->special_args[0] == 1)
             {
                 S_StartMobjSound(mobj, hexen_sfx_thrustspike_raise);
-                if (mobj->args[1])
+                if (mobj->special_args[1])
                     P_SetMobjState(mobj, HEXEN_S_BTHRUSTLOWER);
                 else
                     P_SetMobjState(mobj, HEXEN_S_THRUSTLOWER);

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -614,7 +614,7 @@ static int GetPolyobjMirror(int poly)
     {
         if (polyobjs[i].tag == poly)
         {
-            return ((*polyobjs[i].segs)->linedef->args[1]);
+            return ((*polyobjs[i].segs)->linedef->special_args[1]);
         }
     }
     return 0;
@@ -1174,14 +1174,14 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
     for (i = 0; i < numsegs; i++)
     {
         if (segs[i].linedef->special == PO_LINE_START &&
-            segs[i].linedef->args[0] == tag)
+            segs[i].linedef->special_args[0] == tag)
         {
             if (polyobjs[index].segs)
             {
                 I_Error("SpawnPolyobj:  Polyobj %d already spawned.\n", tag);
             }
             segs[i].linedef->special = 0;
-            segs[i].linedef->args[0] = 0;
+            segs[i].linedef->special_args[0] = 0;
             PolySegCount = 1;
             PolyStartX = segs[i].v1->x;
             PolyStartY = segs[i].v1->y;
@@ -1195,7 +1195,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             polyobjs[index].crush = crush;
             polyobjs[index].hurt = hurt;
             polyobjs[index].tag = tag;
-            polyobjs[index].seqType = segs[i].linedef->args[2];
+            polyobjs[index].seqType = segs[i].linedef->special_args[2];
             if (polyobjs[index].seqType < 0
                 || polyobjs[index].seqType >= SEQTYPE_NUMSEQ)
             {
@@ -1214,15 +1214,15 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             for (i = 0; i < numsegs; i++)
             {
                 if (segs[i].linedef->special == PO_LINE_EXPLICIT &&
-                    segs[i].linedef->args[0] == tag)
+                    segs[i].linedef->special_args[0] == tag)
                 {
-                    if (!segs[i].linedef->args[1])
+                    if (!segs[i].linedef->special_args[1])
                     {
                         I_Error
                             ("SpawnPolyobj:  Explicit line missing order number (probably %d) in poly %d.\n",
                              j + 1, tag);
                     }
-                    if (segs[i].linedef->args[1] == j)
+                    if (segs[i].linedef->special_args[1] == j)
                     {
                         polySegList[psIndex] = &segs[i];
                         polyobjs[index].numsegs++;
@@ -1241,11 +1241,11 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             for (i = 0; i < numsegs; i++)
             {
                 if (segs[i].linedef->special == PO_LINE_EXPLICIT &&
-                    segs[i].linedef->args[0] == tag
-                    && segs[i].linedef->args[1] == j)
+                    segs[i].linedef->special_args[0] == tag
+                    && segs[i].linedef->special_args[1] == j)
                 {
                     segs[i].linedef->special = 0;
-                    segs[i].linedef->args[0] = 0;
+                    segs[i].linedef->special_args[0] = 0;
                 }
             }
             if (psIndex == psIndexOld)
@@ -1255,7 +1255,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
                 for (i = 0; i < numsegs; i++)
                 {
                     if (segs[i].linedef->special == PO_LINE_EXPLICIT &&
-                        segs[i].linedef->args[0] == tag)
+                        segs[i].linedef->special_args[0] == tag)
                     {
                         I_Error
                             ("SpawnPolyobj:  Missing explicit line %d for poly %d\n",
@@ -1275,12 +1275,12 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             {
                 polyobjs[index].segs[i] = polySegList[i];
             }
-            polyobjs[index].seqType = (*polyobjs[index].segs)->linedef->args[3];
+            polyobjs[index].seqType = (*polyobjs[index].segs)->linedef->special_args[3];
         }
         // Next, change the polyobjs first line to point to a mirror
         //              if it exists
-        (*polyobjs[index].segs)->linedef->args[1] =
-            (*polyobjs[index].segs)->linedef->args[2];
+        (*polyobjs[index].segs)->linedef->special_args[1] =
+            (*polyobjs[index].segs)->linedef->special_args[2];
     }
 }
 

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -159,6 +159,21 @@ void T_RotatePoly(polyevent_t * pe)
     }
 }
 
+// TODO: EV_RotateZDoomPoly int range
+dboolean EV_RotateZDoomPoly(line_t * line, int polyobj, int speed,
+                            int angle, int direction, dboolean overRide)
+{
+    byte args[5];
+
+    args[0] = polyobj;
+    args[1] = speed;
+    args[2] = angle;
+    args[3] = 0;
+    args[4] = 0;
+
+    return EV_RotatePoly(line, args, direction, overRide);
+}
+
 dboolean EV_RotatePoly(line_t * line, byte * args, int direction, dboolean overRide)
 {
     int mirror;
@@ -338,6 +353,21 @@ dboolean EV_MovePolyTo(line_t * line, int polyNum, fixed_t speed,
     return true;
 }
 
+// TODO: EV_MoveZDoomPoly int range
+dboolean EV_MoveZDoomPoly(line_t * line, int polyobj, int speed,
+                          int angle, int distance, dboolean timesEight, dboolean overRide)
+{
+    byte args[5];
+
+    args[0] = polyobj;
+    args[1] = speed;
+    args[2] = angle;
+    args[3] = distance;
+    args[4] = 0;
+
+    return EV_MovePoly(line, args, timesEight, overRide);
+}
+
 dboolean EV_MovePoly(line_t * line, byte * args, dboolean timesEight, dboolean overRide)
 {
     int polyNum;
@@ -495,6 +525,21 @@ void T_PolyDoor(polydoor_t * pd)
         default:
             break;
     }
+}
+
+// TODO: EV_OpenZDoomPolyDoor int range
+dboolean EV_OpenZDoomPolyDoor(line_t * line, int polyobj, int speed,
+                              int angle, int delay, podoortype_t type)
+{
+    byte args[5];
+
+    args[0] = polyobj;
+    args[1] = speed;
+    args[2] = angle;
+    args[3] = delay;
+    args[4] = 0;
+
+    return EV_OpenPolyDoor(line, args, type);
 }
 
 dboolean EV_OpenPolyDoor(line_t * line, byte * args, podoortype_t type)

--- a/prboom2/src/hexen/po_man.c
+++ b/prboom2/src/hexen/po_man.c
@@ -614,7 +614,7 @@ static int GetPolyobjMirror(int poly)
     {
         if (polyobjs[i].tag == poly)
         {
-            return ((*polyobjs[i].segs)->linedef->arg2);
+            return ((*polyobjs[i].segs)->linedef->args[1]);
         }
     }
     return 0;
@@ -1174,14 +1174,14 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
     for (i = 0; i < numsegs; i++)
     {
         if (segs[i].linedef->special == PO_LINE_START &&
-            segs[i].linedef->arg1 == tag)
+            segs[i].linedef->args[0] == tag)
         {
             if (polyobjs[index].segs)
             {
                 I_Error("SpawnPolyobj:  Polyobj %d already spawned.\n", tag);
             }
             segs[i].linedef->special = 0;
-            segs[i].linedef->arg1 = 0;
+            segs[i].linedef->args[0] = 0;
             PolySegCount = 1;
             PolyStartX = segs[i].v1->x;
             PolyStartY = segs[i].v1->y;
@@ -1195,7 +1195,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             polyobjs[index].crush = crush;
             polyobjs[index].hurt = hurt;
             polyobjs[index].tag = tag;
-            polyobjs[index].seqType = segs[i].linedef->arg3;
+            polyobjs[index].seqType = segs[i].linedef->args[2];
             if (polyobjs[index].seqType < 0
                 || polyobjs[index].seqType >= SEQTYPE_NUMSEQ)
             {
@@ -1214,15 +1214,15 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             for (i = 0; i < numsegs; i++)
             {
                 if (segs[i].linedef->special == PO_LINE_EXPLICIT &&
-                    segs[i].linedef->arg1 == tag)
+                    segs[i].linedef->args[0] == tag)
                 {
-                    if (!segs[i].linedef->arg2)
+                    if (!segs[i].linedef->args[1])
                     {
                         I_Error
                             ("SpawnPolyobj:  Explicit line missing order number (probably %d) in poly %d.\n",
                              j + 1, tag);
                     }
-                    if (segs[i].linedef->arg2 == j)
+                    if (segs[i].linedef->args[1] == j)
                     {
                         polySegList[psIndex] = &segs[i];
                         polyobjs[index].numsegs++;
@@ -1241,11 +1241,11 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             for (i = 0; i < numsegs; i++)
             {
                 if (segs[i].linedef->special == PO_LINE_EXPLICIT &&
-                    segs[i].linedef->arg1 == tag
-                    && segs[i].linedef->arg2 == j)
+                    segs[i].linedef->args[0] == tag
+                    && segs[i].linedef->args[1] == j)
                 {
                     segs[i].linedef->special = 0;
-                    segs[i].linedef->arg1 = 0;
+                    segs[i].linedef->args[0] = 0;
                 }
             }
             if (psIndex == psIndexOld)
@@ -1255,7 +1255,7 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
                 for (i = 0; i < numsegs; i++)
                 {
                     if (segs[i].linedef->special == PO_LINE_EXPLICIT &&
-                        segs[i].linedef->arg1 == tag)
+                        segs[i].linedef->args[0] == tag)
                     {
                         I_Error
                             ("SpawnPolyobj:  Missing explicit line %d for poly %d\n",
@@ -1275,12 +1275,12 @@ static void SpawnPolyobj(int index, int tag, dboolean crush, dboolean hurt)
             {
                 polyobjs[index].segs[i] = polySegList[i];
             }
-            polyobjs[index].seqType = (*polyobjs[index].segs)->linedef->arg4;
+            polyobjs[index].seqType = (*polyobjs[index].segs)->linedef->args[3];
         }
         // Next, change the polyobjs first line to point to a mirror
         //              if it exists
-        (*polyobjs[index].segs)->linedef->arg2 =
-            (*polyobjs[index].segs)->linedef->arg3;
+        (*polyobjs[index].segs)->linedef->args[1] =
+            (*polyobjs[index].segs)->linedef->args[2];
     }
 }
 

--- a/prboom2/src/hexen/po_man.h
+++ b/prboom2/src/hexen/po_man.h
@@ -69,6 +69,12 @@ void PO_ResetBlockMap(dboolean allocate);
 
 // zdoom
 
+dboolean EV_RotateZDoomPoly(line_t * line, int polyobj, int speed,
+                            int angle, int direction, dboolean overRide);
+dboolean EV_MoveZDoomPoly(line_t * line, int polyobj, int speed,
+                          int angle, int distance, dboolean timesEight, dboolean overRide);
+dboolean EV_OpenZDoomPolyDoor(line_t * line, int polyobj, int speed,
+                              int angle, int delay, podoortype_t type);
 dboolean EV_StopPoly(int polyNum);
 dboolean EV_MovePolyTo(line_t * line, int polyNum, fixed_t speed,
                        fixed_t x, fixed_t y, dboolean overRide);

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -460,7 +460,7 @@ static void StreamIn_mobj_t(mobj_t *str)
     // byte args[5];
     for (i=0; i<5; ++i)
     {
-        str->args[i] = SV_ReadByte();
+        str->special_args[i] = SV_ReadByte();
     }
 
     str->friction = ORIG_FRICTION;
@@ -611,7 +611,7 @@ static void StreamOut_mobj_t(mobj_t *str)
     // byte args[5];
     for (i=0; i<5; ++i)
     {
-        SV_WriteByte(str->args[i]);
+        SV_WriteByte(str->special_args[i]);
     }
 }
 
@@ -1351,11 +1351,11 @@ static void ArchiveWorld(void)
     {
         SV_WriteLong(li->flags);
         SV_WriteByte(li->special);
-        SV_WriteByte(li->args[0]);
-        SV_WriteByte(li->args[1]);
-        SV_WriteByte(li->args[2]);
-        SV_WriteByte(li->args[3]);
-        SV_WriteByte(li->args[4]);
+        SV_WriteByte(li->special_args[0]);
+        SV_WriteByte(li->special_args[1]);
+        SV_WriteByte(li->special_args[2]);
+        SV_WriteByte(li->special_args[3]);
+        SV_WriteByte(li->special_args[4]);
         for (j = 0; j < 2; j++)
         {
             if (li->sidenum[j] == NO_INDEX)
@@ -1400,11 +1400,11 @@ static void UnarchiveWorld(void)
     {
         li->flags = SV_ReadLong();
         li->special = SV_ReadByte();
-        li->args[0] = SV_ReadByte();
-        li->args[1] = SV_ReadByte();
-        li->args[2] = SV_ReadByte();
-        li->args[3] = SV_ReadByte();
-        li->args[4] = SV_ReadByte();
+        li->special_args[0] = SV_ReadByte();
+        li->special_args[1] = SV_ReadByte();
+        li->special_args[2] = SV_ReadByte();
+        li->special_args[3] = SV_ReadByte();
+        li->special_args[4] = SV_ReadByte();
         for (j = 0; j < 2; j++)
         {
             if (li->sidenum[j] == NO_INDEX)

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -1351,11 +1351,11 @@ static void ArchiveWorld(void)
     {
         SV_WriteLong(li->flags);
         SV_WriteByte(li->special);
-        SV_WriteByte(li->arg1);
-        SV_WriteByte(li->arg2);
-        SV_WriteByte(li->arg3);
-        SV_WriteByte(li->arg4);
-        SV_WriteByte(li->arg5);
+        SV_WriteByte(li->args[0]);
+        SV_WriteByte(li->args[1]);
+        SV_WriteByte(li->args[2]);
+        SV_WriteByte(li->args[3]);
+        SV_WriteByte(li->args[4]);
         for (j = 0; j < 2; j++)
         {
             if (li->sidenum[j] == NO_INDEX)
@@ -1400,11 +1400,11 @@ static void UnarchiveWorld(void)
     {
         li->flags = SV_ReadLong();
         li->special = SV_ReadByte();
-        li->arg1 = SV_ReadByte();
-        li->arg2 = SV_ReadByte();
-        li->arg3 = SV_ReadByte();
-        li->arg4 = SV_ReadByte();
-        li->arg5 = SV_ReadByte();
+        li->args[0] = SV_ReadByte();
+        li->args[1] = SV_ReadByte();
+        li->args[2] = SV_ReadByte();
+        li->args[3] = SV_ReadByte();
+        li->args[4] = SV_ReadByte();
         for (j = 0; j < 2; j++)
         {
             if (li->sidenum[j] == NO_INDEX)

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -457,10 +457,10 @@ static void StreamIn_mobj_t(mobj_t *str)
     // int special;
     str->special = SV_ReadLong();
 
-    // byte args[5];
+    // int args[5];
     for (i=0; i<5; ++i)
     {
-        str->special_args[i] = SV_ReadByte();
+        str->special_args[i] = SV_ReadLong();
     }
 
     str->friction = ORIG_FRICTION;
@@ -608,10 +608,10 @@ static void StreamOut_mobj_t(mobj_t *str)
     // int special;
     SV_WriteLong(str->special);
 
-    // byte args[5];
+    // int args[5];
     for (i=0; i<5; ++i)
     {
-        SV_WriteByte(str->special_args[i]);
+        SV_WriteLong(str->special_args[i]);
     }
 }
 
@@ -1350,12 +1350,13 @@ static void ArchiveWorld(void)
     for (i = 0, li = lines; i < numlines; i++, li++)
     {
         SV_WriteLong(li->flags);
+        // TODO: how does this work? it's a short
         SV_WriteByte(li->special);
-        SV_WriteByte(li->special_args[0]);
-        SV_WriteByte(li->special_args[1]);
-        SV_WriteByte(li->special_args[2]);
-        SV_WriteByte(li->special_args[3]);
-        SV_WriteByte(li->special_args[4]);
+        SV_WriteLong(li->special_args[0]);
+        SV_WriteLong(li->special_args[1]);
+        SV_WriteLong(li->special_args[2]);
+        SV_WriteLong(li->special_args[3]);
+        SV_WriteLong(li->special_args[4]);
         for (j = 0; j < 2; j++)
         {
             if (li->sidenum[j] == NO_INDEX)
@@ -1400,11 +1401,11 @@ static void UnarchiveWorld(void)
     {
         li->flags = SV_ReadLong();
         li->special = SV_ReadByte();
-        li->special_args[0] = SV_ReadByte();
-        li->special_args[1] = SV_ReadByte();
-        li->special_args[2] = SV_ReadByte();
-        li->special_args[3] = SV_ReadByte();
-        li->special_args[4] = SV_ReadByte();
+        li->special_args[0] = SV_ReadLong();
+        li->special_args[1] = SV_ReadLong();
+        li->special_args[2] = SV_ReadLong();
+        li->special_args[3] = SV_ReadLong();
+        li->special_args[4] = SV_ReadLong();
         for (j = 0; j < 2; j++)
         {
             if (li->sidenum[j] == NO_INDEX)

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -905,7 +905,7 @@ static void P_SpawnZDoomCeiling(sector_t *sec, ceiling_e type, line_t *line, int
   return;
 }
 
-int EV_DoZDoomCeiling(ceiling_e type, line_t *line, byte tag, fixed_t speed, fixed_t speed2,
+int EV_DoZDoomCeiling(ceiling_e type, line_t *line, int tag, fixed_t speed, fixed_t speed2,
                       fixed_t height, int crush, byte silent, int change, crushmode_e crushmode)
 {
   sector_t *sec;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -1006,7 +1006,7 @@ void Heretic_EV_VerticalDoor(line_t * line, mobj_t * thing)
 // hexen
 
 static void P_SpawnZDoomDoor(sector_t *sec, vldoor_e type, line_t *line, fixed_t speed,
-                             int topwait, byte lightTag, int topcountdown)
+                             int topwait, int lightTag, int topcountdown)
 {
   vldoor_t *door;
 
@@ -1060,14 +1060,13 @@ static void P_SpawnZDoomDoor(sector_t *sec, vldoor_e type, line_t *line, fixed_t
   }
 }
 
-int EV_DoZDoomDoor(vldoor_e type, line_t *line, mobj_t *mo, byte tag, byte speed_byte, int topwait,
-                   zdoom_lock_t lock, byte lightTag, dboolean boomgen, int topcountdown)
+int EV_DoZDoomDoor(vldoor_e type, line_t *line, mobj_t *mo, int tag, fixed_t speed, int topwait,
+                   zdoom_lock_t lock, int lightTag, dboolean boomgen, int topcountdown)
 {
   sector_t *sec;
   vldoor_t *door;
-  fixed_t speed;
 
-  speed = (fixed_t) speed_byte * FRACUNIT / 8;
+  speed *= FRACUNIT / 8;
 
   if (lock && !P_CheckKeys(mo, lock, true))
     return 0;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -1248,8 +1248,8 @@ dboolean Hexen_EV_VerticalDoor(line_t * line, mobj_t * thing)
             door->type = DREV_NORMAL;
             break;
     }
-    door->speed = line->args[1] * (FRACUNIT / 8);
-    door->topwait = line->args[2];
+    door->speed = line->special_args[1] * (FRACUNIT / 8);
+    door->topwait = line->special_args[2];
 
     //
     // find the top and bottom of the movement range

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -1202,7 +1202,7 @@ int Hexen_EV_DoDoor(line_t * line, byte * args, vldoor_e type)
         }
         door->type = type;
         door->speed = speed;
-        door->topwait = args[2];        // line->arg3
+        door->topwait = args[2];
         SN_StartSequence((mobj_t *) & door->sector->soundorg,
                          SEQ_DOOR_STONE + door->sector->seqType);
     }
@@ -1248,8 +1248,8 @@ dboolean Hexen_EV_VerticalDoor(line_t * line, mobj_t * thing)
             door->type = DREV_NORMAL;
             break;
     }
-    door->speed = line->arg2 * (FRACUNIT / 8);
-    door->topwait = line->arg3;
+    door->speed = line->args[1] * (FRACUNIT / 8);
+    door->topwait = line->args[2];
 
     //
     // find the top and bottom of the movement range

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -7752,6 +7752,7 @@ void A_SorcOffense2(mobj_t * actor)
 
     index = actor->special_args[4] << 5;
     actor->special_args[4] += 15;
+    actor->special_args[4] &= 0xff;
     delta = (finesine[index]) * SORCFX4_SPREAD_ANGLE;
     delta = (delta >> FRACBITS) * ANG1;
     ang1 = actor->angle + delta;

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -2495,7 +2495,7 @@ void A_Explode(mobj_t *thingy)
       case HEXEN_MT_SORCBALL3:
         distance = 255;
         damage = 255;
-        thingy->args[0] = 1; // don't play bounce
+        thingy->special_args[0] = 1; // don't play bounce
         break;
       case HEXEN_MT_SORCFX1:       // Sorcerer spell 1
         damage = 30;
@@ -4255,7 +4255,7 @@ void A_MinotaurDecide(mobj_t * actor)
         actor->momy = FixedMul(g_mntr_charge_speed, finesine[angle]);
         // Charge duration
         if (hexen)
-          actor->args[4] = 35 / 2;
+          actor->special_args[4] = 35 / 2;
         else
           actor->special1.i = 35 / 2;
     }
@@ -4280,12 +4280,12 @@ void A_MinotaurCharge(mobj_t * actor)
     if (hexen && !actor->target)
       return;
 
-    if (hexen ? actor->args[4] > 0 : actor->special1.i)
+    if (hexen ? actor->special_args[4] > 0 : actor->special1.i)
     {
         puff = P_SpawnMobj(actor->x, actor->y, actor->z, g_mntr_charge_puff);
         puff->momz = 2 * FRACUNIT;
         if (hexen)
-          actor->args[4]--;
+          actor->special_args[4]--;
         else
           actor->special1.i--;
     }
@@ -5298,7 +5298,7 @@ dboolean P_UpdateMorphedMonster(mobj_t * actor, int tics)
         mo->special1.i = 5 * 35;  // Next try in 5 seconds
         mo->special2.i = moType;
         mo->tid = oldMonster.tid;
-        memcpy(mo->args, oldMonster.args, 5);
+        memcpy(mo->special_args, oldMonster.special_args, 5);
         map_format.add_mobj_thing_id(mo, oldMonster.tid);
         dsda_WatchMorph(mo);
         return (false);
@@ -5307,7 +5307,7 @@ dboolean P_UpdateMorphedMonster(mobj_t * actor, int tics)
     P_SetTarget(&mo->target, oldMonster.target);
     mo->tid = oldMonster.tid;
     mo->special = oldMonster.special;
-    memcpy(mo->args, oldMonster.args, 5);
+    memcpy(mo->special_args, oldMonster.special_args, 5);
     map_format.add_mobj_thing_id(mo, oldMonster.tid);
     fog = P_SpawnMobj(x, y, z + TELEFOGHEIGHT, HEXEN_MT_TFOG);
     S_StartMobjSound(fog, hexen_sfx_teleport);
@@ -5433,7 +5433,7 @@ static dboolean CheckMinotaurAge(mobj_t *mo)
     // The start time is stored in the mobj_t structure, but it is stored
     // in little endian format. For Vanilla savegame compatibility we must
     // swap it to the native endianness.
-    memcpy(&starttime, mo->args, sizeof(unsigned int));
+    memcpy(&starttime, mo->special_args, sizeof(unsigned int));
 
     if (leveltime - LittleLong(starttime) >= MAULATORTICS)
     {
@@ -6413,12 +6413,12 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
                                             actor->target->y);
             for (i = 0; i < 5; i++)
             {
-                if (!target->args[i])
+                if (!target->special_args[i])
                 {
                     continue;
                 }
                 search = -1;
-                mo = P_FindMobjFromTID(target->args[i], &search);
+                mo = P_FindMobjFromTID(target->special_args[i], &search);
                 angleToSpot = R_PointToAngle2(actor->x, actor->y,
                                               mo->x, mo->y);
                 if (abs((int) angleToSpot - (int) angleToTarget) < bestAngle)
@@ -6432,7 +6432,7 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
                 search = -1;
                 P_SetTarget(
                   &actor->special1.m,
-                  P_FindMobjFromTID(target->args[bestArg], &search)
+                  P_FindMobjFromTID(target->special_args[bestArg], &search)
                 );
             }
         }
@@ -6442,11 +6442,11 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
             {
                 i = (P_Random(pr_hexen) >> 2) % 5;
             }
-            while (!target->args[i]);
+            while (!target->special_args[i]);
             search = -1;
             P_SetTarget(
               &actor->special1.m,
-              P_FindMobjFromTID(target->args[i], &search)
+              P_FindMobjFromTID(target->special_args[i], &search)
             );
         }
     }
@@ -7171,7 +7171,7 @@ void A_FreezeDeath(mobj_t * actor)
     else if (actor->flags & MF_COUNTKILL && actor->special)
     {
         // Initiate monster death actions.
-        map_format.execute_line_special(actor->special, actor->args, NULL, 0, actor);
+        map_format.execute_line_special(actor->special, actor->special_args, NULL, 0, actor);
     }
 }
 
@@ -7426,9 +7426,9 @@ void A_SorcSpinBalls(mobj_t * actor)
     fixed_t z;
 
     A_SlowBalls(actor);
-    actor->args[0] = 0;         // Currently no defense
-    actor->args[3] = SORC_NORMAL;
-    actor->args[4] = SORCBALL_INITIAL_SPEED;    // Initial orbit speed
+    actor->special_args[0] = 0;         // Currently no defense
+    actor->special_args[3] = SORC_NORMAL;
+    actor->special_args[4] = SORCBALL_INITIAL_SPEED;    // Initial orbit speed
     actor->special1.i = ANG1;
     z = actor->z - actor->floorclip + actor->info->height;
 
@@ -7450,7 +7450,7 @@ void A_SorcBallOrbit(mobj_t * actor)
 {
     int x, y;
     angle_t angle, baseangle;
-    int mode = actor->target->args[3];
+    int mode = actor->target->special_args[3];
     mobj_t *parent = (mobj_t *) actor->target;
     int dist = parent->radius - (actor->radius << 1);
     angle_t prevangle = actor->special1.i;
@@ -7492,13 +7492,13 @@ void A_SorcBallOrbit(mobj_t * actor)
             break;
         case SORC_STOPPING:    // Balls stopping
             if ((parent->special2.i == actor->type) &&
-                (parent->args[1] > SORCBALL_SPEED_ROTATIONS) &&
+                (parent->special_args[1] > SORCBALL_SPEED_ROTATIONS) &&
                 (abs((int) angle - (int) (parent->angle >> ANGLETOFINESHIFT)) <
                  (30 << 5)))
             {
                 // Can stop now
-                actor->target->args[3] = SORC_FIRESPELL;
-                actor->target->args[4] = 0;
+                actor->target->special_args[3] = SORC_FIRESPELL;
+                actor->target->special_args[4] = 0;
                 // Set angle so ball angle == sorcerer angle
                 switch (actor->type)
                 {
@@ -7534,13 +7534,13 @@ void A_SorcBallOrbit(mobj_t * actor)
                 {
                     S_StartVoidSound(hexen_sfx_sorcerer_spellcast);
                     actor->special2.i = SORCFX4_RAPIDFIRE_TIME;
-                    actor->args[4] = 128;
-                    parent->args[3] = SORC_FIRING_SPELL;
+                    actor->special_args[4] = 128;
+                    parent->special_args[3] = SORC_FIRING_SPELL;
                 }
                 else
                 {
                     A_CastSorcererSpell(actor);
-                    parent->args[3] = SORC_STOPPED;
+                    parent->special_args[3] = SORC_STOPPED;
                 }
             }
             break;
@@ -7550,7 +7550,7 @@ void A_SorcBallOrbit(mobj_t * actor)
                 if (actor->special2.i-- <= 0)
                 {
                     // Done rapid firing
-                    parent->args[3] = SORC_STOPPED;
+                    parent->special_args[3] = SORC_STOPPED;
                     // Back to orbit balls
                     if (parent->health > 0)
                         P_SetMobjStateNF(parent, HEXEN_S_SORC_ATTACK4);
@@ -7567,9 +7567,9 @@ void A_SorcBallOrbit(mobj_t * actor)
             break;
     }
 
-    if ((angle < prevangle) && (parent->args[4] == SORCBALL_TERMINAL_SPEED))
+    if ((angle < prevangle) && (parent->special_args[4] == SORCBALL_TERMINAL_SPEED))
     {
-        parent->args[1]++;      // Bump rotation counter
+        parent->special_args[1]++;      // Bump rotation counter
         // Completed full rotation - make woosh sound
         S_StartMobjSound(actor, hexen_sfx_sorcerer_ballwoosh);
     }
@@ -7583,23 +7583,23 @@ void A_SorcBallOrbit(mobj_t * actor)
 
 void A_SpeedBalls(mobj_t * actor)
 {
-    actor->args[3] = SORC_ACCELERATE;   // speed mode
-    actor->args[2] = SORCBALL_TERMINAL_SPEED;   // target speed
+    actor->special_args[3] = SORC_ACCELERATE;   // speed mode
+    actor->special_args[2] = SORCBALL_TERMINAL_SPEED;   // target speed
 }
 
 void A_SlowBalls(mobj_t * actor)
 {
-    actor->args[3] = SORC_DECELERATE;   // slow mode
-    actor->args[2] = SORCBALL_INITIAL_SPEED;    // target speed
+    actor->special_args[3] = SORC_DECELERATE;   // slow mode
+    actor->special_args[2] = SORCBALL_INITIAL_SPEED;    // target speed
 }
 
 void A_StopBalls(mobj_t * actor)
 {
     int chance = P_Random(pr_hexen);
-    actor->args[3] = SORC_STOPPING;     // stopping mode
-    actor->args[1] = 0;         // Reset rotation counter
+    actor->special_args[3] = SORC_STOPPING;     // stopping mode
+    actor->special_args[1] = 0;         // Reset rotation counter
 
-    if ((actor->args[0] <= 0) && (chance < 200))
+    if ((actor->special_args[0] <= 0) && (chance < 200))
     {
         actor->special2.i = HEXEN_MT_SORCBALL2; // Blue
     }
@@ -7618,14 +7618,14 @@ void A_AccelBalls(mobj_t * actor)
 {
     mobj_t *sorc = actor->target;
 
-    if (sorc->args[4] < sorc->args[2])
+    if (sorc->special_args[4] < sorc->special_args[2])
     {
-        sorc->args[4]++;
+        sorc->special_args[4]++;
     }
     else
     {
-        sorc->args[3] = SORC_NORMAL;
-        if (sorc->args[4] >= SORCBALL_TERMINAL_SPEED)
+        sorc->special_args[3] = SORC_NORMAL;
+        if (sorc->special_args[4] >= SORCBALL_TERMINAL_SPEED)
         {
             // Reached terminal velocity - stop balls
             A_StopBalls(sorc);
@@ -7637,13 +7637,13 @@ void A_DecelBalls(mobj_t * actor)
 {
     mobj_t *sorc = actor->target;
 
-    if (sorc->args[4] > sorc->args[2])
+    if (sorc->special_args[4] > sorc->special_args[2])
     {
-        sorc->args[4]--;
+        sorc->special_args[4]--;
     }
     else
     {
-        sorc->args[3] = SORC_NORMAL;
+        sorc->special_args[3] = SORC_NORMAL;
     }
 }
 
@@ -7651,7 +7651,7 @@ void A_SorcUpdateBallAngle(mobj_t * actor)
 {
     if (actor->type == HEXEN_MT_SORCBALL1)
     {
-        actor->target->special1.i += ANG1 * actor->target->args[4];
+        actor->target->special1.i += ANG1 * actor->target->special_args[4];
     }
 }
 
@@ -7679,7 +7679,7 @@ void A_CastSorcererSpell(mobj_t * actor)
                 SORC_DEFENSE_HEIGHT * FRACUNIT;
             mo = P_SpawnMobj(actor->x, actor->y, z, HEXEN_MT_SORCFX2);
             parent->flags2 |= MF2_REFLECTIVE | MF2_INVULNERABLE;
-            parent->args[0] = SORC_DEFENSE_TIME;
+            parent->special_args[0] = SORC_DEFENSE_TIME;
             if (mo)
                 P_SetTarget(&mo->target, parent);
             break;
@@ -7725,16 +7725,16 @@ void A_SorcOffense1(mobj_t * actor)
     {
         P_SetTarget(&mo->target, parent);
         P_SetTarget(&mo->special1.m, parent->target);
-        mo->args[4] = BOUNCE_TIME_UNIT;
-        mo->args[3] = 15;       // Bounce time in seconds
+        mo->special_args[4] = BOUNCE_TIME_UNIT;
+        mo->special_args[3] = 15;       // Bounce time in seconds
     }
     mo = P_SpawnMissileAngle(parent, HEXEN_MT_SORCFX1, ang2, 0);
     if (mo)
     {
         P_SetTarget(&mo->target, parent);
         P_SetTarget(&mo->special1.m, parent->target);
-        mo->args[4] = BOUNCE_TIME_UNIT;
-        mo->args[3] = 15;       // Bounce time in seconds
+        mo->special_args[4] = BOUNCE_TIME_UNIT;
+        mo->special_args[3] = 15;       // Bounce time in seconds
     }
 }
 
@@ -7747,8 +7747,8 @@ void A_SorcOffense2(mobj_t * actor)
     mobj_t *dest = parent->target;
     int dist;
 
-    index = actor->args[4] << 5;
-    actor->args[4] += 15;
+    index = actor->special_args[4] << 5;
+    actor->special_args[4] += 15;
     delta = (finesine[index]) * SORCFX4_SPREAD_ANGLE;
     delta = (delta >> FRACBITS) * ANG1;
     ang1 = actor->angle + delta;
@@ -7766,8 +7766,8 @@ void A_SorcOffense2(mobj_t * actor)
 
 void A_SorcBossAttack(mobj_t * actor)
 {
-    actor->args[3] = SORC_ACCELERATE;
-    actor->args[2] = SORCBALL_INITIAL_SPEED;
+    actor->special_args[3] = SORC_ACCELERATE;
+    actor->special_args[2] = SORCBALL_INITIAL_SPEED;
 }
 
 void A_SpawnFizzle(mobj_t * actor)
@@ -7825,7 +7825,7 @@ void A_SorcFX2Split(mobj_t * actor)
     if (mo)
     {
         P_SetTarget(&mo->target, actor->target);
-        mo->args[0] = 0;        // CW
+        mo->special_args[0] = 0;        // CW
         mo->special1.i = actor->angle;    // Set angle
         P_SetMobjStateNF(mo, HEXEN_S_SORCFX2_ORBIT1);
     }
@@ -7833,7 +7833,7 @@ void A_SorcFX2Split(mobj_t * actor)
     if (mo)
     {
         P_SetTarget(&mo->target, actor->target);
-        mo->args[0] = 1;        // CCW
+        mo->special_args[0] = 1;        // CCW
         mo->special1.i = actor->angle;    // Set angle
         P_SetMobjStateNF(mo, HEXEN_S_SORCFX2_ORBIT1);
     }
@@ -7848,23 +7848,23 @@ void A_SorcFX2Orbit(mobj_t * actor)
     fixed_t dist = parent->info->radius;
 
     if ((parent->health <= 0) ||        // Sorcerer is dead
-        (!parent->args[0]))     // Time expired
+        (!parent->special_args[0]))     // Time expired
     {
         P_SetMobjStateNF(actor, actor->info->deathstate);
-        parent->args[0] = 0;
+        parent->special_args[0] = 0;
         parent->flags2 &= ~MF2_REFLECTIVE;
         parent->flags2 &= ~MF2_INVULNERABLE;
     }
 
-    if (actor->args[0] && (parent->args[0]-- <= 0))     // Time expired
+    if (actor->special_args[0] && (parent->special_args[0]-- <= 0))     // Time expired
     {
         P_SetMobjStateNF(actor, actor->info->deathstate);
-        parent->args[0] = 0;
+        parent->special_args[0] = 0;
         parent->flags2 &= ~MF2_REFLECTIVE;
     }
 
     // Move to new position based on angle
-    if (actor->args[0])         // Counter clock-wise
+    if (actor->special_args[0])         // Counter clock-wise
     {
         actor->special1.i += ANG1 * 10;
         angle = ((angle_t) actor->special1.i) >> ANGLETOFINESHIFT;
@@ -7938,15 +7938,15 @@ void A_SorcBallPop(mobj_t * actor)
     actor->momy = ((P_Random(pr_hexen) % 10) - 5) << FRACBITS;
     actor->momz = (2 + (P_Random(pr_hexen) % 3)) << FRACBITS;
     actor->special2.i = 4 * FRACUNIT;     // Initial bounce factor
-    actor->args[4] = BOUNCE_TIME_UNIT;  // Bounce time unit
-    actor->args[3] = 5;         // Bounce time in seconds
+    actor->special_args[4] = BOUNCE_TIME_UNIT;  // Bounce time unit
+    actor->special_args[3] = 5;         // Bounce time in seconds
 }
 
 void A_BounceCheck(mobj_t * actor)
 {
-    if (actor->args[4]-- <= 0)
+    if (actor->special_args[4]-- <= 0)
     {
-        if (actor->args[3]-- <= 0)
+        if (actor->special_args[3]-- <= 0)
         {
             P_SetMobjState(actor, actor->info->deathstate);
             switch (actor->type)
@@ -7965,7 +7965,7 @@ void A_BounceCheck(mobj_t * actor)
         }
         else
         {
-            actor->args[4] = BOUNCE_TIME_UNIT;
+            actor->special_args[4] = BOUNCE_TIME_UNIT;
         }
     }
 }
@@ -8291,8 +8291,8 @@ void KSpiritInit(mobj_t * spirit, mobj_t * korax)
 
     P_SetTarget(&spirit->special1.m, korax);     // Swarm around korax
     spirit->special2.i = 32 + (P_Random(pr_hexen) & 7);   // Float bob index
-    spirit->args[0] = 10;       // initial turn value
-    spirit->args[1] = 0;        // initial look angle
+    spirit->special_args[0] = 10;       // initial turn value
+    spirit->special_args[1] = 0;        // initial look angle
 
     // Spawn a tail for spirit
     tail = P_SpawnMobj(spirit->x, spirit->y, spirit->z, HEXEN_MT_HOLY_TAIL);
@@ -8606,8 +8606,8 @@ void A_KSpiritRoam(mobj_t * actor)
     {
         if (actor->special1.m)
         {
-            A_KSpiritSeeker(actor, actor->args[0] * ANG1,
-                            actor->args[0] * ANG1 * 2);
+            A_KSpiritSeeker(actor, actor->special_args[0] * ANG1,
+                            actor->special_args[0] * ANG1 * 2);
         }
         A_KSpiritWeave(actor);
         if (P_Random(pr_hexen) < 50)

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -5298,7 +5298,7 @@ dboolean P_UpdateMorphedMonster(mobj_t * actor, int tics)
         mo->special1.i = 5 * 35;  // Next try in 5 seconds
         mo->special2.i = moType;
         mo->tid = oldMonster.tid;
-        memcpy(mo->special_args, oldMonster.special_args, 5);
+        memcpy(mo->special_args, oldMonster.special_args, SPECIAL_ARGS_SIZE);
         map_format.add_mobj_thing_id(mo, oldMonster.tid);
         dsda_WatchMorph(mo);
         return (false);
@@ -5307,7 +5307,7 @@ dboolean P_UpdateMorphedMonster(mobj_t * actor, int tics)
     P_SetTarget(&mo->target, oldMonster.target);
     mo->tid = oldMonster.tid;
     mo->special = oldMonster.special;
-    memcpy(mo->special_args, oldMonster.special_args, 5);
+    memcpy(mo->special_args, oldMonster.special_args, SPECIAL_ARGS_SIZE);
     map_format.add_mobj_thing_id(mo, oldMonster.tid);
     fog = P_SpawnMobj(x, y, z + TELEFOGHEIGHT, HEXEN_MT_TFOG);
     S_StartMobjSound(fog, hexen_sfx_teleport);
@@ -5428,12 +5428,15 @@ void A_MinotaurLook(mobj_t * actor);
 // have passed. Returns false if killed.
 static dboolean CheckMinotaurAge(mobj_t *mo)
 {
+    byte args[5];
     unsigned int starttime;
+
+    COLLAPSE_SPECIAL_ARGS(args, mo->special_args);
 
     // The start time is stored in the mobj_t structure, but it is stored
     // in little endian format. For Vanilla savegame compatibility we must
     // swap it to the native endianness.
-    memcpy(&starttime, mo->special_args, sizeof(unsigned int));
+    memcpy(&starttime, args, sizeof(unsigned int));
 
     if (leveltime - LittleLong(starttime) >= MAULATORTICS)
     {

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -5428,17 +5428,7 @@ void A_MinotaurLook(mobj_t * actor);
 // have passed. Returns false if killed.
 static dboolean CheckMinotaurAge(mobj_t *mo)
 {
-    byte args[5];
-    unsigned int starttime;
-
-    COLLAPSE_SPECIAL_ARGS(args, mo->special_args);
-
-    // The start time is stored in the mobj_t structure, but it is stored
-    // in little endian format. For Vanilla savegame compatibility we must
-    // swap it to the native endianness.
-    memcpy(&starttime, args, sizeof(unsigned int));
-
-    if (leveltime - LittleLong(starttime) >= MAULATORTICS)
+    if (leveltime - mo->special_args[0] >= MAULATORTICS)
     {
         P_DamageMobj(mo, NULL, NULL, 10000);
         return false;

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -1405,7 +1405,7 @@ static void P_SpawnZDoomFloor(sector_t *sec, floor_e floortype, line_t *line,
   }
 }
 
-int EV_DoZDoomFloor(floor_e floortype, line_t *line, byte tag, fixed_t speed, fixed_t height,
+int EV_DoZDoomFloor(floor_e floortype, line_t *line, int tag, fixed_t speed, fixed_t height,
                     int crush, int change, dboolean hexencrush, dboolean hereticlower)
 {
   sector_t *sec;

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -3423,6 +3423,7 @@ static void Hexen_P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
 // Search thinker list for minotaur
 static mobj_t *ActiveMinotaur(player_t * master)
 {
+    byte args[5];
     mobj_t *mo;
     player_t *plr;
     thinker_t *think;
@@ -3441,7 +3442,9 @@ static mobj_t *ActiveMinotaur(player_t * master)
             continue;           // for morphed minotaurs
         if (mo->flags & MF_CORPSE)
             continue;
-        starttime = (unsigned int *) mo->special_args;
+        // TODO: CheckMinotaurAge uses LittleLong, why not here?
+        COLLAPSE_SPECIAL_ARGS(args, mo->special_args);
+        starttime = (unsigned int *) args;
         if ((leveltime - *starttime) >= MAULATORTICS)
             continue;
         plr = mo->special1.m->player;
@@ -3541,7 +3544,7 @@ static dboolean P_MorphMonster(mobj_t * actor)
     monster->tid = oldMonster.tid;
     monster->special = oldMonster.special;
     map_format.add_mobj_thing_id(monster, oldMonster.tid);
-    memcpy(monster->special_args, oldMonster.special_args, 5);
+    memcpy(monster->special_args, oldMonster.special_args, SPECIAL_ARGS_SIZE);
     dsda_WatchMorph(monster);
 
     // check for turning off minotaur power for active icon

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -3423,11 +3423,9 @@ static void Hexen_P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
 // Search thinker list for minotaur
 static mobj_t *ActiveMinotaur(player_t * master)
 {
-    byte args[5];
     mobj_t *mo;
     player_t *plr;
     thinker_t *think;
-    unsigned int *starttime;
 
     for (think = thinkercap.next; think != &thinkercap; think = think->next)
     {
@@ -3442,10 +3440,7 @@ static mobj_t *ActiveMinotaur(player_t * master)
             continue;           // for morphed minotaurs
         if (mo->flags & MF_CORPSE)
             continue;
-        // TODO: CheckMinotaurAge uses LittleLong, why not here?
-        COLLAPSE_SPECIAL_ARGS(args, mo->special_args);
-        starttime = (unsigned int *) args;
-        if ((leveltime - *starttime) >= MAULATORTICS)
+        if (leveltime - mo->special_args[0] >= MAULATORTICS)
             continue;
         plr = mo->special1.m->player;
         if (plr == master)

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -768,7 +768,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
   if (special->special)
   {
-    map_format.execute_line_special(special->special, special->args, NULL, 0, player->mo);
+    map_format.execute_line_special(special->special, special->special_args, NULL, 0, player->mo);
     special->special = 0;
   }
 
@@ -839,7 +839,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
         }
         else
         {
-            map_format.execute_line_special(target->special, target->args, NULL, 0, target);
+            map_format.execute_line_special(target->special, target->special_args, NULL, 0, target);
         }
     }
   }
@@ -2329,7 +2329,7 @@ void P_MinotaurSlam(mobj_t * source, mobj_t * target)
     {
         target->reactiontime = 14 + (P_Random(pr_heretic) & 7);
     }
-    source->args[0] = 0;        // Stop charging
+    source->special_args[0] = 0;        // Stop charging
 }
 
 void P_TouchWhirlwind(mobj_t * target)
@@ -2856,7 +2856,7 @@ void TryPickupWeapon(player_t * player, pclass_t weaponClass,
     P_SetMessage(player, message, false);
     if (weapon->special)
     {
-        map_format.execute_line_special(weapon->special, weapon->args, NULL, 0, player->mo);
+        map_format.execute_line_special(weapon->special, weapon->special_args, NULL, 0, player->mo);
         weapon->special = 0;
     }
 
@@ -2952,7 +2952,7 @@ static void TryPickupWeaponPiece(player_t * player, pclass_t matchClass,
     // Pick up the weapon piece
     if (pieceMobj->special)
     {
-        map_format.execute_line_special(pieceMobj->special, pieceMobj->args, NULL, 0, player->mo);
+        map_format.execute_line_special(pieceMobj->special, pieceMobj->special_args, NULL, 0, player->mo);
         pieceMobj->special = 0;
     }
     if (remove)
@@ -3087,7 +3087,7 @@ static void TryPickupArtifact(player_t * player, artitype_t artifactType, mobj_t
     {
         if (artifact->special)
         {
-            map_format.execute_line_special(artifact->special, artifact->args, NULL, 0, NULL);
+            map_format.execute_line_special(artifact->special, artifact->special_args, NULL, 0, NULL);
             artifact->special = 0;
         }
         player->bonuscount += BONUSADD;
@@ -3191,7 +3191,7 @@ static void Hexen_P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
             // get removed for coop netplay
             if (special->special)
             {
-                map_format.execute_line_special(special->special, special->args, NULL, 0, toucher);
+                map_format.execute_line_special(special->special, special->special_args, NULL, 0, toucher);
                 special->special = 0;
             }
 
@@ -3401,7 +3401,7 @@ static void Hexen_P_TouchSpecialThing(mobj_t * special, mobj_t * toucher)
     }
     if (special->special)
     {
-        map_format.execute_line_special(special->special, special->args, NULL, 0, toucher);
+        map_format.execute_line_special(special->special, special->special_args, NULL, 0, toucher);
         special->special = 0;
     }
     if (deathmatch && respawn && !(special->flags & MF_DROPPED))
@@ -3441,7 +3441,7 @@ static mobj_t *ActiveMinotaur(player_t * master)
             continue;           // for morphed minotaurs
         if (mo->flags & MF_CORPSE)
             continue;
-        starttime = (unsigned int *) mo->args;
+        starttime = (unsigned int *) mo->special_args;
         if ((leveltime - *starttime) >= MAULATORTICS)
             continue;
         plr = mo->special1.m->player;
@@ -3541,7 +3541,7 @@ static dboolean P_MorphMonster(mobj_t * actor)
     monster->tid = oldMonster.tid;
     monster->special = oldMonster.special;
     map_format.add_mobj_thing_id(monster, oldMonster.tid);
-    memcpy(monster->args, oldMonster.args, 5);
+    memcpy(monster->special_args, oldMonster.special_args, 5);
     dsda_WatchMorph(monster);
 
     // check for turning off minotaur power for active icon

--- a/prboom2/src/p_lights.c
+++ b/prboom2/src/p_lights.c
@@ -546,7 +546,7 @@ static void P_SpawnZDoomLightGlow(sector_t *sec, short startlevel, short endleve
   g->oneshot = oneshot;
 }
 
-void EV_StartLightFading(int tag, byte level, byte tics)
+void EV_StartLightFading(int tag, short level, short tics)
 {
   const int *id_p;
 
@@ -568,7 +568,7 @@ void EV_StartLightFading(int tag, byte level, byte tics)
   }
 }
 
-void EV_StartLightGlowing(int tag, byte upper, byte lower, byte tics)
+void EV_StartLightGlowing(int tag, short upper, short lower, short tics)
 {
   const int *id_p;
 
@@ -577,7 +577,7 @@ void EV_StartLightGlowing(int tag, byte upper, byte lower, byte tics)
 
   if (upper < lower)
   {
-    byte temp = upper;
+    short temp = upper;
     upper = lower;
     lower = temp;
   }
@@ -628,7 +628,7 @@ static void P_SpawnZDoomLightFlicker(sector_t *sec, short upper, short lower)
   g->count = (P_Random(pr_lights) & 64) + 1;
 }
 
-void EV_StartLightFlickering(int tag, byte upper, byte lower)
+void EV_StartLightFlickering(int tag, short upper, short lower)
 {
   const int *id_p;
 

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -3898,18 +3898,18 @@ dboolean PTR_PuzzleItemTraverse(intercept_t * in)
         {                       // Don't use back sides
             return false;
         }
-        if (PuzzleItemType != in->d.line->arg1)
+        if (PuzzleItemType != in->d.line->args[0])
         {                       // Item type doesn't match
             return false;
         }
 
         // Construct an args[] array that would contain the values from
         // the line that would be passed by Vanilla Hexen.
-        args[0] = in->d.line->arg3;
-        args[1] = in->d.line->arg4;
-        args[2] = in->d.line->arg5;
+        args[0] = in->d.line->args[2];
+        args[1] = in->d.line->args[3];
+        args[2] = in->d.line->args[4];
 
-        P_StartACS(in->d.line->arg2, 0, args, PuzzleItemUser, in->d.line, 0);
+        P_StartACS(in->d.line->args[1], 0, args, PuzzleItemUser, in->d.line, 0);
         in->d.line->special = 0;
         PuzzleActivated = true;
         return false;           // Stop searching

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -3659,7 +3659,7 @@ dboolean PIT_ThrustStompThing(mobj_t * thing)
         return true;            // don't clip against self
 
     P_DamageMobj(thing, tsthing, tsthing, 10001);
-    tsthing->args[1] = 1;       // Mark thrust thing as bloody
+    tsthing->special_args[1] = 1;       // Mark thrust thing as bloody
 
     return true;
 }
@@ -3898,18 +3898,18 @@ dboolean PTR_PuzzleItemTraverse(intercept_t * in)
         {                       // Don't use back sides
             return false;
         }
-        if (PuzzleItemType != in->d.line->args[0])
+        if (PuzzleItemType != in->d.line->special_args[0])
         {                       // Item type doesn't match
             return false;
         }
 
         // Construct an args[] array that would contain the values from
         // the line that would be passed by Vanilla Hexen.
-        args[0] = in->d.line->args[2];
-        args[1] = in->d.line->args[3];
-        args[2] = in->d.line->args[4];
+        args[0] = in->d.line->special_args[2];
+        args[1] = in->d.line->special_args[3];
+        args[2] = in->d.line->special_args[4];
 
-        P_StartACS(in->d.line->args[1], 0, args, PuzzleItemUser, in->d.line, 0);
+        P_StartACS(in->d.line->special_args[1], 0, args, PuzzleItemUser, in->d.line, 0);
         in->d.line->special = 0;
         PuzzleActivated = true;
         return false;           // Stop searching
@@ -3920,12 +3920,12 @@ dboolean PTR_PuzzleItemTraverse(intercept_t * in)
     {                           // Wrong special
         return true;
     }
-    if (PuzzleItemType != mobj->args[0])
+    if (PuzzleItemType != mobj->special_args[0])
     {                           // Item type doesn't match
         return true;
     }
 
-    P_StartACS(mobj->args[1], 0, &mobj->args[2], PuzzleItemUser, NULL, 0);
+    P_StartACS(mobj->special_args[1], 0, &mobj->special_args[2], PuzzleItemUser, NULL, 0);
     mobj->special = 0;
     PuzzleActivated = true;
     return false;               // Stop searching

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -3925,7 +3925,11 @@ dboolean PTR_PuzzleItemTraverse(intercept_t * in)
         return true;
     }
 
-    P_StartACS(mobj->special_args[1], 0, &mobj->special_args[2], PuzzleItemUser, NULL, 0);
+    args[0] = mobj->special_args[2];
+    args[1] = mobj->special_args[3];
+    args[2] = mobj->special_args[4];
+
+    P_StartACS(mobj->special_args[1], 0, args, PuzzleItemUser, NULL, 0);
     mobj->special = 0;
     PuzzleActivated = true;
     return false;               // Stop searching

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2098,8 +2098,9 @@ dboolean P_IsDoomnumAllowed(int doomnum)
 
 static dboolean P_ShouldSpawnPlayer(const mapthing_t* mthing)
 {
-  return !deathmatch &&
-         (map_format.zdoom ? mthing->args[0] == leave_data.position : !mthing->args[0]);
+  return !deathmatch && (map_format.zdoom ?
+                         mthing->special_args[0] == leave_data.position :
+                         !mthing->special_args[0]);
 }
 
 mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
@@ -2234,7 +2235,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
     }
 
     if (map_format.hexen)
-      start = mthing->args[0];
+      start = mthing->special_args[0];
 
     // save spots for respawning in coop games
     playerstarts[start][thingtype - 1] = *mthing;
@@ -2278,7 +2279,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
 
       player = 4 + mthing->type - 9100;
 
-      player_start = &playerstarts[mthing->args[0]][player];
+      player_start = &playerstarts[mthing->special_args[0]][player];
       memcpy(player_start, mthing, sizeof(mapthing_t));
       player_start->type = player + 1;
 
@@ -2352,7 +2353,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
   if (!raven && thingtype == 14165 && map_format.hexen)
   {
     // Use the ambient number
-    iden_num = BETWEEN(0, 64, mthing->args[0]); // Mus change
+    iden_num = BETWEEN(0, 64, mthing->special_args[0]); // Mus change
     thingtype = 14164;            // MT_MUSICSOURCE
   }
 
@@ -2468,11 +2469,11 @@ spawnit:
     }
     mobj->tid = mthing->tid;
     mobj->special = mthing->special;
-    mobj->special_args[0] = mthing->args[0];
-    mobj->special_args[1] = mthing->args[1];
-    mobj->special_args[2] = mthing->args[2];
-    mobj->special_args[3] = mthing->args[3];
-    mobj->special_args[4] = mthing->args[4];
+    mobj->special_args[0] = mthing->special_args[0];
+    mobj->special_args[1] = mthing->special_args[1];
+    mobj->special_args[2] = mthing->special_args[2];
+    mobj->special_args[3] = mthing->special_args[3];
+    mobj->special_args[4] = mthing->special_args[4];
   }
 
   if (mobj->flags2 & MF2_FLOATBOB)

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2468,11 +2468,11 @@ spawnit:
     }
     mobj->tid = mthing->tid;
     mobj->special = mthing->special;
-    mobj->args[0] = mthing->args[0];
-    mobj->args[1] = mthing->args[1];
-    mobj->args[2] = mthing->args[2];
-    mobj->args[3] = mthing->args[3];
-    mobj->args[4] = mthing->args[4];
+    mobj->special_args[0] = mthing->args[0];
+    mobj->special_args[1] = mthing->args[1];
+    mobj->special_args[2] = mthing->args[2];
+    mobj->special_args[3] = mthing->args[3];
+    mobj->special_args[4] = mthing->args[4];
   }
 
   if (mobj->flags2 & MF2_FLOATBOB)
@@ -3336,7 +3336,7 @@ void P_FloorBounceMissile(mobj_t * mo)
                 case HEXEN_MT_SORCBALL1:
                 case HEXEN_MT_SORCBALL2:
                 case HEXEN_MT_SORCBALL3:
-                    if (!mo->args[0])
+                    if (!mo->special_args[0])
                         S_StartMobjSound(mo, mo->info->seesound);
                     break;
                 default:

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2099,7 +2099,7 @@ dboolean P_IsDoomnumAllowed(int doomnum)
 static dboolean P_ShouldSpawnPlayer(const mapthing_t* mthing)
 {
   return !deathmatch &&
-         (map_format.zdoom ? mthing->arg1 == leave_data.position : !mthing->arg1);
+         (map_format.zdoom ? mthing->args[0] == leave_data.position : !mthing->args[0]);
 }
 
 mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
@@ -2234,7 +2234,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
     }
 
     if (map_format.hexen)
-      start = mthing->arg1;
+      start = mthing->args[0];
 
     // save spots for respawning in coop games
     playerstarts[start][thingtype - 1] = *mthing;
@@ -2278,7 +2278,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
 
       player = 4 + mthing->type - 9100;
 
-      player_start = &playerstarts[mthing->arg1][player];
+      player_start = &playerstarts[mthing->args[0]][player];
       memcpy(player_start, mthing, sizeof(mapthing_t));
       player_start->type = player + 1;
 
@@ -2352,7 +2352,7 @@ mobj_t* P_SpawnMapThing (const mapthing_t* mthing, int index)
   if (!raven && thingtype == 14165 && map_format.hexen)
   {
     // Use the ambient number
-    iden_num = BETWEEN(0, 64, mthing->arg1); // Mus change
+    iden_num = BETWEEN(0, 64, mthing->args[0]); // Mus change
     thingtype = 14164;            // MT_MUSICSOURCE
   }
 
@@ -2468,11 +2468,11 @@ spawnit:
     }
     mobj->tid = mthing->tid;
     mobj->special = mthing->special;
-    mobj->args[0] = mthing->arg1;
-    mobj->args[1] = mthing->arg2;
-    mobj->args[2] = mthing->arg3;
-    mobj->args[3] = mthing->arg4;
-    mobj->args[4] = mthing->arg5;
+    mobj->args[0] = mthing->args[0];
+    mobj->args[1] = mthing->args[1];
+    mobj->args[2] = mthing->args[2];
+    mobj->args[3] = mthing->args[3];
+    mobj->args[4] = mthing->args[4];
   }
 
   if (mobj->flags2 & MF2_FLOATBOB)

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -399,7 +399,7 @@ typedef struct mobj_s
     int archiveNum;             // Identity during archive
     short tid;                  // thing identifier
     int special;                // special
-    byte args[5];               // special arguments
+    byte special_args[5];        // special arguments
 
     // zdoom
     fixed_t gravity;

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -399,7 +399,7 @@ typedef struct mobj_s
     int archiveNum;             // Identity during archive
     short tid;                  // thing identifier
     int special;                // special
-    byte special_args[5];        // special arguments
+    int special_args[5];        // special arguments
 
     // zdoom
     fixed_t gravity;

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -3550,8 +3550,8 @@ void A_CHolyAttack2(mobj_t * actor)
         mo->angle = actor->angle + (ANG45 + ANG45 / 2) - ANG45 * j;
         P_ThrustMobj(mo, mo->angle, mo->info->speed);
         P_SetTarget(&mo->target, actor->target);
-        mo->args[0] = 10;       // initial turn value
-        mo->args[1] = 0;        // initial look angle
+        mo->special_args[0] = 10;       // initial turn value
+        mo->special_args[1] = 0;        // initial look angle
         if (deathmatch)
         {                       // Ghosts last slightly less longer in DeathMatch
             mo->health = 85;
@@ -3729,11 +3729,11 @@ void A_CHolySeek(mobj_t * actor)
     }
     if (actor->special1.m)
     {
-        CHolySeekerMissile(actor, actor->args[0] * ANG1,
-                           actor->args[0] * ANG1 * 2);
+        CHolySeekerMissile(actor, actor->special_args[0] * ANG1,
+                           actor->special_args[0] * ANG1 * 2);
         if (!((leveltime + 7) & 15))
         {
-            actor->args[0] = 5 + (P_Random(pr_hexen) / 20);
+            actor->special_args[0] = 5 + (P_Random(pr_hexen) / 20);
         }
     }
     CHolyWeave(actor);
@@ -3885,7 +3885,7 @@ void A_FireConePL1(player_t * player, pspdef_t * psp)
                 | SHARDSPAWN_RIGHT;
             mo->special2.i = 3;   // Set sperm count (levels of reproductivity)
             P_SetTarget(&mo->target, pmo);
-            mo->args[0] = 3;    // Mark Initial shard as super damage
+            mo->special_args[0] = 3;    // Mark Initial shard as super damage
         }
     }
 }
@@ -3913,7 +3913,7 @@ void A_ShedShard(mobj_t * actor)
             mo->special2.i = spermcount;
             mo->momz = actor->momz;
             P_SetTarget(&mo->target, actor->target);
-            mo->args[0] = (spermcount == 3) ? 2 : 0;
+            mo->special_args[0] = (spermcount == 3) ? 2 : 0;
         }
     }
     if (spawndir & SHARDSPAWN_RIGHT)
@@ -3927,7 +3927,7 @@ void A_ShedShard(mobj_t * actor)
             mo->special2.i = spermcount;
             mo->momz = actor->momz;
             P_SetTarget(&mo->target, actor->target);
-            mo->args[0] = (spermcount == 3) ? 2 : 0;
+            mo->special_args[0] = (spermcount == 3) ? 2 : 0;
         }
     }
     if (spawndir & SHARDSPAWN_UP)
@@ -3945,7 +3945,7 @@ void A_ShedShard(mobj_t * actor)
                 mo->special1.i = SHARDSPAWN_UP;
             mo->special2.i = spermcount;
             P_SetTarget(&mo->target, actor->target);
-            mo->args[0] = (spermcount == 3) ? 2 : 0;
+            mo->special_args[0] = (spermcount == 3) ? 2 : 0;
         }
     }
     if (spawndir & SHARDSPAWN_DOWN)
@@ -3963,7 +3963,7 @@ void A_ShedShard(mobj_t * actor)
                 mo->special1.i = SHARDSPAWN_DOWN;
             mo->special2.i = spermcount;
             P_SetTarget(&mo->target, actor->target);
-            mo->args[0] = (spermcount == 3) ? 2 : 0;
+            mo->special_args[0] = (spermcount == 3) ? 2 : 0;
         }
     }
 }

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -186,7 +186,7 @@ void P_ArchiveWorld (void)
     P_SAVE_X(li->special);
     P_SAVE_X(li->tag);
     P_SAVE_BYTE(li->player_activations);
-    P_SAVE_ARRAY(li->args);
+    P_SAVE_ARRAY(li->special_args);
 
     for (j = 0; j < 2; j++)
       if (li->sidenum[j] != NO_INDEX)
@@ -243,7 +243,7 @@ void P_UnArchiveWorld (void)
     P_LOAD_X(li->special);
     P_LOAD_X(li->tag);
     P_LOAD_BYTE(li->player_activations);
-    P_LOAD_ARRAY(li->args);
+    P_LOAD_ARRAY(li->special_args);
 
     for (j = 0; j < 2; j++)
       if (li->sidenum[j] != NO_INDEX)

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -186,11 +186,7 @@ void P_ArchiveWorld (void)
     P_SAVE_X(li->special);
     P_SAVE_X(li->tag);
     P_SAVE_BYTE(li->player_activations);
-    P_SAVE_BYTE(li->arg1);
-    P_SAVE_BYTE(li->arg2);
-    P_SAVE_BYTE(li->arg3);
-    P_SAVE_BYTE(li->arg4);
-    P_SAVE_BYTE(li->arg5);
+    P_SAVE_ARRAY(li->args);
 
     for (j = 0; j < 2; j++)
       if (li->sidenum[j] != NO_INDEX)
@@ -247,11 +243,7 @@ void P_UnArchiveWorld (void)
     P_LOAD_X(li->special);
     P_LOAD_X(li->tag);
     P_LOAD_BYTE(li->player_activations);
-    P_LOAD_BYTE(li->arg1);
-    P_LOAD_BYTE(li->arg2);
-    P_LOAD_BYTE(li->arg3);
-    P_LOAD_BYTE(li->arg4);
-    P_LOAD_BYTE(li->arg5);
+    P_LOAD_ARRAY(li->args);
 
     for (j = 0; j < 2; j++)
       if (li->sidenum[j] != NO_INDEX)

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1758,11 +1758,11 @@ static void P_LoadThings(int lump)
       mt.type = LittleShort(hmt->type);
       mt.options = LittleShort(hmt->options);
       mt.special = hmt->special;
-      mt.args[0] = hmt->arg1;
-      mt.args[1] = hmt->arg2;
-      mt.args[2] = hmt->arg3;
-      mt.args[3] = hmt->arg4;
-      mt.args[4] = hmt->arg5;
+      mt.special_args[0] = hmt->arg1;
+      mt.special_args[1] = hmt->arg2;
+      mt.special_args[2] = hmt->arg3;
+      mt.special_args[3] = hmt->arg4;
+      mt.special_args[4] = hmt->arg5;
       mt.gravity = FRACUNIT;
       mt.health = FRACUNIT;
     }
@@ -1778,11 +1778,11 @@ static void P_LoadThings(int lump)
       mt.type = LittleShort(dmt->type);
       mt.options = LittleShort(dmt->options);
       mt.special = 0;
-      mt.args[0] = 0;
-      mt.args[1] = 0;
-      mt.args[2] = 0;
-      mt.args[3] = 0;
-      mt.args[4] = 0;
+      mt.special_args[0] = 0;
+      mt.special_args[1] = 0;
+      mt.special_args[2] = 0;
+      mt.special_args[3] = 0;
+      mt.special_args[4] = 0;
       mt.gravity = FRACUNIT;
       mt.health = FRACUNIT;
     }
@@ -1825,11 +1825,11 @@ static void P_LoadUDMFThings(int lump)
     mt.type = dmt->type;
     mt.options = 0;
     mt.special = dmt->special;
-    mt.args[0] = dmt->arg0;
-    mt.args[1] = dmt->arg1;
-    mt.args[2] = dmt->arg2;
-    mt.args[3] = dmt->arg3;
-    mt.args[4] = dmt->arg4;
+    mt.special_args[0] = dmt->arg0;
+    mt.special_args[1] = dmt->arg1;
+    mt.special_args[2] = dmt->arg2;
+    mt.special_args[3] = dmt->arg3;
+    mt.special_args[4] = dmt->arg4;
     mt.gravity = dsda_StringToFixed(dmt->gravity);
     mt.health = dsda_StringToFixed(dmt->health);
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1758,11 +1758,11 @@ static void P_LoadThings(int lump)
       mt.type = LittleShort(hmt->type);
       mt.options = LittleShort(hmt->options);
       mt.special = hmt->special;
-      mt.arg1 = hmt->arg1;
-      mt.arg2 = hmt->arg2;
-      mt.arg3 = hmt->arg3;
-      mt.arg4 = hmt->arg4;
-      mt.arg5 = hmt->arg5;
+      mt.args[0] = hmt->arg1;
+      mt.args[1] = hmt->arg2;
+      mt.args[2] = hmt->arg3;
+      mt.args[3] = hmt->arg4;
+      mt.args[4] = hmt->arg5;
       mt.gravity = FRACUNIT;
       mt.health = FRACUNIT;
     }
@@ -1778,11 +1778,11 @@ static void P_LoadThings(int lump)
       mt.type = LittleShort(dmt->type);
       mt.options = LittleShort(dmt->options);
       mt.special = 0;
-      mt.arg1 = 0;
-      mt.arg2 = 0;
-      mt.arg3 = 0;
-      mt.arg4 = 0;
-      mt.arg5 = 0;
+      mt.args[0] = 0;
+      mt.args[1] = 0;
+      mt.args[2] = 0;
+      mt.args[3] = 0;
+      mt.args[4] = 0;
       mt.gravity = FRACUNIT;
       mt.health = FRACUNIT;
     }
@@ -1825,11 +1825,11 @@ static void P_LoadUDMFThings(int lump)
     mt.type = dmt->type;
     mt.options = 0;
     mt.special = dmt->special;
-    mt.arg1 = dmt->arg0;
-    mt.arg2 = dmt->arg1;
-    mt.arg3 = dmt->arg2;
-    mt.arg4 = dmt->arg3;
-    mt.arg5 = dmt->arg4;
+    mt.args[0] = dmt->arg0;
+    mt.args[1] = dmt->arg1;
+    mt.args[2] = dmt->arg2;
+    mt.args[3] = dmt->arg3;
+    mt.args[4] = dmt->arg4;
     mt.gravity = dsda_StringToFixed(dmt->gravity);
     mt.health = dsda_StringToFixed(dmt->health);
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1985,21 +1985,21 @@ static void P_SetLineID(line_t *ld)
   switch (ld->special)
   {
     case zl_line_set_identification:
-      ld->tag = (unsigned short) 256 * ld->arg5 + ld->arg1;
+      ld->tag = (unsigned short) 256 * ld->args[4] + ld->args[0];
       ld->special = 0;
       break;
     case zl_translucent_line:
-      ld->tag = ld->arg1;
+      ld->tag = ld->args[0];
       break;
     case zl_teleport_line:
     case zl_scroll_texture_model:
-      ld->tag = ld->arg1;
+      ld->tag = ld->args[0];
       break;
     case zl_polyobj_start_line:
-      ld->tag = ld->arg4;
+      ld->tag = ld->args[3];
       break;
     case zl_polyobj_explicit_line:
-      ld->tag = ld->arg5;
+      ld->tag = ld->args[4];
       break;
   }
 }
@@ -2121,11 +2121,11 @@ static void P_LoadLineDefs (int lump)
       ld->flags = (unsigned short)LittleShort(mld->flags);
       ld->special = mld->special; // just a byte in hexen
       ld->tag = 0;
-      ld->arg1 = mld->arg1;
-      ld->arg2 = mld->arg2;
-      ld->arg3 = mld->arg3;
-      ld->arg4 = mld->arg4;
-      ld->arg5 = mld->arg5;
+      ld->args[0] = mld->arg1;
+      ld->args[1] = mld->arg2;
+      ld->args[2] = mld->arg3;
+      ld->args[3] = mld->arg4;
+      ld->args[4] = mld->arg5;
       ld->v1 = &vertexes[(unsigned short)LittleShort(mld->v1)];
       ld->v2 = &vertexes[(unsigned short)LittleShort(mld->v2)];
       ld->sidenum[0] = LittleShort(mld->sidenum[0]);
@@ -2139,11 +2139,11 @@ static void P_LoadLineDefs (int lump)
       ld->flags = (unsigned short)LittleShort(mld->flags);
       ld->special = LittleShort(mld->special);
       ld->tag = LittleShort(mld->tag);
-      ld->arg1 = 0;
-      ld->arg2 = 0;
-      ld->arg3 = 0;
-      ld->arg4 = 0;
-      ld->arg5 = 0;
+      ld->args[0] = 0;
+      ld->args[1] = 0;
+      ld->args[2] = 0;
+      ld->args[3] = 0;
+      ld->args[4] = 0;
       ld->v1 = &vertexes[(unsigned short)LittleShort(mld->v1)];
       ld->v2 = &vertexes[(unsigned short)LittleShort(mld->v2)];
       ld->sidenum[0] = LittleShort(mld->sidenum[0]);
@@ -2178,11 +2178,11 @@ static void P_LoadUDMFLineDefs(int lump)
     ld->flags = (mld->flags & ML_BOOM);
     ld->special = mld->special;
     ld->tag = (mld->id >= 0 ? mld->id : 0);
-    ld->arg1 = mld->arg0;
-    ld->arg2 = mld->arg1;
-    ld->arg3 = mld->arg2;
-    ld->arg4 = mld->arg3;
-    ld->arg5 = mld->arg4;
+    ld->args[0] = mld->arg0;
+    ld->args[1] = mld->arg1;
+    ld->args[2] = mld->arg2;
+    ld->args[3] = mld->arg3;
+    ld->args[4] = mld->arg4;
     ld->v1 = &vertexes[mld->v1];
     ld->v2 = &vertexes[mld->v2];
     ld->sidenum[0] = mld->sidefront;
@@ -2379,13 +2379,13 @@ void P_PostProcessZDoomLineSpecial(line_t *ld)
       else
         tranmap = W_LumpByNum(lump - 1);
 
-      if (!ld->arg1)
+      if (!ld->args[0])
       {
         ld->tranmap = tranmap;
         ld->alpha = 0.66f;
       }
       else
-        for (id_p = dsda_FindLinesFromID(ld->arg1); *id_p >= 0; id_p++)
+        for (id_p = dsda_FindLinesFromID(ld->args[0]); *id_p >= 0; id_p++)
         {
           lines[*id_p].tranmap = tranmap;
           lines[*id_p].alpha = 0.66f;

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1985,21 +1985,21 @@ static void P_SetLineID(line_t *ld)
   switch (ld->special)
   {
     case zl_line_set_identification:
-      ld->tag = (unsigned short) 256 * ld->args[4] + ld->args[0];
+      ld->tag = (unsigned short) 256 * ld->special_args[4] + ld->special_args[0];
       ld->special = 0;
       break;
     case zl_translucent_line:
-      ld->tag = ld->args[0];
+      ld->tag = ld->special_args[0];
       break;
     case zl_teleport_line:
     case zl_scroll_texture_model:
-      ld->tag = ld->args[0];
+      ld->tag = ld->special_args[0];
       break;
     case zl_polyobj_start_line:
-      ld->tag = ld->args[3];
+      ld->tag = ld->special_args[3];
       break;
     case zl_polyobj_explicit_line:
-      ld->tag = ld->args[4];
+      ld->tag = ld->special_args[4];
       break;
   }
 }
@@ -2121,11 +2121,11 @@ static void P_LoadLineDefs (int lump)
       ld->flags = (unsigned short)LittleShort(mld->flags);
       ld->special = mld->special; // just a byte in hexen
       ld->tag = 0;
-      ld->args[0] = mld->arg1;
-      ld->args[1] = mld->arg2;
-      ld->args[2] = mld->arg3;
-      ld->args[3] = mld->arg4;
-      ld->args[4] = mld->arg5;
+      ld->special_args[0] = mld->arg1;
+      ld->special_args[1] = mld->arg2;
+      ld->special_args[2] = mld->arg3;
+      ld->special_args[3] = mld->arg4;
+      ld->special_args[4] = mld->arg5;
       ld->v1 = &vertexes[(unsigned short)LittleShort(mld->v1)];
       ld->v2 = &vertexes[(unsigned short)LittleShort(mld->v2)];
       ld->sidenum[0] = LittleShort(mld->sidenum[0]);
@@ -2139,11 +2139,11 @@ static void P_LoadLineDefs (int lump)
       ld->flags = (unsigned short)LittleShort(mld->flags);
       ld->special = LittleShort(mld->special);
       ld->tag = LittleShort(mld->tag);
-      ld->args[0] = 0;
-      ld->args[1] = 0;
-      ld->args[2] = 0;
-      ld->args[3] = 0;
-      ld->args[4] = 0;
+      ld->special_args[0] = 0;
+      ld->special_args[1] = 0;
+      ld->special_args[2] = 0;
+      ld->special_args[3] = 0;
+      ld->special_args[4] = 0;
       ld->v1 = &vertexes[(unsigned short)LittleShort(mld->v1)];
       ld->v2 = &vertexes[(unsigned short)LittleShort(mld->v2)];
       ld->sidenum[0] = LittleShort(mld->sidenum[0]);
@@ -2178,11 +2178,11 @@ static void P_LoadUDMFLineDefs(int lump)
     ld->flags = (mld->flags & ML_BOOM);
     ld->special = mld->special;
     ld->tag = (mld->id >= 0 ? mld->id : 0);
-    ld->args[0] = mld->arg0;
-    ld->args[1] = mld->arg1;
-    ld->args[2] = mld->arg2;
-    ld->args[3] = mld->arg3;
-    ld->args[4] = mld->arg4;
+    ld->special_args[0] = mld->arg0;
+    ld->special_args[1] = mld->arg1;
+    ld->special_args[2] = mld->arg2;
+    ld->special_args[3] = mld->arg3;
+    ld->special_args[4] = mld->arg4;
     ld->v1 = &vertexes[mld->v1];
     ld->v2 = &vertexes[mld->v2];
     ld->sidenum[0] = mld->sidefront;
@@ -2379,13 +2379,13 @@ void P_PostProcessZDoomLineSpecial(line_t *ld)
       else
         tranmap = W_LumpByNum(lump - 1);
 
-      if (!ld->args[0])
+      if (!ld->special_args[0])
       {
         ld->tranmap = tranmap;
         ld->alpha = 0.66f;
       }
       else
-        for (id_p = dsda_FindLinesFromID(ld->args[0]); *id_p >= 0; id_p++)
+        for (id_p = dsda_FindLinesFromID(ld->special_args[0]); *id_p >= 0; id_p++)
         {
           lines[*id_p].tranmap = tranmap;
           lines[*id_p].alpha = 0.66f;

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -5922,7 +5922,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
       break;
     case zl_generic_door:
       {
-        byte tag, lightTag;
+        int tag, lightTag;
         vldoor_e type;
         dboolean boomgen = false;
 
@@ -7388,7 +7388,24 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
     case zl_damage_thing:
       if (mo)
       {
-        P_DamageMobj(mo, NULL, NULL, args[0] ? args[0] : 10000);
+        if (args[0] < 0)
+        {
+          // TODO: negative damage heals
+          // if (it->player)
+          // {
+          //   P_GiveBody (it, -arg0);
+          // }
+          // else
+          // {
+          //   it->health -= arg0;
+          //   if (it->SpawnHealth() < it->health)
+          //     it->health = it->SpawnHealth();
+          // }
+        }
+        else
+        {
+          P_DamageMobj(mo, NULL, NULL, args[0] ? args[0] : 10000);
+        }
         buttonSuccess = 1;
       }
       break;
@@ -7401,7 +7418,28 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
         while ((target = dsda_FindMobjFromThingIDOrMobj(args[0], mo, &search)))
         {
           if (target->flags & MF_SHOOTABLE)
-            P_DamageMobj(target, NULL, mo, args[1]);
+          {
+            if (args[1] > 0)
+            {
+              P_DamageMobj(target, NULL, mo, args[1]);
+            }
+            else
+            {
+              // TODO: negative damage heals
+              // if (actor->health < actor->SpawnHealth())
+              // {
+              //   actor->health -= amount;
+              //   if (actor->health > actor->SpawnHealth())
+              //   {
+              //     actor->health = actor->SpawnHealth();
+              //   }
+              //   if (actor->player != NULL)
+              //   {
+              //     actor->player->health = actor->health;
+              //   }
+              // }
+            }
+          }
         }
       }
       buttonSuccess = 1;

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -3447,11 +3447,11 @@ void P_SpawnZDoomSectorSpecial(sector_t *sector, int i)
 
 static void P_TransferLineArgs(line_t *l, byte *args)
 {
-  args[0] = l->args[0];
-  args[1] = l->args[1];
-  args[2] = l->args[2];
-  args[3] = l->args[3];
-  args[4] = l->args[4];
+  args[0] = l->special_args[0];
+  args[1] = l->special_args[1];
+  args[2] = l->special_args[2];
+  args[3] = l->special_args[3];
+  args[4] = l->special_args[4];
 }
 
 static void P_SpawnVanillaExtras(void)
@@ -3532,7 +3532,7 @@ void P_SpawnZDoomExtra(line_t *l, int i)
     // support for drawn heights coming from different sector
     case zl_transfer_heights:
       sec = sides[*l->sidenum].sector->iSectorID;
-      FIND_SECTORS(id_p, l->args[0])
+      FIND_SECTORS(id_p, l->special_args[0])
         sectors[*id_p].heightsec = sec;
       break;
 
@@ -3540,7 +3540,7 @@ void P_SpawnZDoomExtra(line_t *l, int i)
     // floor lighting independently (e.g. lava)
     case zl_transfer_floor_light:
       sec = sides[*l->sidenum].sector->iSectorID;
-      FIND_SECTORS(id_p, l->args[0])
+      FIND_SECTORS(id_p, l->special_args[0])
         sectors[*id_p].floorlightsec = sec;
       break;
 
@@ -3548,24 +3548,24 @@ void P_SpawnZDoomExtra(line_t *l, int i)
     // ceiling lighting independently
     case zl_transfer_ceiling_light:
       sec = sides[*l->sidenum].sector->iSectorID;
-      FIND_SECTORS(id_p, l->args[0])
+      FIND_SECTORS(id_p, l->special_args[0])
         sectors[*id_p].ceilinglightsec = sec;
       break;
 
     // [Graf Zahl] Add support for setting lighting
     // per wall independently
     case zl_transfer_wall_light:
-      // new DWallLightTransfer (lines[i].frontsector, lines[i].args[0], lines[i].args[1]);
+      // new DWallLightTransfer (lines[i].frontsector, lines[i].special_args[0], lines[i].special_args[1]);
       break;
 
     case zl_sector_attach_3d_midtex:
-      // P_Attach3dMidtexLinesToSector(lines[i].frontsector, lines[i].args[0], lines[i].args[1], !!lines[i].args[2]);
+      // P_Attach3dMidtexLinesToSector(lines[i].frontsector, lines[i].special_args[0], lines[i].special_args[1], !!lines[i].special_args[2]);
       break;
 
     case zl_sector_set_link:
-      // if (lines[i].args[0] == 0)
+      // if (lines[i].special_args[0] == 0)
       // {
-      //   P_AddSectorLinks(lines[i].frontsector, lines[i].args[1], lines[i].args[2], lines[i].args[3]);
+      //   P_AddSectorLinks(lines[i].frontsector, lines[i].special_args[1], lines[i].special_args[2], lines[i].special_args[3]);
       // }
       break;
 
@@ -3583,15 +3583,15 @@ void P_SpawnZDoomExtra(line_t *l, int i)
       // arg 2 = 0:floor, 1:ceiling, 2:both
       // arg 3 = 0: anchor, 1: reference line
       // arg 4 = for the anchor only: alpha
-      // if ((lines[i].args[1] == 0 || lines[i].args[1] == 6) && lines[i].args[3] == 0)
+      // if ((lines[i].special_args[1] == 0 || lines[i].special_args[1] == 6) && lines[i].special_args[3] == 0)
       // {
-      //   P_SpawnPortal(&lines[i], lines[i].args[0], lines[i].args[2], lines[i].args[4], lines[i].args[1]);
+      //   P_SpawnPortal(&lines[i], lines[i].special_args[0], lines[i].special_args[2], lines[i].special_args[4], lines[i].special_args[1]);
       // }
-      // else if (lines[i].args[1] == 3 || lines[i].args[1] == 4)
+      // else if (lines[i].special_args[1] == 3 || lines[i].special_args[1] == 4)
       // {
       //   line_t *line = &lines[i];
-      //   unsigned pnum = P_GetPortal(line->args[1] == 3 ? PORTS_PLANE : PORTS_HORIZON, line->args[2], line->frontsector, NULL, { 0,0 });
-      //   CopyPortal(line->args[0], line->args[2], pnum, 0, true);
+      //   unsigned pnum = P_GetPortal(line->special_args[1] == 3 ? PORTS_PLANE : PORTS_HORIZON, line->special_args[2], line->frontsector, NULL, { 0,0 });
+      //   CopyPortal(line->special_args[0], line->special_args[2], pnum, 0, true);
       // }
       break;
 
@@ -3601,13 +3601,13 @@ void P_SpawnZDoomExtra(line_t *l, int i)
 
     // [RH] ZDoom Static_Init settings
     case zl_static_init:
-      switch (l->args[1])
+      switch (l->special_args[1])
       {
         case zi_init_gravity:
         {
           fixed_t grav = FixedDiv(P_AproxDistance(l->dx, l->dy), 100 * FRACUNIT);
           sec = sides[*l->sidenum].sector->iSectorID;
-          FIND_SECTORS(id_p, l->args[0])
+          FIND_SECTORS(id_p, l->special_args[0])
             sectors[*id_p].gravity = grav;
         }
         break;
@@ -3636,7 +3636,7 @@ void P_SpawnZDoomExtra(line_t *l, int i)
           }
 
           sec = sides[*l->sidenum].sector->iSectorID;
-          FIND_SECTORS(id_p, l->args[0])
+          FIND_SECTORS(id_p, l->special_args[0])
           {
             sectors[*id_p].damage = damage;
             sectors[*id_p].flags |= flags;
@@ -3645,8 +3645,8 @@ void P_SpawnZDoomExtra(line_t *l, int i)
         break;
 
         case zi_init_sector_link:
-          // if (lines[i].args[3] == 0)
-          //   P_AddSectorLinksByID(lines[i].frontsector, lines[i].args[0], lines[i].args[2]);
+          // if (lines[i].special_args[3] == 0)
+          //   P_AddSectorLinksByID(lines[i].frontsector, lines[i].special_args[0], lines[i].special_args[2]);
           break;
 
         // killough 10/98:
@@ -3658,7 +3658,7 @@ void P_SpawnZDoomExtra(line_t *l, int i)
         // linedef). Still requires user to use F_SKY1 for the floor
         // or ceiling texture, to distinguish floor and ceiling sky.
         case zi_init_transfer_sky:
-          FIND_SECTORS(id_p, l->args[0])
+          FIND_SECTORS(id_p, l->special_args[0])
             sectors[*id_p].sky = i | PL_SKYFLAT;
           break;
       }
@@ -4009,7 +4009,7 @@ static void P_InitCopyScrollers(void)
     {
       // don't allow copying the scroller if the sector has the same tag
       //   as it would just duplicate it.
-      if (l->frontsector->tag == l->args[0])
+      if (l->frontsector->tag == l->special_args[0])
         P_AddCopyScroller(l);
 
       l->special = 0;
@@ -4037,16 +4037,16 @@ void P_SpawnZDoomScroller(line_t *l, int i)
       special == zl_scroll_floor   ||
       special == zl_scroll_texture_model)
   {
-    if (l->args[1] & 3)
+    if (l->special_args[1] & 3)
     {
       // if 1, then displacement
       // if 2, then accelerative (also if 3)
       control = sides[*l->sidenum].sector->iSectorID;
-      if (l->args[1] & 2)
+      if (l->special_args[1] & 2)
         accel = 1;
     }
 
-    if (special == zl_scroll_texture_model || l->args[1] & 4)
+    if (special == zl_scroll_texture_model || l->special_args[1] & 4)
     {
       // The line housing the special controls the
       // direction and speed of scrolling.
@@ -4056,8 +4056,8 @@ void P_SpawnZDoomScroller(line_t *l, int i)
     else
     {
       // The speed and direction are parameters to the special.
-      dx = (fixed_t) (l->args[3] - 128) * FRACUNIT / 32;
-      dy = (fixed_t) (l->args[4] - 128) * FRACUNIT / 32;
+      dx = (fixed_t) (l->special_args[3] - 128) * FRACUNIT / 32;
+      dy = (fixed_t) (l->special_args[4] - 128) * FRACUNIT / 32;
     }
   }
 
@@ -4067,46 +4067,46 @@ void P_SpawnZDoomScroller(line_t *l, int i)
     const int *id_p;
 
     case zl_scroll_ceiling:
-      FIND_SECTORS(id_p, l->args[0])
+      FIND_SECTORS(id_p, l->special_args[0])
         Add_Scroller(sc_ceiling, -dx, dy, control, *id_p, accel);
 
       for (j = 0; j < copyscroller_count; ++j)
       {
         line_t *cs = copyscrollers[j];
 
-        if (cs->args[0] == l->args[0] && cs->args[1] & 1)
+        if (cs->special_args[0] == l->special_args[0] && cs->special_args[1] & 1)
           Add_Scroller(sc_ceiling, -dx, dy, control, cs->frontsector->iSectorID, accel);
       }
 
       l->special = 0;
       break;
     case zl_scroll_floor:
-      if (l->args[2] != 1)
+      if (l->special_args[2] != 1)
       { // scroll the floor texture
-        FIND_SECTORS(id_p, l->args[0])
+        FIND_SECTORS(id_p, l->special_args[0])
           Add_Scroller(sc_floor, -dx, dy, control, *id_p, accel);
 
         for (j = 0; j < copyscroller_count; ++j)
         {
           line_t *cs = copyscrollers[j];
 
-          if (cs->args[0] == l->args[0] && cs->args[1] & 2)
+          if (cs->special_args[0] == l->special_args[0] && cs->special_args[1] & 2)
             Add_Scroller(sc_floor, -dx, dy, control, cs->frontsector->iSectorID, accel);
         }
       }
 
-      if (l->args[2] > 0)
+      if (l->special_args[2] > 0)
       { // carry objects on the floor
         dx = FixedMul(dx, CARRYFACTOR);
         dy = FixedMul(dy, CARRYFACTOR);
-        FIND_SECTORS(id_p, l->args[0])
+        FIND_SECTORS(id_p, l->special_args[0])
           Add_Scroller(sc_carry, dx, dy, control, *id_p, accel);
 
         for (j = 0; j < copyscroller_count; ++j)
         {
           line_t *cs = copyscrollers[j];
 
-          if (cs->args[0] == l->args[0] && cs->args[1] & 4)
+          if (cs->special_args[0] == l->special_args[0] && cs->special_args[1] & 4)
             Add_Scroller(sc_carry, dx, dy, control, cs->frontsector->iSectorID, accel);
         }
       }
@@ -4116,7 +4116,7 @@ void P_SpawnZDoomScroller(line_t *l, int i)
     case zl_scroll_texture_model:
       // killough 3/1/98: scroll wall according to linedef
       // (same direction and speed as scrolling floors)
-      for (id_p = dsda_FindLinesFromID(l->args[0]); *id_p >= 0; id_p++)
+      for (id_p = dsda_FindLinesFromID(l->special_args[0]); *id_p >= 0; id_p++)
         if (*id_p != i)
           Add_WallScroller(dx, dy, lines + *id_p, control, accel);
 
@@ -4124,37 +4124,37 @@ void P_SpawnZDoomScroller(line_t *l, int i)
       break;
     case zl_scroll_texture_offsets:
       // killough 3/2/98: scroll according to sidedef offsets
-      // MAP_FORMAT_TODO: l->args[0] SCROLLTYPE
+      // MAP_FORMAT_TODO: l->special_args[0] SCROLLTYPE
       j = lines[i].sidenum[0];
       Add_Scroller(sc_side, -sides[j].textureoffset, sides[j].rowoffset, -1, j, accel);
       l->special = 0;
       break;
     case zl_scroll_texture_left:
       j = lines[i].sidenum[0];
-      // MAP_FORMAT_TODO: l->args[1] SCROLLTYPE
-      Add_Scroller(sc_side, l->args[0] / 64, 0, -1, j, accel);
+      // MAP_FORMAT_TODO: l->special_args[1] SCROLLTYPE
+      Add_Scroller(sc_side, l->special_args[0] / 64, 0, -1, j, accel);
       break;
     case zl_scroll_texture_right:
       j = lines[i].sidenum[0];
-      // MAP_FORMAT_TODO: l->args[1] SCROLLTYPE
-      Add_Scroller(sc_side, -l->args[0] / 64, 0, -1, j, accel);
+      // MAP_FORMAT_TODO: l->special_args[1] SCROLLTYPE
+      Add_Scroller(sc_side, -l->special_args[0] / 64, 0, -1, j, accel);
       break;
     case zl_scroll_texture_up:
       j = lines[i].sidenum[0];
-      // MAP_FORMAT_TODO: l->args[1] SCROLLTYPE
-      Add_Scroller(sc_side, 0, l->args[0] / 64, -1, j, accel);
+      // MAP_FORMAT_TODO: l->special_args[1] SCROLLTYPE
+      Add_Scroller(sc_side, 0, l->special_args[0] / 64, -1, j, accel);
       break;
     case zl_scroll_texture_down:
       j = lines[i].sidenum[0];
-      // MAP_FORMAT_TODO: l->args[1] SCROLLTYPE
-      Add_Scroller(sc_side, 0, -l->args[0] / 64, -1, j, accel);
+      // MAP_FORMAT_TODO: l->special_args[1] SCROLLTYPE
+      Add_Scroller(sc_side, 0, -l->special_args[0] / 64, -1, j, accel);
       break;
     case zl_scroll_texture_both:
       j = lines[i].sidenum[0];
 
-      if (l->args[0] == 0) {
-        dx = (l->args[1] - l->args[2]) / 64;
-        dy = (l->args[4] - l->args[3]) / 64;
+      if (l->special_args[0] == 0) {
+        dx = (l->special_args[1] - l->special_args[2]) / 64;
+        dy = (l->special_args[4] - l->special_args[3]) / 64;
         Add_Scroller(sc_side, dx, dy, -1, j, accel);
       }
 
@@ -4371,12 +4371,12 @@ void P_SpawnZDoomFriction(line_t *l)
   {
     int value;
 
-    if (l->args[1])
-      value = l->args[1] <= 200 ? l->args[1] : 200;
+    if (l->special_args[1])
+      value = l->special_args[1] <= 200 ? l->special_args[1] : 200;
     else
       value = P_AproxDistance(l->dx, l->dy) >> FRACBITS;
 
-    P_ApplySectorFriction(l->args[0], value, false);
+    P_ApplySectorFriction(l->special_args[0], value, false);
 
     l->special = 0;
   }
@@ -4715,7 +4715,7 @@ void P_SpawnCompatiblePusher(line_t *l)
 
 static void CalculatePushVector(line_t *l, int magnitude, int angle, fixed_t *dx, fixed_t *dy)
 {
-  if (l->args[3])
+  if (l->special_args[3])
   {
     *dx = l->dx;
     *dy = l->dy;
@@ -4739,28 +4739,28 @@ void P_SpawnZDoomPusher(line_t *l)
   switch (l->special)
   {
     case zl_sector_set_wind: // wind
-      CalculatePushVector(l, l->args[1], l->args[2], &dx, &dy);
-      FIND_SECTORS(id_p, l->args[0])
+      CalculatePushVector(l, l->special_args[1], l->special_args[2], &dx, &dy);
+      FIND_SECTORS(id_p, l->special_args[0])
         Add_Pusher(p_wind, dx, dy, NULL, *id_p);
       l->special = 0;
       break;
     case zl_sector_set_current: // current
-      CalculatePushVector(l, l->args[1], l->args[2], &dx, &dy);
-      FIND_SECTORS(id_p, l->args[0])
+      CalculatePushVector(l, l->special_args[1], l->special_args[2], &dx, &dy);
+      FIND_SECTORS(id_p, l->special_args[0])
         Add_Pusher(p_current, dx, dy, NULL, *id_p);
       l->special = 0;
       break;
     case zl_point_push_set_force: // push/pull
-      CalculatePushVector(l, l->args[2], 0, &dx, &dy);
-      if (l->args[0])
+      CalculatePushVector(l, l->special_args[2], 0, &dx, &dy);
+      if (l->special_args[0])
       {  // [RH] Find thing by sector
-        FIND_SECTORS(id_p, l->args[0])
+        FIND_SECTORS(id_p, l->special_args[0])
         {
           thing = P_GetPushThing(*id_p);
           if (thing) // No MT_P* means no effect
           {
             // [RH] Allow narrowing it down by tid
-            if (!l->args[1] || l->args[1] == thing->tid)
+            if (!l->special_args[1] || l->special_args[1] == thing->tid)
               Add_Pusher(p_push, dx, dy, thing, *id_p);
           }
         }
@@ -4769,7 +4769,7 @@ void P_SpawnZDoomPusher(line_t *l)
       {  // [RH] Find thing by tid
         int s;
 
-        for (s = -1; (thing = P_FindMobjFromTID(l->args[1], &s)) != NULL;)
+        for (s = -1; (thing = P_FindMobjFromTID(l->special_args[1], &s)) != NULL;)
           if (thing->type == map_format.mt_push || thing->type == map_format.mt_pull)
             Add_Pusher(p_push, dx, dy, thing, thing->subsector->sector->iSectorID);
       }
@@ -5547,7 +5547,7 @@ dboolean EV_LineSearchForPuzzleItem(line_t * line, byte * args, mobj_t * mo)
         type = arti - hexen_arti_firstpuzzitem;
         if (type < 0)
             continue;
-        if (type == line->args[0])
+        if (type == line->special_args[0])
         {
             // A puzzle item was found for the line
             if (P_UseArtifact(player, arti))
@@ -5658,7 +5658,7 @@ dboolean P_TestActivateZDoomLine(line_t *line, mobj_t *mo, int side, line_activa
         switch (line->special)
         {
           case zl_door_raise:
-            if (line->args[0] == 0 && line->args[1] < 64)
+            if (line->special_args[0] == 0 && line->special_args[1] < 64)
               noway = false;
             break;
           case zl_teleport:
@@ -5673,7 +5673,7 @@ dboolean P_TestActivateZDoomLine(line_t *line, mobj_t *mo, int side, line_activa
           switch (line->special)
           {
             case zl_door_raise:
-              if (line->args[1] >= 64)
+              if (line->special_args[1] >= 64)
                 break;
             case zl_teleport:
             case zl_teleport_no_fog:
@@ -6464,7 +6464,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, byte * args, line_t * line, int 
             line->flags & ML_REPEATSPECIAL &&
             line->special == zl_generic_stairs)
         {
-          line->args[3] ^= 1;
+          line->special_args[3] ^= 1;
         }
       }
       break;
@@ -7108,9 +7108,9 @@ dboolean P_ExecuteZDoomLineSpecial(int special, byte * args, line_t * line, int 
         while ((target = dsda_FindMobjFromThingIDOrMobj(args[0], mo, &search)))
         {
           target->special = args[1];
-          target->args[0] = args[2];
-          target->args[1] = args[3];
-          target->args[2] = args[4];
+          target->special_args[0] = args[2];
+          target->special_args[1] = args[3];
+          target->special_args[2] = args[4];
         }
       }
       buttonSuccess = 1;
@@ -7828,7 +7828,7 @@ static void Hexen_P_SpawnSpecials(void)
                 numlinespecials++;
                 break;
             case 121:          // Line_SetIdentification
-                if (lines[i].args[0])
+                if (lines[i].special_args[0])
                 {
                     if (TaggedLineCount == MAX_TAGGED_LINES)
                     {
@@ -7836,7 +7836,7 @@ static void Hexen_P_SpawnSpecials(void)
                                 "(%d) exceeded.", MAX_TAGGED_LINES);
                     }
                     TaggedLines[TaggedLineCount].line = &lines[i];
-                    TaggedLines[TaggedLineCount++].lineTag = lines[i].args[0];
+                    TaggedLines[TaggedLineCount++].lineTag = lines[i].special_args[0];
                 }
                 lines[i].special = 0;
                 break;

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -3445,15 +3445,6 @@ void P_SpawnZDoomSectorSpecial(sector_t *sector, int i)
   }
 }
 
-static void P_TransferLineArgs(line_t *l, byte *args)
-{
-  args[0] = l->special_args[0];
-  args[1] = l->special_args[1];
-  args[2] = l->special_args[2];
-  args[3] = l->special_args[3];
-  args[4] = l->special_args[4];
-}
-
 static void P_SpawnVanillaExtras(void)
 {
   int i;
@@ -5731,7 +5722,6 @@ dboolean P_TestActivateHexenLine(line_t *line, mobj_t *mo, int side, line_activa
 
 dboolean P_ActivateLine(line_t * line, mobj_t * mo, int side, line_activation_t activationType)
 {
-  byte args[5];
   dboolean repeat;
   dboolean buttonSuccess;
 
@@ -5747,9 +5737,8 @@ dboolean P_ActivateLine(line_t * line, mobj_t * mo, int side, line_activation_t 
 
   repeat = (line->flags & ML_REPEATSPECIAL) != 0;
 
-  P_TransferLineArgs(line, args);
-
-  buttonSuccess = map_format.execute_line_special(line->special, args, line, side, mo);
+  buttonSuccess =
+    map_format.execute_line_special(line->special, line->special_args, line, side, mo);
 
   if (!repeat && buttonSuccess)
   {                           // clear the special on non-retriggerable lines
@@ -5897,9 +5886,12 @@ static angle_t P_ArgToAngle(angle_t arg)
   return arg * (ANG180 / 128);
 }
 
-dboolean P_ExecuteZDoomLineSpecial(int special, byte * args, line_t * line, int side, mobj_t * mo)
+dboolean P_ExecuteZDoomLineSpecial(int special, int * special_args, line_t * line, int side, mobj_t * mo)
 {
+  byte args[5];
   dboolean buttonSuccess = false;
+
+  COLLAPSE_SPECIAL_ARGS(args, special_args);
 
   switch (special)
   {
@@ -7463,11 +7455,13 @@ dboolean P_ExecuteZDoomLineSpecial(int special, byte * args, line_t * line, int 
   return buttonSuccess;
 }
 
-dboolean P_ExecuteHexenLineSpecial(int special, byte * args, line_t * line, int side, mobj_t * mo)
+dboolean P_ExecuteHexenLineSpecial(int special, int * special_args, line_t * line, int side, mobj_t * mo)
 {
-    dboolean buttonSuccess;
+    byte args[5];
+    dboolean buttonSuccess = false;
 
-    buttonSuccess = false;
+    COLLAPSE_SPECIAL_ARGS(args, special_args);
+
     switch (special)
     {
         case 1:                // Poly Start Line

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -1646,13 +1646,13 @@ void P_AddMobjSecret(mobj_t *mobj);
 void P_PlayerCollectSecret(player_t *player);
 dboolean P_CheckKeys(mobj_t *mo, zdoom_lock_t lock, dboolean legacy);
 dboolean P_CheckSwitchRange(line_t *line, mobj_t *mo, int sideno);
-int EV_DoZDoomDoor(vldoor_e type, line_t *line, mobj_t *mo, byte tag, byte speed_byte, int topwait,
-                   zdoom_lock_t lock, byte lightTag, dboolean boomgen, int topcountdown);
-int EV_DoZDoomFloor(floor_e floortype, line_t *line, byte tag, fixed_t speed, fixed_t height,
+int EV_DoZDoomDoor(vldoor_e type, line_t *line, mobj_t *mo, int tag, fixed_t speed, int topwait,
+                   zdoom_lock_t lock, int lightTag, dboolean boomgen, int topcountdown);
+int EV_DoZDoomFloor(floor_e floortype, line_t *line, int tag, fixed_t speed, fixed_t height,
                    int crush, int change, dboolean hexencrush, dboolean hereticlower);
 int EV_ZDoomFloorCrushStop(int tag);
 int EV_DoZDoomDonut(int tag, line_t *line, fixed_t pillarspeed, fixed_t slimespeed);
-int EV_DoZDoomCeiling(ceiling_e type, line_t *line, byte tag, fixed_t speed, fixed_t speed2,
+int EV_DoZDoomCeiling(ceiling_e type, line_t *line, int tag, fixed_t speed, fixed_t speed2,
                       fixed_t height, int crush, byte silent, int change, crushmode_e crushmode);
 int EV_ZDoomCeilingCrushStop(int tag, dboolean remove);
 int EV_DoZDoomPlat(int tag, line_t *line, plattype_e type, fixed_t height,
@@ -1669,9 +1669,9 @@ void EV_LightChange(int tag, short change);
 void EV_LightSet(int tag, short level);
 void EV_LightSetMinNeighbor(int tag);
 void EV_LightSetMaxNeighbor(int tag);
-void EV_StartLightFading(int tag, byte level, byte tics);
-void EV_StartLightGlowing(int tag, byte upper, byte lower, byte tics);
-void EV_StartLightFlickering(int tag, byte upper, byte lower);
+void EV_StartLightFading(int tag, short level, short tics);
+void EV_StartLightGlowing(int tag, short upper, short lower, short tics);
+void EV_StartLightFlickering(int tag, short upper, short lower);
 void EV_StartZDoomLightStrobing(int tag, int upper, int lower, int brighttime, int darktime);
 void EV_StartZDoomLightStrobingDoom(int tag, int brighttime, int darktime);
 void EV_StopLightEffect(int tag);

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -1945,7 +1945,7 @@ void P_TeleportOther(mobj_t * victim)
         if (victim->flags & MF_COUNTKILL && victim->special)
         {
             map_format.remove_mobj_thing_id(victim);
-            map_format.execute_line_special(victim->special, victim->args, NULL, 0, victim);
+            map_format.execute_line_special(victim->special, victim->special_args, NULL, 0, victim);
             victim->special = 0;
         }
 

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -339,7 +339,7 @@ typedef struct line_s
   byte player_activations;
 
   // hexen
-  byte args[5];
+  byte special_args[5];
 
   // zdoom
   line_activation_t activation;

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -339,11 +339,7 @@ typedef struct line_s
   byte player_activations;
 
   // hexen
-  byte arg1;
-  byte arg2;
-  byte arg3;
-  byte arg4;
-  byte arg5;
+  byte args[5];
 
   // zdoom
   line_activation_t activation;

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -339,7 +339,7 @@ typedef struct line_s
   byte player_activations;
 
   // hexen
-  byte special_args[5];
+  int special_args[5];
 
   // zdoom
   line_activation_t activation;
@@ -352,6 +352,12 @@ typedef struct line_s
 } line_t;
 
 #define LINE_ARG_COUNT 5
+#define SPECIAL_ARGS_SIZE (5 * sizeof(int))
+#define COLLAPSE_SPECIAL_ARGS(dest, source) { dest[0] = source[0]; \
+                                              dest[1] = source[1]; \
+                                              dest[2] = source[2]; \
+                                              dest[3] = source[3]; \
+                                              dest[4] = source[4]; }
 
 // phares 3/14/98
 //


### PR DESCRIPTION
This PR migrates from byte arguments to integer arguments for thing and line specials. It also renames `args` to `special_args` and uses arrays in all structs for consistency and sanity.

While that may seem like a simple task, hexen has some assumptions about argument size:
- Using `memcpy` with a specific size
- Storing integers decomposed into the byte array
- Using byte overflow for looping counters

Hopefully all these cases have been addressed - at least all hexen demos are in sync.
There are some leftover tasks to support negative values for a few zdoom specials, but otherwise the handling is migrated.