### PR TITLE
Self-ref sector fixes (and more)

### DIFF
--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -918,28 +918,25 @@ static void gld_PreprocessSectors(void)
     memset(vertexcheck2,0,numvertexes*sizeof(vertexcheck2[0]));
     for (j=0; j<sectors[i].linecount; j++)
     {
-      v1num=((intptr_t)sectors[i].lines[j]->v1-(intptr_t)vertexes)/sizeof(vertex_t);
-      v2num=((intptr_t)sectors[i].lines[j]->v2-(intptr_t)vertexes)/sizeof(vertex_t);
-      if ((v1num>=numvertexes) || (v2num>=numvertexes))
-        continue;
+      line_t *l = sectors[i].lines[j];
+      v1num = l->v1 - vertexes;
+      v2num = l->v2 - vertexes;
 
       // e6y: for correct handling of missing textures.
       // We do not need to apply some algos for isolated lines.
       vertexcheck2[v1num]++;
       vertexcheck2[v2num]++;
 
-      if (sectors[i].lines[j]->sidenum[0]!=NO_INDEX)
-        if (sides[sectors[i].lines[j]->sidenum[0]].sector==&sectors[i])
-        {
+      if (l->frontsector == &sectors[i])
+      {
           vertexcheck[v1num]|=1;
           vertexcheck[v2num]|=2;
-        }
-      if (sectors[i].lines[j]->sidenum[1]!=NO_INDEX)
-        if (sides[sectors[i].lines[j]->sidenum[1]].sector==&sectors[i])
-        {
-          vertexcheck[v1num]|=2;
-          vertexcheck[v2num]|=1;
-        }
+      }
+      else
+      {
+        vertexcheck[v1num]|=2;
+        vertexcheck[v2num]|=1;
+      }
     }
     if (sectors[i].linecount<3)
     {

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -49,9 +49,9 @@
 // an approximation of software rendering behavior.  Presumably
 // bleedthrough normally occurs when the sector's floor is so
 // low that it is completely occluded from the current view.
-#define FLOOR_BLEED_THRESHOLD 500
+#define FLOOR_BLEED_THRESHOLD 400
 // Same, but for ceiling
-#define CEILING_BLEED_THRESHOLD 500
+#define CEILING_BLEED_THRESHOLD 400
 
 int currentsubsectornum;
 

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -375,6 +375,18 @@ static void R_AddLine (seg_t *line)
 
   if (V_IsOpenGLMode())
   {
+    line_t* l = line->linedef;
+    sector_t* sec = subsectors[currentsubsectornum].sector;
+
+    // Don't add plane to drawing list until we encounter a
+    // non-self-referencing linedef in the subsector.
+    if (sec->gl_validcount != validcount && (l == NULL || l->frontsector != l->backsector))
+    {
+      sec->gl_validcount = validcount;
+
+      gld_AddPlane(currentsubsectornum, floorplane, ceilingplane);
+    }
+
     angle1 = R_PointToPseudoAngle(line->v1->x, line->v1->y);
     angle2 = R_PointToPseudoAngle(line->v2->x, line->v2->y);
 
@@ -619,7 +631,7 @@ static void R_Subsector(int num)
   sub = &subsectors[num];
   currentsubsectornum = num;
 
-  if (V_IsSoftwareMode() || !gl_use_stencil || sub->sector->validcount != validcount)
+  if (V_IsSoftwareMode() || sub->sector->gl_validcount != validcount)
   {
     frontsector = sub->sector;
 
@@ -667,7 +679,7 @@ static void R_Subsector(int num)
   // e6y
   // New algo can handle fake flats and ceilings
   // much more correctly and fastly the the original
-    if (V_IsOpenGLMode())
+    if (V_IsOpenGLMode() && sub->sector->gl_validcount != validcount)
     {
       // check if the sector is faked
       sector_t *tmpsec = NULL;
@@ -797,9 +809,6 @@ static void R_Subsector(int num)
     sub->sector->validcount = validcount;
 
     R_AddSprites(sub, (floorlightlevel+ceilinglightlevel)/2);
-
-    if (V_IsOpenGLMode())
-      gld_AddPlane(num, floorplane, ceilingplane);
   }
 
   // hexen

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -137,6 +137,8 @@ typedef struct sector_s
   int bbox[4];           // bounding box in map units
   degenmobj_t soundorg;  // origin for any sounds played by the sector
   int validcount;        // if == validcount, already checked
+  // Needed by GL path to register flats in sector for rendering only once
+  int gl_validcount;
   mobj_t *thinglist;     // list of mobjs in sector
 
   /* killough 8/28/98: friction is a sector property, not an mobj property.

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -117,6 +117,7 @@ typedef struct
 #define SECF_LIGHTCEILINGABSOLUTE  0x00080000
 #define SECF_DAMAGEFLAGS (SECF_ENDGODMODE|SECF_ENDLEVEL|SECF_DMGTERRAINFX|SECF_HAZARD|SECF_DMGUNBLOCKABLE)
 #define SECF_TRANSFERMASK (SECF_SECRET|SECF_WASSECRET|SECF_DAMAGEFLAGS|SECF_FRICTION|SECF_PUSH)
+#define SECTOR_IS_REAL             0x00200000
 
 typedef struct
 {
@@ -168,6 +169,9 @@ typedef struct sector_s
 
   int linecount;
   struct line_s **lines;
+
+  // For gl_preprocess
+  struct sector_s* gl_pp;
 
   // killough 10/98: support skies coming from sidedefs. Allows scrolling
   // skies and other effects. No "level info" kind of lump is needed,
@@ -290,6 +294,7 @@ typedef byte r_flags_t;
 #define RF_IGNORE   0x08 // Renderer can skip this line
 #define RF_CLOSED   0x10 // Line blocks view
 #define RF_ISOLATED 0x20 // Isolated line
+#define RF_REAL     0x40 // Real (not self-referencing trick) line
 
 typedef enum
 {
@@ -351,6 +356,11 @@ typedef struct line_s
   int healthgroup;
   const byte* tranmap;
   float alpha;
+
+  // gl_preprocess
+  struct line_s* subgraph;
+  unsigned int max_cycle;
+  unsigned int max_subgraph_cycle;
 } line_t;
 
 #define LINE_ARG_COUNT 5


### PR DESCRIPTION
Summary of the problems leading to this point:

1. HR2 MAP01 has a bad rendering glitch (issue #235)
2. It's caused by a broken test for sector closedness that assumes linedef side 0 was facing the sector.  Since it falsely thinks the sector is closed, it uses GLU tessellation, which generates no triangles and results in HOM.
3. Fixing the broken test causes it to fall back on subsector tessellation, which fixes the glitch in combination with tweaking a bleeding threshold.
4. Fixing the broken test also opens a can of worms: a lot of self-referencing sectors were *accidentally* being rendered correctly because of it, including some in HR2 MAP01 and kdikdizd.  This was mostly dumb luck:
    - Trying to tessellate an unclosed sector can generate no triangles.  If the unclosed sector was self-referencing, this caused it to be invisible (as it should be)
    - Trying to tessellate an unclosed sector can succeed anyway because it has a closed subset.  This can fill in a self-referencing sector contained within it (also good)
5. Fixing the above requires making the GL rendering path act like the software path by not rendering flats of self-referencing sectors, and restoring self-ref sector tests in `gl_preprocess.c` so that their subsectors can "fill in" their parents.

This was the only way I could get all of AV MAP01, HR MAP01, HR2 MAP01, AVMAP01, and kdikdizd MAP15 to render correctly at the same time.  The new self-ref sector test is very precise by taking a graph-theoretic approach.  I guess it always comes back to graph search.

Note that the sector closedness test and GLU tessellation logic are also doing similar but more ad-hoc graph searches to find the sector contours.  These could be subsequently refactored to use results from the initial search.