### PR TITLE
automap: fix clipping of textures/things in GL

### DIFF
--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -97,6 +97,14 @@ void dsda_GLSetRenderSceneScissor() {
             gl_scene_width, gl_scene_height);
 }
 
+void dsda_GLSetScreenSpaceScissor(int x, int y, int w, int h)
+{
+  glScissor(gl_viewport_x + x * gl_scale_x,
+            gl_viewport_y + (SCREENHEIGHT - (y + h)) * gl_scale_y,
+            w * gl_scale_x,
+            h * gl_scale_y);
+}
+
 void dsda_GLUpdateStatusBarVisible() {
   int saved_visible;
   int current_visible;

--- a/prboom2/src/dsda/gl/render_scale.h
+++ b/prboom2/src/dsda/gl/render_scale.h
@@ -36,6 +36,7 @@ void dsda_GLSetRenderViewportParams(void);
 void dsda_GLSetRenderViewport(void);
 void dsda_GLSetRenderViewportScissor(void);
 void dsda_GLSetRenderSceneScissor(void);
+void dsda_GLSetScreenSpaceScissor(int x, int y, int w, int h);
 void dsda_GLUpdateStatusBarVisible(void);
 void dsda_GLLetterboxClear(void);
 void dsda_GLStartMeltRenderTexture(void);

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -464,7 +464,7 @@ void gld_MapDrawSubsectors(player_t *plr, int fx, int fy, fixed_t mx, fixed_t my
 
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
-  glScissor(fx, SCREENHEIGHT - (fy + fh), fw, fh);
+  dsda_GLSetScreenSpaceScissor(fx, fy, fw, fh);
   glEnable(GL_SCISSOR_TEST);
 
   if (automap_rotate)

--- a/prboom2/src/gl_map.c
+++ b/prboom2/src/gl_map.c
@@ -44,6 +44,7 @@
 #include "m_misc.h"
 #include "am_map.h"
 #include "lprintf.h"
+#include "dsda/gl/render_scale.h"
 
 am_icon_t am_icons[am_icon_count + 1] =
 {
@@ -156,7 +157,7 @@ void gld_DrawNiceThings(int fx, int fy, int fw, int fh)
   int i;
   int j;
 
-  glScissor(fx, SCREENHEIGHT - (fy + fh), fw, fh);
+  dsda_GLSetScreenSpaceScissor(fx, fy, fw, fh);
   glEnable(GL_SCISSOR_TEST);
 
   glDisable(GL_ALPHA_TEST);


### PR DESCRIPTION
glScissor uses window coordinates, so the dsda render scale and viewport have to be taken into account.

Closes #193