### PR TITLE
gl_preprocess: revert out self-ref sector hacks

### DIFF
--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -117,7 +117,6 @@ typedef struct
 #define SECF_LIGHTCEILINGABSOLUTE  0x00080000
 #define SECF_DAMAGEFLAGS (SECF_ENDGODMODE|SECF_ENDLEVEL|SECF_DMGTERRAINFX|SECF_HAZARD|SECF_DMGUNBLOCKABLE)
 #define SECF_TRANSFERMASK (SECF_SECRET|SECF_WASSECRET|SECF_DAMAGEFLAGS|SECF_FRICTION|SECF_PUSH)
-#define SECTOR_IS_REAL             0x00200000
 
 typedef struct
 {
@@ -167,9 +166,6 @@ typedef struct sector_s
 
   int linecount;
   struct line_s **lines;
-
-  // For gl_preprocess
-  struct sector_s* gl_pp;
 
   // killough 10/98: support skies coming from sidedefs. Allows scrolling
   // skies and other effects. No "level info" kind of lump is needed,


### PR DESCRIPTION
I think it's going to take a more radical approach to fix self-referencing sectors.  Putting things back the way they were while I do some experimenting.