### PR TITLE
Better sector tests

### DIFF
--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -750,7 +750,7 @@ static dboolean gld_IsRealLine(sector_t* sector, line_t* line)
       continue;
     if (sector->lines[i]->v1 == line->v1 || sector->lines[i]->v2 == line->v1)
       v1c++;
-    if (sector->lines[i]->v2 == line->v2 || sector->lines[i]->v2 == line->v2)
+    if (sector->lines[i]->v1 == line->v2 || sector->lines[i]->v2 == line->v2)
       v2c++;
   }
 
@@ -1101,28 +1101,25 @@ static void gld_PreprocessSectors(void)
     memset(vertexcheck2,0,numvertexes*sizeof(vertexcheck2[0]));
     for (j=0; j<sectors[i].linecount; j++)
     {
-      v1num=((intptr_t)sectors[i].lines[j]->v1-(intptr_t)vertexes)/sizeof(vertex_t);
-      v2num=((intptr_t)sectors[i].lines[j]->v2-(intptr_t)vertexes)/sizeof(vertex_t);
-      if ((v1num>=numvertexes) || (v2num>=numvertexes))
-        continue;
+      line_t *l = sectors[i].lines[j];
+      v1num = l->v1 - vertexes;
+      v2num = l->v2 - vertexes;
 
       // e6y: for correct handling of missing textures.
       // We do not need to apply some algos for isolated lines.
       vertexcheck2[v1num]++;
       vertexcheck2[v2num]++;
 
-      if (sectors[i].lines[j]->sidenum[0]!=NO_INDEX)
-        if (sides[sectors[i].lines[j]->sidenum[0]].sector==&sectors[i])
-        {
+      if (l->frontsector == &sectors[i])
+      {
           vertexcheck[v1num]|=1;
           vertexcheck[v2num]|=2;
-        }
-      if (sectors[i].lines[j]->sidenum[1]!=NO_INDEX)
-        if (sides[sectors[i].lines[j]->sidenum[1]].sector==&sectors[i])
-        {
-          vertexcheck[v1num]|=2;
-          vertexcheck[v2num]|=1;
-        }
+      }
+      else
+      {
+        vertexcheck[v1num]|=2;
+        vertexcheck[v2num]|=1;
+      }
     }
     if (sectors[i].linecount<3)
     {

--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -788,10 +788,11 @@ static void gld_MarkRealSectors(void)
   for (i = 0; i < numsectors; i++) {
     real = true;
     for (j = 0; j < sectors[i].linecount; j++) {
-      if (!gld_IsRealLine(&sectors[i], sectors[i].lines[j])) {
+      if (gld_IsRealLine(&sectors[i], sectors[i].lines[j]))
+        // While we're at it, mark lines that are real
+        sectors[i].lines[j]->flags |= RF_REAL;
+      else
         real = false;
-        break;
-      }
     }
     if (real) {
       sectors[i].flags |= SECTOR_IS_REAL;
@@ -857,7 +858,7 @@ static sector_t* gld_SelfReferencingSectorContainer(sector_t* sector)
   for (i = 0; i < sector->linecount; ++i)
   {
     l = sector->lines[i];
-    if (!gld_IsRealLine(sector, l))
+    if (!(l->flags & RF_REAL))
     {
       angle_t ang = R_PointToAngle2(l->v1->x, l->v1->y, l->v2->x, l->v2->y) + ANG90;
       fixed_t offsx = finecosine[ang >> ANGLETOFINESHIFT] >> 5;
@@ -880,7 +881,7 @@ static sector_t* gld_SelfReferencingSectorContainer(sector_t* sector)
   for (i = 0; i < sector->linecount; ++i)
   {
     l = sector->lines[i];
-    if (gld_IsRealLine(sector, l))
+    if (l->flags & RF_REAL)
     {
       if ((cont = gld_ResolveContainer(sector, l->frontsector)))
         return cont;

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -49,9 +49,9 @@
 // an approximation of software rendering behavior.  Presumably
 // bleedthrough normally occurs when the sector's floor is so
 // low that it is completely occluded from the current view.
-#define FLOOR_BLEED_THRESHOLD 500
+#define FLOOR_BLEED_THRESHOLD 400
 // Same, but for ceiling
-#define CEILING_BLEED_THRESHOLD 500
+#define CEILING_BLEED_THRESHOLD 400
 
 int currentsubsectornum;
 

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -354,6 +354,10 @@ typedef struct line_s
   int healthgroup;
   const byte* tranmap;
   float alpha;
+
+  // gl_preprocess
+  unsigned int max_cycle;
+  struct line_s* subgraph;
 } line_t;
 
 #define LINE_ARG_COUNT 5

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -292,6 +292,7 @@ typedef byte r_flags_t;
 #define RF_IGNORE   0x08 // Renderer can skip this line
 #define RF_CLOSED   0x10 // Line blocks view
 #define RF_ISOLATED 0x20 // Isolated line
+#define RF_REAL     0x40 // Real (not self-referencing trick) line
 
 typedef enum
 {


### PR DESCRIPTION
Closes #235

Opening as draft because I still need to convince myself the algorithm is correct and test more.  I did try a huge Sunder map to confirm the performance is OK with sectors with huge numbers of lines.

The real problem this is fixing is that the existing check for sector closedness in the code is... just wrong.  It marks sectors as closed when they aren't, then attempts GLU tessellation when it can't possibly generate any useful triangles.  Fixing the test makes it fall back on subsector tessellation as it should and fixes the bug.

Unfortunately, fixing the test means some self-referencing sectors become visible when they shouldn't be, because they were accidentally being made invisible by the bug!  So the test for self-referencing sectors needed to be fixed/improved to catch more cases.

Fixing anything in this renderer is a game of whack-a-mole.