### PR TITLE
Grid layout for `weapon_text` HUD component

### DIFF
--- a/docs/hud.md
+++ b/docs/hud.md
@@ -47,7 +47,8 @@ You can find the current default configuration [here](../prboom2/data/lumps/dsda
 - `composite_time`: shows the current level time and the total time
 - `keys`: shows the acquired keys
 - `ammo_text`: shows the weapons and ammo as the status bar does
-- `weapon_text`: shows the acquired weapons (color-coded for berserk)
+- `weapon_text`: shows the acquired weapons (color-coded for berserk). Pass `1`
+  as an argument to use a 3x3 grid layout
 - `ready_ammo_text`: shows the ammo for the current weapon
 - `big_ammo`: shows the ammo for the current weapon in the status bar font
 - `armor_text`: shows the player armor (color-coded)

--- a/docs/hud.md
+++ b/docs/hud.md
@@ -47,8 +47,9 @@ You can find the current default configuration [here](../prboom2/data/lumps/dsda
 - `composite_time`: shows the current level time and the total time
 - `keys`: shows the acquired keys
 - `ammo_text`: shows the weapons and ammo as the status bar does
-- `weapon_text`: shows the acquired weapons (color-coded for berserk). Pass `1`
-  as an argument to use a 3x3 grid layout
+- `weapon_text`: shows the acquired weapons (color-coded for berserk).
+  - Supports 1 argument: `grid`
+  - `grid`: displays the weapons in a 3x3 grid rather than horizontally
 - `ready_ammo_text`: shows the ammo for the current weapon
 - `big_ammo`: shows the ammo for the current weapon in the status bar font
 - `armor_text`: shows the player armor (color-coded)

--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -20,32 +20,58 @@
 #include "weapon_text.h"
 
 static dsda_text_t component;
+static dboolean grid;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   player_t* player;
 
   player = &players[displayplayer];
 
-  snprintf(
-    str,
-    max_size,
-    "WPN \x1b%c%c\x1b%c %c %c %c %c %c %c %c %c",
-    player->powers[pw_strength] ? HUlib_Color(CR_BLUE) : HUlib_Color(CR_GREEN),
-    player->weaponowned[0] ? '1' : ' ',
-    HUlib_Color(CR_GREEN),
-    player->weaponowned[1] ? '2' : ' ',
-    player->weaponowned[2] ? '3' : ' ',
-    player->weaponowned[3] ? '4' : ' ',
-    player->weaponowned[4] ? '5' : ' ',
-    player->weaponowned[5] ? '6' : ' ',
-    player->weaponowned[6] ? '7' : ' ',
-    player->weaponowned[7] ? '8' : ' ',
-    player->weaponowned[8] ? '9' : ' '
-  );
+  if (grid)
+    snprintf(
+      str,
+      max_size,
+      "W \x1b%c%c\x1b%c %c %c\n"
+      "\x1b%cP\x1b%c %c %c %c\n"
+      "\x1b%cN\x1b%c %c %c %c",
+      player->powers[pw_strength] ? HUlib_Color(CR_BLUE) : HUlib_Color(CR_GREEN),
+      player->weaponowned[0] ? '1' : ' ',
+      HUlib_Color(CR_GREEN),
+      player->weaponowned[1] ? '2' : ' ',
+      player->weaponowned[2] ? '3' : ' ',
+      HUlib_Color(CR_WHITE),
+      HUlib_Color(CR_GREEN),
+      player->weaponowned[3] ? '4' : ' ',
+      player->weaponowned[4] ? '5' : ' ',
+      player->weaponowned[5] ? '6' : ' ',
+      HUlib_Color(CR_WHITE),
+      HUlib_Color(CR_GREEN),
+      player->weaponowned[6] ? '7' : ' ',
+      player->weaponowned[7] ? '8' : ' ',
+      player->weaponowned[8] ? '9' : ' '
+    );
+  else
+    snprintf(
+      str,
+      max_size,
+      "WPN \x1b%c%c\x1b%c %c %c %c %c %c %c %c %c",
+      player->powers[pw_strength] ? HUlib_Color(CR_BLUE) : HUlib_Color(CR_GREEN),
+      player->weaponowned[0] ? '1' : ' ',
+      HUlib_Color(CR_GREEN),
+      player->weaponowned[1] ? '2' : ' ',
+      player->weaponowned[2] ? '3' : ' ',
+      player->weaponowned[3] ? '4' : ' ',
+      player->weaponowned[4] ? '5' : ' ',
+      player->weaponowned[5] ? '6' : ' ',
+      player->weaponowned[6] ? '7' : ' ',
+      player->weaponowned[7] ? '8' : ' ',
+      player->weaponowned[8] ? '9' : ' '
+    );
 }
 
 void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  grid = args[0];
 }
 
 void dsda_UpdateWeaponTextHC(void) {

--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -70,8 +70,8 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
   grid = args[0];
+  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateWeaponTextHC(void) {


### PR DESCRIPTION
I found this easier to fit into my custom HUD layout.  Image attached.  Not sure if you'll like it or if you already have other plans for the HUD.

![grid](https://user-images.githubusercontent.com/2101303/219910015-a4ead760-b033-458a-aeb5-e1dfcce2d508.png)

 The first commit fixes a bug with rendering multi-line text.