### PR TITLE
r_bsp: add symmetric logic for ceiling occlusion

### DIFF
--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -50,6 +50,8 @@
 // bleedthrough normally occurs when the sector's floor is so
 // low that it is completely occluded from the current view.
 #define FLOOR_BLEED_THRESHOLD 500
+// Same, but for ceiling
+#define CEILING_BLEED_THRESHOLD 500
 
 int currentsubsectornum;
 
@@ -751,9 +753,14 @@ static void R_Subsector(int num)
           }
         }
 
-        if (frontsector->ceilingheight <= viewz && (frontsector->flags & MISSING_TOPTEXTURES))
+        if (frontsector->flags & MISSING_TOPTEXTURES)
         {
-          tmpsec = GetBestBleedSector(frontsector, 1);
+          tmpsec = NULL;
+          if (frontsector->ceilingheight <= viewz)
+            tmpsec = GetBestBleedSector(frontsector, BLEED_CEILING);
+          if (tmpsec == NULL &&
+              frontsector->ceilingheight - viewz >= (CEILING_BLEED_THRESHOLD << FRACBITS))
+            tmpsec = GetBestBleedSector(frontsector, BLEED_CEILING | BLEED_OCCLUDE);
 
           if (tmpsec)
           {


### PR DESCRIPTION
I didn't bother with this before because you would think there's no point in having a fake "deep" ceiling.  But BTSX1 has one for no discernible reason.

Closes #236 

----

No idea why mappers would do it, but they did.