### PR TITLE
Add support for non-Latin paths on Windows

### DIFF
--- a/prboom2/src/PCSOUND/pcsound.c
+++ b/prboom2/src/PCSOUND/pcsound.c
@@ -33,6 +33,7 @@
 //e6y
 #include "doomtype.h"
 #include "lprintf.h"
+#include "m_file.h"
 
 #ifdef USE_WIN32_PCSOUND_DRIVER
 extern pcsound_driver_t pcsound_win32_driver;
@@ -70,7 +71,7 @@ int PCSound_Init(pcsound_callback_func callback_func)
 
     // Check if the environment variable is set
 
-    driver_name = getenv("PCSOUND_DRIVER");
+    driver_name = M_getenv("PCSOUND_DRIVER");
 
     if (driver_name != NULL)
     {

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -250,7 +250,7 @@ const char *I_DoomExeDir(void)
       {
         Z_Free(base);
         base = (char*)Z_Malloc(1024);
-        if (!getcwd(base, 1024) || !M_WriteAccess(base))
+        if (!M_getcwd(base, 1024) || !M_WriteAccess(base))
           strcpy(base, current_dir_dummy);
       }
     }
@@ -292,7 +292,7 @@ const char *I_DoomExeDir(void)
   static char *base;
   if (!base)        // cache multiple requests
   {
-    char *home = getenv("HOME");
+    char *home = M_getenv("HOME");
     size_t len = strlen(home);
 
     base = Z_Malloc(len + strlen(prboom_dir) + 1);
@@ -390,7 +390,7 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
     memcpy(search, search0, num_search * sizeof(*search));
 
     // add each directory from the $DOOMWADPATH environment variable
-    if ((dwp = getenv("DOOMWADPATH")))
+    if ((dwp = M_getenv("DOOMWADPATH")))
     {
       char *left, *ptr, *dup_dwp;
 
@@ -436,7 +436,7 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
      * and optionally s to a subdirectory of d */
     // switch replaced with lookup table
     if (search[i].env) {
-      if (!(d = getenv(search[i].env)))
+      if (!(d = M_getenv(search[i].env)))
         continue;
     } else if (search[i].func)
       d = search[i].func();

--- a/prboom2/src/dsda/data_organizer.c
+++ b/prboom2/src/dsda/data_organizer.c
@@ -65,7 +65,7 @@ char* dsda_DetectDirectory(const char* env_key, int arg_id) {
   char* result = NULL;
   const char* default_directory;
 
-  default_directory = getenv(env_key);
+  default_directory = M_getenv(env_key);
 
   if (!default_directory)
     default_directory = I_DoomExeDir();

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -82,6 +82,7 @@
 #include "g_game.h"
 #include "d_deh.h"
 #include "e6y.h"
+#include "m_file.h"
 
 #include "dsda/args.h"
 #include "dsda/map_format.h"
@@ -910,12 +911,12 @@ int GetFullPath(const char* FileName, const char* ext, char *Buffer, size_t Buff
     switch(i)
     {
     case 0:
-      getcwd(dir, sizeof(dir));
+      M_getcwd(dir, sizeof(dir));
       break;
     case 1:
-      if (!getenv("DOOMWADDIR"))
+      if (!M_getenv("DOOMWADDIR"))
         continue;
-      strcpy(dir, getenv("DOOMWADDIR"));
+      strcpy(dir, M_getenv("DOOMWADDIR"));
       break;
     case 2:
       strcpy(dir, I_DoomExeDir());

--- a/prboom2/src/i_capture.c
+++ b/prboom2/src/i_capture.c
@@ -647,7 +647,7 @@ void I_CaptureFinish (void)
     cap_tempfile1 = dsda_StringConfig(dsda_config_cap_tempfile1);
     cap_tempfile2 = dsda_StringConfig(dsda_config_cap_tempfile2);
 
-    remove (cap_tempfile1);
-    remove (cap_tempfile2);
+    M_remove (cap_tempfile1);
+    M_remove (cap_tempfile2);
   }
 }

--- a/prboom2/src/i_glob.c
+++ b/prboom2/src/i_glob.c
@@ -17,12 +17,13 @@
 //
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <stdarg.h>
 
+#include "doomtype.h"
 #include "i_glob.h"
+#include "z_zone.h"
 #include "m_misc.h"
 #include "m_file.h"
 #ifdef HAVE_CONFIG_H
@@ -33,8 +34,6 @@
 #if defined(_MSC_VER)
 // For Visual C++, we need to include the win_opendir module.
 #include "win_opendir.h"
-#define strcasecmp _stricmp
-#define strncasecmp _strnicmp
 #elif defined(HAVE_DIRENT_H)
 #include <dirent.h>
 #include <sys/stat.h>
@@ -65,10 +64,10 @@ static dboolean IsDirectory(char *dir, struct dirent *de)
         dboolean result;
 
         int len = snprintf(NULL, 0, "%s/%s", dir, de->d_name);
-        filename = malloc(len+1);
+        filename = Z_Malloc(len+1);
         snprintf(filename, len+1, "%s/%s", dir, de->d_name);
         result = M_IsDir(filename);
-        free(filename);
+        Z_Free(filename);
 
         return result;
     }
@@ -93,9 +92,9 @@ static void FreeStringList(char **globs, int num_globs)
     int i;
     for (i = 0; i < num_globs; ++i)
     {
-        free(globs[i]);
+        Z_Free(globs[i]);
     }
-    free(globs);
+    Z_Free(globs);
 }
 
 glob_t *I_StartMultiGlob(const char *directory, int flags,
@@ -107,12 +106,12 @@ glob_t *I_StartMultiGlob(const char *directory, int flags,
     va_list args;
     char *directory_native;
 
-    globs = malloc(sizeof(char *));
+    globs = Z_Malloc(sizeof(char *));
     if (globs == NULL)
     {
         return NULL;
     }
-    globs[0] = strdup(glob);
+    globs[0] = Z_Strdup(glob);
     num_globs = 1;
 
     va_start(args, glob);
@@ -126,18 +125,18 @@ glob_t *I_StartMultiGlob(const char *directory, int flags,
             break;
         }
 
-        new_globs = realloc(globs, sizeof(char *) * (num_globs + 1));
+        new_globs = Z_Realloc(globs, sizeof(char *) * (num_globs + 1));
         if (new_globs == NULL)
         {
             FreeStringList(globs, num_globs);
         }
         globs = new_globs;
-        globs[num_globs] = strdup(arg);
+        globs[num_globs] = Z_Strdup(arg);
         ++num_globs;
     }
     va_end(args);
 
-    result = malloc(sizeof(glob_t));
+    result = Z_Malloc(sizeof(glob_t));
     if (result == NULL)
     {
         FreeStringList(globs, num_globs);
@@ -150,8 +149,8 @@ glob_t *I_StartMultiGlob(const char *directory, int flags,
     if (result->dir == NULL)
     {
         FreeStringList(globs, num_globs);
-        free(result);
-        free(directory_native);
+        Z_Free(result);
+        Z_Free(directory_native);
         return NULL;
     }
 
@@ -181,10 +180,10 @@ void I_EndGlob(glob_t *glob)
     FreeStringList(glob->globs, glob->num_globs);
     FreeStringList(glob->filenames, glob->filenames_len);
 
-    free(glob->directory);
-    free(glob->last_filename);
+    Z_Free(glob->directory);
+    Z_Free(glob->last_filename);
     (void) closedir(glob->dir);
-    free(glob);
+    Z_Free(glob);
 }
 
 static dboolean MatchesGlob(const char *name, const char *glob, int flags)
@@ -264,7 +263,7 @@ static char *NextGlob(glob_t *glob)
 
     // Return the fully-qualified path, not just the bare filename.
     len = snprintf(NULL, 0, "%s/%s", glob->directory, de->d_name);
-    temp = malloc(len+1);
+    temp = Z_Malloc(len+1);
     snprintf(temp, len+1, "%s/%s", glob->directory, de->d_name);
     ret = ConvertSysNativeMBToUtf8(temp);
     return ret;
@@ -285,7 +284,7 @@ static void ReadAllFilenames(glob_t *glob)
         {
             break;
         }
-        glob->filenames = realloc(glob->filenames,
+        glob->filenames = Z_Realloc(glob->filenames,
                                   (glob->filenames_len + 1) * sizeof(char *));
         glob->filenames[glob->filenames_len] = name;
         ++glob->filenames_len;
@@ -342,7 +341,7 @@ const char *I_NextGlob(glob_t *glob)
     // them back from the system API.
     if ((glob->flags & GLOB_FLAG_SORTED) == 0)
     {
-        free(glob->last_filename);
+        Z_Free(glob->last_filename);
         glob->last_filename = NextGlob(glob);
         return glob->last_filename;
     }

--- a/prboom2/src/i_glob.c
+++ b/prboom2/src/i_glob.c
@@ -35,8 +35,6 @@
 #include "win_opendir.h"
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
-#include <sys/stat.h>
-#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)
 #elif defined(HAVE_DIRENT_H)
 #include <dirent.h>
 #include <sys/stat.h>
@@ -64,21 +62,15 @@ static dboolean IsDirectory(char *dir, struct dirent *de)
 #endif
     {
         char *filename;
-        struct stat sb;
-        int result;
+        dboolean result;
 
         int len = snprintf(NULL, 0, "%s/%s", dir, de->d_name);
         filename = malloc(len+1);
         snprintf(filename, len+1, "%s/%s", dir, de->d_name);
-        result = M_stat(filename, &sb);
+        result = M_IsDir(filename);
         free(filename);
 
-        if (result != 0)
-        {
-            return false;
-        }
-
-        return S_ISDIR(sb.st_mode);
+        return result;
     }
 }
 

--- a/prboom2/src/m_file.c
+++ b/prboom2/src/m_file.c
@@ -83,7 +83,7 @@ static wchar_t *ConvertMultiByteToWide(const char *str, UINT code_page) {
     return NULL;
   }
 
-  wstr = malloc(sizeof(wchar_t) * wlen);
+  wstr = Z_Malloc(sizeof(wchar_t) * wlen);
 
   if (!wstr) {
     lprintf(LO_INFO, "ConvertMultiByteToWide: Failed to allocate new string\n");
@@ -93,7 +93,7 @@ static wchar_t *ConvertMultiByteToWide(const char *str, UINT code_page) {
   if (MultiByteToWideChar(code_page, 0, str, -1, wstr, wlen) == 0) {
     errno = EINVAL;
     lprintf(LO_INFO, "Warning: Failed to convert path to wide encoding\n");
-    free(wstr);
+    Z_Free(wstr);
     return NULL;
   }
 
@@ -112,7 +112,7 @@ static char *ConvertWideToMultiByte(const wchar_t *wstr, UINT code_page) {
     return NULL;
   }
 
-  str = malloc(sizeof(char) * len);
+  str = Z_Malloc(sizeof(char) * len);
 
   if (!str) {
     lprintf(LO_INFO, "ConvertWideToMultiByte: Failed to allocate new string\n");
@@ -122,7 +122,7 @@ static char *ConvertWideToMultiByte(const wchar_t *wstr, UINT code_page) {
   if (WideCharToMultiByte(code_page, 0, wstr, -1, str, len, NULL, NULL) == 0) {
     errno = EINVAL;
     lprintf(LO_INFO, "Warning: Failed to convert path to multi byte encoding\n");
-    free(str);
+    Z_Free(str);
     return NULL;
   }
 
@@ -158,11 +158,11 @@ char *ConvertSysNativeMBToUtf8(const char *str) {
 
   ret = ConvertWideToUtf8(wstr);
 
-  free(wstr);
+  Z_Free(wstr);
 
   return ret;
 #else
-  return strdup(str);
+  return Z_Strdup(str);
 #endif
 }
 
@@ -178,11 +178,11 @@ char *ConvertUtf8ToSysNativeMB(const char *str) {
 
   ret = ConvertWideToSysNativeMB(wstr);
 
-  free(wstr);
+  Z_Free(wstr);
 
   return ret;
 #else
-  return strdup(str);
+  return Z_Strdup(str);
 #endif
 }
 
@@ -198,7 +198,7 @@ static int M_open(const char *filename, int oflag) {
 
   ret = _wopen(wname, oflag);
 
-  free(wname);
+  Z_Free(wname);
 
   return ret;
 #else
@@ -218,7 +218,7 @@ static int M_access(const char *path, int mode) {
 
   ret = _waccess(wpath, mode);
 
-  free(wpath);
+  Z_Free(wpath);
 
   return ret;
 #else
@@ -238,7 +238,7 @@ static int M_mkdir(const char *path) {
 
   ret = _wmkdir(wdir);
 
-  free(wdir);
+  Z_Free(wdir);
 
   return ret;
 #else
@@ -266,7 +266,7 @@ static int M_stat(const char *path, struct stat *buf)
   buf->st_mode = wbuf.st_mode;
   buf->st_mtime = wbuf.st_mtime;
 
-  free(wpath);
+  Z_Free(wpath);
 
   return ret;
 #else
@@ -287,7 +287,7 @@ int M_remove(const char *path)
 
   ret = _wremove(wpath);
 
-  free(wpath);
+  Z_Free(wpath);
 
   return ret;
 #else
@@ -346,14 +346,14 @@ FILE* M_OpenFile(const char *name, const char *mode)
 
   if (!wmode)
   {
-    free(wname);
+    Z_Free(wname);
     return NULL;
   }
 
   file = _wfopen(wname, wmode);
 
-  free(wname);
-  free(wmode);
+  Z_Free(wname);
+  Z_Free(wmode);
 
   return file;
 #else
@@ -487,12 +487,12 @@ char *M_getcwd(char *buffer, int len)
     return ret;
 
   if (strlen(ret) >= len) {
-    free(ret);
+    Z_Free(ret);
     return NULL;
   }
 
   strcpy(buffer, ret);
-  free(ret);
+  Z_Free(ret);
 
   return buffer;
 #else
@@ -528,16 +528,16 @@ char *M_getenv(const char *name) {
 
   wenv = _wgetenv(wname);
 
-  free(wname);
+  Z_Free(wname);
 
   if (wenv)
     env = ConvertWideToUtf8(wenv);
   else
     env = NULL;
 
-  env_vars = realloc(env_vars, (num_vars + 1) * sizeof(*env_vars));
+  env_vars = Z_Realloc(env_vars, (num_vars + 1) * sizeof(*env_vars));
   env_vars[num_vars].var = env;
-  env_vars[num_vars].name = strdup(name);
+  env_vars[num_vars].name = Z_Strdup(name);
   num_vars++;
 
   return env;

--- a/prboom2/src/m_file.c
+++ b/prboom2/src/m_file.c
@@ -246,28 +246,7 @@ static int M_mkdir(const char *path) {
 #endif
 }
 
-int M_remove(const char *path)
-{
-#ifdef _WIN32
-  wchar_t *wpath;
-  int ret;
-
-  wpath = ConvertUtf8ToWide(path);
-
-  if (!wpath)
-    return 0;
-
-  ret = _wremove(wpath);
-
-  free(wpath);
-
-  return ret;
-#else
-  return remove(path);
-#endif
-}
-
-int M_stat(const char *path, struct stat *buf)
+static int M_stat(const char *path, struct stat *buf)
 {
 #ifdef _WIN32
   wchar_t *wpath;
@@ -292,6 +271,27 @@ int M_stat(const char *path, struct stat *buf)
   return ret;
 #else
   return stat(path, buf);
+#endif
+}
+
+int M_remove(const char *path)
+{
+#ifdef _WIN32
+  wchar_t *wpath;
+  int ret;
+
+  wpath = ConvertUtf8ToWide(path);
+
+  if (!wpath)
+    return 0;
+
+  ret = _wremove(wpath);
+
+  free(wpath);
+
+  return ret;
+#else
+  return remove(path);
 #endif
 }
 

--- a/prboom2/src/m_file.c
+++ b/prboom2/src/m_file.c
@@ -328,7 +328,7 @@ FILE* M_OpenFile(const char *name, const char *mode)
   FILE *file;
   wchar_t *wname, *wmode;
 
-  wname = ConvertUtf8ToWide(filename);
+  wname = ConvertUtf8ToWide(name);
 
   if (!wname)
     return NULL;
@@ -348,7 +348,7 @@ FILE* M_OpenFile(const char *name, const char *mode)
 
   return file;
 #else
-  return fopen(filename, mode);
+  return fopen(name, mode);
 #endif
 }
 

--- a/prboom2/src/m_file.c
+++ b/prboom2/src/m_file.c
@@ -143,8 +143,10 @@ static wchar_t *ConvertSysNativeMBToWide(const char *str) {
 static char *ConvertWideToSysNativeMB(const wchar_t *wstr) {
   return ConvertWideToMultiByte(wstr, CP_ACP);
 }
+#endif
 
 char *ConvertSysNativeMBToUtf8(const char *str) {
+#ifdef _WIN32
   char *ret = NULL;
   wchar_t *wstr = NULL;
 
@@ -158,9 +160,13 @@ char *ConvertSysNativeMBToUtf8(const char *str) {
   free(wstr);
 
   return ret;
+#else
+  return strdup(str);
+#endif
 }
 
 char *ConvertUtf8ToSysNativeMB(const char *str) {
+#ifdef _WIN32
   char *ret = NULL;
   wchar_t *wstr = NULL;
 
@@ -174,8 +180,10 @@ char *ConvertUtf8ToSysNativeMB(const char *str) {
   free(wstr);
 
   return ret;
-}
+#else
+  return strdup(str);
 #endif
+}
 
 static int M_open(const char *filename, int oflag) {
 #ifdef _WIN32

--- a/prboom2/src/m_file.c
+++ b/prboom2/src/m_file.c
@@ -47,6 +47,7 @@
 #endif
 
 #include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <errno.h>

--- a/prboom2/src/m_file.h
+++ b/prboom2/src/m_file.h
@@ -35,6 +35,7 @@
 #define __M_FILE__
 
 #include <stdio.h>
+#include <sys/stat.h>
 
 #include "doomtype.h"
 

--- a/prboom2/src/m_file.h
+++ b/prboom2/src/m_file.h
@@ -58,8 +58,8 @@ char *M_getenv(const char *name);
 
 #ifdef _WIN32
 wchar_t *ConvertUtf8ToWide(const char *str);
+#endif
 char *ConvertSysNativeMBToUtf8(const char *str);
 char *ConvertUtf8ToSysNativeMB(const char *str);
-#endif
 
 #endif

--- a/prboom2/src/m_file.h
+++ b/prboom2/src/m_file.h
@@ -35,7 +35,6 @@
 #define __M_FILE__
 
 #include <stdio.h>
-#include <sys/stat.h>
 
 #include "doomtype.h"
 
@@ -52,7 +51,6 @@ int M_ReadFile (char const* name,byte** buffer);
 int M_ReadFileToString(char const *name, char **buffer);
 
 int M_remove(const char *path);
-int M_stat(const char *path, struct stat *buf);
 char *M_getcwd(char *buffer, int len);
 char *M_getenv(const char *name);
 

--- a/prboom2/src/m_file.h
+++ b/prboom2/src/m_file.h
@@ -50,4 +50,15 @@ dboolean M_WriteFile (char const* name, const void* source, size_t length);
 int M_ReadFile (char const* name,byte** buffer);
 int M_ReadFileToString(char const *name, char **buffer);
 
+int M_remove(const char *path);
+int M_stat(const char *path, struct stat *buf);
+char *M_getcwd(char *buffer, int len);
+char *M_getenv(const char *name);
+
+#ifdef _WIN32
+wchar_t *ConvertUtf8ToWide(const char *str);
+char *ConvertSysNativeMBToUtf8(const char *str);
+char *ConvertUtf8ToSysNativeMB(const char *str);
+#endif
+
 #endif

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -133,7 +133,7 @@ void W_InitCache(void)
         mapped_wad[wad_index].hnd = CreateFileW(wname,
           GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
           NULL, OPEN_EXISTING, 0, NULL);
-        free(wname);
+        Z_Free(wname);
         if (mapped_wad[wad_index].hnd==INVALID_HANDLE_VALUE)
           I_Error("W_InitCache: CreateFile for memory mapping failed (LastError %li)",GetLastError());
         mapped_wad[wad_index].hnd_map =

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -54,6 +54,7 @@
 #include "z_zone.h"
 #include "lprintf.h"
 #include "i_system.h"
+#include "m_file.h"
 
 #include "e6y.h"//e6y
 
@@ -128,9 +129,11 @@ void W_InitCache(void)
 #endif
       if (!mapped_wad[wad_index].data)
       {
-        mapped_wad[wad_index].hnd = CreateFile(wadfiles[wad_index].name,
+        wchar_t *wname = ConvertUtf8ToWide(wadfiles[wad_index].name);
+        mapped_wad[wad_index].hnd = CreateFileW(wname,
           GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
           NULL, OPEN_EXISTING, 0, NULL);
+        free(wname);
         if (mapped_wad[wad_index].hnd==INVALID_HANDLE_VALUE)
           I_Error("W_InitCache: CreateFile for memory mapping failed (LastError %li)",GetLastError());
         mapped_wad[wad_index].hnd_map =


### PR DESCRIPTION
I did not change the `data/rd_*` files, and there is `fopen()` under the `#TEST` macros in `midifile.c`.

Alternative to #204 