### PR TITLE
Blood: The Bleedening

### DIFF
--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -58,6 +58,12 @@ typedef enum
   gl_lightmode_last
 } gl_lightmode_t;
 
+enum bleedtype {
+  BLEED_NONE = 0x0,
+  BLEED_CEILING = 0x1,
+  BLEED_OCCLUDE = 0x2
+};
+
 extern int gl_drawskys;
 extern int gl_hardware_gamma;
 extern gl_lightmode_t gl_lightmode;
@@ -143,7 +149,7 @@ dboolean gld_SphereInFrustum(float x, float y, float z, float radius);
 //missing flats (fake floors and ceilings)
 extern dboolean gl_use_stencil;
 sector_t* GetBestFake(sector_t *sector, int ceiling, int validcount);
-sector_t* GetBestBleedSector(sector_t* source, int ceiling);
+sector_t* GetBestBleedSector(sector_t* source, enum bleedtype type);
 
 void gld_DrawMapLines(void);
 

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -726,10 +726,14 @@ static void R_Subsector(int num)
          * a future patch by refactoring this into the renderer and tagging
          * visible candidate sectors during drawing.
          */
-        if ((frontsector->floorheight >= viewz ||
-             viewz - frontsector->floorheight >= (FLOOR_BLEED_THRESHOLD << FRACBITS)) &&
-            (frontsector->flags & MISSING_BOTTOMTEXTURES)) {
-          tmpsec = GetBestBleedSector(frontsector, 0);
+        if (frontsector->flags & MISSING_BOTTOMTEXTURES)
+        {
+          tmpsec = NULL;
+          if (frontsector->floorheight >= viewz)
+            tmpsec = GetBestBleedSector(frontsector, BLEED_NONE);
+          if (tmpsec == NULL &&
+              viewz - frontsector->floorheight >= (FLOOR_BLEED_THRESHOLD << FRACBITS))
+            tmpsec = GetBestBleedSector(frontsector, BLEED_OCCLUDE);
 
           if (tmpsec)
           {


### PR DESCRIPTION
Fixes Sunder 2047 MAP31.  Tested on that and all the previous maps.

----

Distinguish occlusion and non-occlusion bleeding when registering and looking up sectors.  Avoids false-positives.