### PR TITLE
Manage hud configs

### DIFF
--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -479,7 +479,7 @@ static void dsda_UpdateActiveHUD(void) {
     dsda_ResetActiveHUD();
 }
 
-static void dsda_RefreshHUDComponentStatus(void) {
+static void dsda_RefreshHUD(void) {
   if (!dsda_HUDActive())
     return;
 
@@ -491,6 +491,9 @@ static void dsda_RefreshHUDComponentStatus(void) {
   dsda_RefreshExHudLevelSplits();
   dsda_RefreshExHudCoordinateDisplay();
   dsda_RefreshExHudCommandDisplay();
+
+  if (in_game && gamestate == GS_LEVEL)
+    dsda_UpdateExHud();
 }
 
 void dsda_InitExHud(void) {
@@ -501,7 +504,7 @@ void dsda_InitExHud(void) {
 
   dsda_LoadHUDConfig();
   dsda_UpdateActiveHUD();
-  dsda_RefreshHUDComponentStatus();
+  dsda_RefreshHUD();
 }
 
 void dsda_UpdateExHud(void) {

--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -36,9 +36,9 @@
 #include "exhud.h"
 
 typedef struct {
-  void (*init)(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-  void (*update)(void);
-  void (*draw)(void);
+  void (*init)(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+  void (*update)(void* data);
+  void (*draw)(void* data);
   const char* name;
   const int default_vpt;
   const dboolean strict;
@@ -47,6 +47,7 @@ typedef struct {
   const dboolean not_level;
   dboolean on;
   dboolean initialized;
+  void* data;
 } exhud_component_t;
 
 typedef enum {
@@ -308,7 +309,8 @@ static void dsda_TurnComponentOff(int id) {
 
 static void dsda_InitializeComponent(int id, int x, int y, int vpt, int* args, int arg_count) {
   components[id].initialized = true;
-  components[id].init(x, y, vpt | components[id].default_vpt | VPT_EX_TEXT, args, arg_count);
+  components[id].init(x, y, vpt | components[id].default_vpt | VPT_EX_TEXT,
+                 args, arg_count, &components[id].data);
 
   if (components[id].off_by_default)
     dsda_TurnComponentOff(id);
@@ -517,7 +519,7 @@ void dsda_UpdateExHud(void) {
       !components[i].not_level &&
       (!components[i].strict || !dsda_StrictMode())
     )
-      components[i].update();
+      components[i].update(components[i].data);
 }
 
 void dsda_DrawExHud(void) {
@@ -535,7 +537,7 @@ void dsda_DrawExHud(void) {
       !components[i].not_level &&
       (!components[i].strict || !dsda_StrictMode())
     )
-      components[i].draw();
+      components[i].draw(components[i].data);
 }
 
 void dsda_DrawExIntermission(void) {
@@ -550,7 +552,7 @@ void dsda_DrawExIntermission(void) {
       components[i].intermission &&
       (!components[i].strict || !dsda_StrictMode())
     )
-      components[i].draw();
+      components[i].draw(components[i].data);
 }
 
 void dsda_ToggleRenderStats(void) {

--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -262,7 +262,36 @@ exhud_component_t components[exhud_component_count] = {
   },
 };
 
+typedef struct {
+  const char* name;
+  dboolean status_bar;
+  dboolean loaded;
+} dsda_hud_container_t;
+
+typedef enum {
+  hud_ex,
+  hud_off,
+  hud_full,
+  hud_null,
+} dsda_hud_variant_t;
+
+static dsda_hud_container_t containers[] = {
+  [hud_ex]   = { "ex", true },
+  [hud_off]  = { "off", true },
+  [hud_full] = { "full", false },
+  [hud_null] = { NULL }
+};
+
+static dsda_hud_container_t* container;
+
 int dsda_show_render_stats;
+
+int dsda_ExHudVerticalOffset(void) {
+  if (container && container->status_bar)
+    return g_st_height;
+
+  return 0;
+}
 
 static void dsda_TurnComponentOn(int id) {
   if (!components[id].initialized)
@@ -415,9 +444,13 @@ void dsda_InitExHud(void) {
   if (!hud_config)
     return;
 
+  container = R_FullView() ? &containers[hud_full] :
+              dsda_IntConfig(dsda_config_exhud) ? &containers[hud_ex] :
+              &containers[hud_off];
+
   snprintf(target, sizeof(target), "%s %s",
            hexen ? "hexen" : heretic ? "heretic" : "doom",
-           R_FullView() ? "full" : dsda_IntConfig(dsda_config_exhud) ? "ex" : "off");
+           container->name);
 
   for (line_i = 0; hud_config[line_i]; ++line_i) {
     line = hud_config[line_i];

--- a/prboom2/src/dsda/hud_components/ammo_text.c
+++ b/prboom2/src/dsda/hud_components/ammo_text.c
@@ -95,7 +95,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size, int i) {
     );
 }
 
-void dsda_InitAmmoTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitAmmoTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   int i;
 
   if (arg_count > 0)
@@ -114,7 +114,7 @@ void dsda_InitAmmoTextHC(int x_offset, int y_offset, int vpt, int* args, int arg
     dsda_InitTextHC(&component[i], x_offset, y_offset - i * 8, vpt);
 }
 
-void dsda_UpdateAmmoTextHC(void) {
+void dsda_UpdateAmmoTextHC(void* data) {
   int i;
 
   for (i = 0; i < component_config->count; ++i) {
@@ -123,7 +123,7 @@ void dsda_UpdateAmmoTextHC(void) {
   }
 }
 
-void dsda_DrawAmmoTextHC(void) {
+void dsda_DrawAmmoTextHC(void* data) {
   int i;
 
   for (i = 0; i < component_config->count; ++i)

--- a/prboom2/src/dsda/hud_components/ammo_text.h
+++ b/prboom2/src/dsda/hud_components/ammo_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_AMMO_TEXT__
 #define __DSDA_HUD_COMPONENT_AMMO_TEXT__
 
-void dsda_InitAmmoTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateAmmoTextHC(void);
-void dsda_DrawAmmoTextHC(void);
+void dsda_InitAmmoTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateAmmoTextHC(void* data);
+void dsda_DrawAmmoTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/armor_text.c
+++ b/prboom2/src/dsda/hud_components/armor_text.c
@@ -54,15 +54,15 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   }
 }
 
-void dsda_InitArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateArmorTextHC(void) {
+void dsda_UpdateArmorTextHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawArmorTextHC(void) {
+void dsda_DrawArmorTextHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/armor_text.c
+++ b/prboom2/src/dsda/hud_components/armor_text.c
@@ -19,7 +19,11 @@
 
 #include "armor_text.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   player_t* player;
@@ -55,14 +59,21 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateArmorTextHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawArmorTextHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/armor_text.h
+++ b/prboom2/src/dsda/hud_components/armor_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_ARMOR_TEXT__
 #define __DSDA_HUD_COMPONENT_ARMOR_TEXT__
 
-void dsda_InitArmorTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateArmorTextHC(void);
-void dsda_DrawArmorTextHC(void);
+void dsda_InitArmorTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateArmorTextHC(void* data);
+void dsda_DrawArmorTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/attempts.c
+++ b/prboom2/src/dsda/hud_components/attempts.c
@@ -37,15 +37,15 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   );
 }
 
-void dsda_InitAttemptsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitAttemptsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateAttemptsHC(void) {
+void dsda_UpdateAttemptsHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawAttemptsHC(void) {
+void dsda_DrawAttemptsHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/attempts.c
+++ b/prboom2/src/dsda/hud_components/attempts.c
@@ -21,7 +21,11 @@
 
 #include "attempts.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   if (!demorecording)
@@ -38,14 +42,21 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitAttemptsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateAttemptsHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawAttemptsHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/attempts.h
+++ b/prboom2/src/dsda/hud_components/attempts.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_ATTEMPTS__
 #define __DSDA_HUD_COMPONENT_ATTEMPTS__
 
-void dsda_InitAttemptsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateAttemptsHC(void);
-void dsda_DrawAttemptsHC(void);
+void dsda_InitAttemptsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateAttemptsHC(void* data);
+void dsda_DrawAttemptsHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/base.c
+++ b/prboom2/src/dsda/hud_components/base.c
@@ -23,6 +23,8 @@ static char digit_lump[9];
 static const char* digit_lump_format;
 
 int dsda_HudComponentY(int y_offset, int vpt) {
+  int dsda_ExHudVerticalOffset(void);
+
   int y = 0;
   int vpt_align;
 
@@ -35,8 +37,7 @@ int dsda_HudComponentY(int y_offset, int vpt) {
     y = 200;
     y_offset = -y_offset;
 
-    if (R_PartialView())
-      y -= g_st_height;
+    y -= dsda_ExHudVerticalOffset();
   }
 
   return y + y_offset;

--- a/prboom2/src/dsda/hud_components/big_ammo.c
+++ b/prboom2/src/dsda/hud_components/big_ammo.c
@@ -43,14 +43,14 @@ static void dsda_DrawComponent(void) {
                      CR_DEFAULT, component.vpt, 3, ammo);
 }
 
-void dsda_InitBigAmmoHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitBigAmmoHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateBigAmmoHC(void) {
+void dsda_UpdateBigAmmoHC(void* data) {
   return;
 }
 
-void dsda_DrawBigAmmoHC(void) {
+void dsda_DrawBigAmmoHC(void* data) {
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_ammo.c
+++ b/prboom2/src/dsda/hud_components/big_ammo.c
@@ -21,7 +21,11 @@
 
 #define PATCH_DELTA_X 14
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_DrawComponent(void) {
   player_t* player;
@@ -39,18 +43,23 @@ static void dsda_DrawComponent(void) {
 
   ammo = player->ammo[ammo_type];
 
-  dsda_DrawBigNumber(component.x, component.y, PATCH_DELTA_X, 0,
-                     CR_DEFAULT, component.vpt, 3, ammo);
+  dsda_DrawBigNumber(local->component.x, local->component.y, PATCH_DELTA_X, 0,
+                     CR_DEFAULT, local->component.vpt, 3, ammo);
 }
 
 void dsda_InitBigAmmoHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateBigAmmoHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawBigAmmoHC(void* data) {
+  local = data;
+
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_ammo.h
+++ b/prboom2/src/dsda/hud_components/big_ammo.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_BIG_AMMO__
 #define __DSDA_HUD_COMPONENT_BIG_AMMO__
 
-void dsda_InitBigAmmoHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateBigAmmoHC(void);
-void dsda_DrawBigAmmoHC(void);
+void dsda_InitBigAmmoHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateBigAmmoHC(void* data);
+void dsda_DrawBigAmmoHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/big_armor.c
+++ b/prboom2/src/dsda/hud_components/big_armor.c
@@ -19,7 +19,12 @@
 
 #include "big_armor.h"
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
+
 static int armor_lump_green;
 static int armor_lump_blue;
 static int patch_delta_x;
@@ -34,8 +39,8 @@ static void dsda_DrawComponent(void) {
   int armor;
 
   player = &players[displayplayer];
-  x = component.x;
-  y = component.y;
+  x = local->component.x;
+  y = local->component.y;
 
   if (hexen) {
     armor = dsda_HexenArmor(player);
@@ -58,16 +63,19 @@ static void dsda_DrawComponent(void) {
     }
   }
 
-  V_DrawNumPatch(x, y, FG, lump, CR_DEFAULT, component.vpt);
+  V_DrawNumPatch(x, y, FG, lump, CR_DEFAULT, local->component.vpt);
 
   x += patch_spacing;
   y += patch_vertical_spacing;
 
   dsda_DrawBigNumber(x, y, patch_delta_x, 0,
-                     cm, component.vpt, 3, armor);
+                     cm, local->component.vpt, 3, armor);
 }
 
 void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   if (heretic) {
     armor_lump_green = R_NumPatchForSpriteIndex(HERETIC_SPR_SHLD);
     armor_lump_blue = R_NumPatchForSpriteIndex(HERETIC_SPR_SHD2);
@@ -90,13 +98,15 @@ void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt, int* args, int arg
     patch_spacing = 2;
   }
   patch_spacing += MAX(R_NumPatchWidth(armor_lump_green), R_NumPatchWidth(armor_lump_blue));
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateBigArmorHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawBigArmorHC(void* data) {
+  local = data;
+
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_armor.c
+++ b/prboom2/src/dsda/hud_components/big_armor.c
@@ -67,7 +67,7 @@ static void dsda_DrawComponent(void) {
                      cm, component.vpt, 3, armor);
 }
 
-void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (heretic) {
     armor_lump_green = R_NumPatchForSpriteIndex(HERETIC_SPR_SHLD);
     armor_lump_blue = R_NumPatchForSpriteIndex(HERETIC_SPR_SHD2);
@@ -93,10 +93,10 @@ void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt, int* args, int arg
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateBigArmorHC(void) {
+void dsda_UpdateBigArmorHC(void* data) {
   return;
 }
 
-void dsda_DrawBigArmorHC(void) {
+void dsda_DrawBigArmorHC(void* data) {
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_armor.h
+++ b/prboom2/src/dsda/hud_components/big_armor.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_BIG_ARMOR__
 #define __DSDA_HUD_COMPONENT_BIG_ARMOR__
 
-void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateBigArmorHC(void);
-void dsda_DrawBigArmorHC(void);
+void dsda_InitBigArmorHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateBigArmorHC(void* data);
+void dsda_DrawBigArmorHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/big_armor_text.c
+++ b/prboom2/src/dsda/hud_components/big_armor_text.c
@@ -47,7 +47,7 @@ static void dsda_DrawComponent(void) {
                      cm, component.vpt, 3, armor);
 }
 
-void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (heretic)
     patch_delta_x = 10;
   else if (hexen)
@@ -58,10 +58,10 @@ void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateBigArmorTextHC(void) {
+void dsda_UpdateBigArmorTextHC(void* data) {
   return;
 }
 
-void dsda_DrawBigArmorTextHC(void) {
+void dsda_DrawBigArmorTextHC(void* data) {
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_armor_text.c
+++ b/prboom2/src/dsda/hud_components/big_armor_text.c
@@ -19,7 +19,12 @@
 
 #include "big_armor_text.h"
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
+
 static int patch_delta_x;
 
 static void dsda_DrawComponent(void) {
@@ -43,11 +48,14 @@ static void dsda_DrawComponent(void) {
       cm = CR_LIGHTBLUE;
   }
 
-  dsda_DrawBigNumber(component.x, component.y, patch_delta_x, 0,
-                     cm, component.vpt, 3, armor);
+  dsda_DrawBigNumber(local->component.x, local->component.y, patch_delta_x, 0,
+                     cm, local->component.vpt, 3, armor);
 }
 
 void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   if (heretic)
     patch_delta_x = 10;
   else if (hexen)
@@ -55,13 +63,15 @@ void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt, int* args, int
   else
     patch_delta_x = 14;
 
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateBigArmorTextHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawBigArmorTextHC(void* data) {
+  local = data;
+
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_armor_text.h
+++ b/prboom2/src/dsda/hud_components/big_armor_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_BIG_ARMOR_TEXT__
 #define __DSDA_HUD_COMPONENT_BIG_ARMOR_TEXT__
 
-void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateBigArmorTextHC(void);
-void dsda_DrawBigArmorTextHC(void);
+void dsda_InitBigArmorTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateBigArmorTextHC(void* data);
+void dsda_DrawBigArmorTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/big_artifact.c
+++ b/prboom2/src/dsda/hud_components/big_artifact.c
@@ -19,18 +19,27 @@
 
 #include "big_artifact.h"
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 void dsda_InitBigArtifactHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateBigArtifactHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawBigArtifactHC(void* data) {
   extern void DrawArtifact(int x, int y, int vpt);
 
-  DrawArtifact(component.x, component.y, component.vpt);
+  local = data;
+
+  DrawArtifact(local->component.x, local->component.y, local->component.vpt);
 }

--- a/prboom2/src/dsda/hud_components/big_artifact.c
+++ b/prboom2/src/dsda/hud_components/big_artifact.c
@@ -21,15 +21,15 @@
 
 static dsda_patch_component_t component;
 
-void dsda_InitBigArtifactHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitBigArtifactHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateBigArtifactHC(void) {
+void dsda_UpdateBigArtifactHC(void* data) {
   return;
 }
 
-void dsda_DrawBigArtifactHC(void) {
+void dsda_DrawBigArtifactHC(void* data) {
   extern void DrawArtifact(int x, int y, int vpt);
 
   DrawArtifact(component.x, component.y, component.vpt);

--- a/prboom2/src/dsda/hud_components/big_artifact.h
+++ b/prboom2/src/dsda/hud_components/big_artifact.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_BIG_ARTIFACT__
 #define __DSDA_HUD_COMPONENT_BIG_ARTIFACT__
 
-void dsda_InitBigArtifactHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateBigArtifactHC(void);
-void dsda_DrawBigArtifactHC(void);
+void dsda_InitBigArtifactHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateBigArtifactHC(void* data);
+void dsda_DrawBigArtifactHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/big_health.c
+++ b/prboom2/src/dsda/hud_components/big_health.c
@@ -23,7 +23,12 @@
 #define PATCH_SPACING 2
 #define PATCH_VERTICAL_SPACING 2
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
+
 static int health_lump;
 static int patch_delta_x;
 static int patch_vertical_spacing;
@@ -36,15 +41,15 @@ static void dsda_DrawComponent(void) {
   int cm;
 
   player = &players[displayplayer];
-  x = component.x;
-  y = component.y;
+  x = local->component.x;
+  y = local->component.y;
 
   cm = player->health <= hud_health_red ? CR_RED :
        player->health <= hud_health_yellow ? CR_GOLD :
        player->health <= hud_health_green ? CR_GREEN :
        CR_LIGHTBLUE;
 
-  V_DrawNumPatch(x, y, FG, health_lump, CR_DEFAULT, component.vpt);
+  V_DrawNumPatch(x, y, FG, health_lump, CR_DEFAULT, local->component.vpt);
 
   x += patch_spacing;
   y += patch_vertical_spacing;
@@ -52,10 +57,13 @@ static void dsda_DrawComponent(void) {
   health = player->health < 0 ? 0 : player->health;
 
   dsda_DrawBigNumber(x, y, patch_delta_x, 0,
-                     cm, component.vpt, 3, player->health);
+                     cm, local->component.vpt, 3, player->health);
 }
 
 void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   if (heretic) {
     health_lump = R_NumPatchForSpriteIndex(HERETIC_SPR_PTN2);
     patch_delta_x = 10;
@@ -75,13 +83,15 @@ void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt, int* args, int ar
     patch_spacing = 2;
   }
   patch_spacing += R_NumPatchWidth(health_lump);
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateBigHealthHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawBigHealthHC(void* data) {
+  local = data;
+
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_health.c
+++ b/prboom2/src/dsda/hud_components/big_health.c
@@ -55,7 +55,7 @@ static void dsda_DrawComponent(void) {
                      cm, component.vpt, 3, player->health);
 }
 
-void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (heretic) {
     health_lump = R_NumPatchForSpriteIndex(HERETIC_SPR_PTN2);
     patch_delta_x = 10;
@@ -78,10 +78,10 @@ void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt, int* args, int ar
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateBigHealthHC(void) {
+void dsda_UpdateBigHealthHC(void* data) {
   return;
 }
 
-void dsda_DrawBigHealthHC(void) {
+void dsda_DrawBigHealthHC(void* data) {
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_health.h
+++ b/prboom2/src/dsda/hud_components/big_health.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_BIG_HEALTH__
 #define __DSDA_HUD_COMPONENT_BIG_HEALTH__
 
-void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateBigHealthHC(void);
-void dsda_DrawBigHealthHC(void);
+void dsda_InitBigHealthHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateBigHealthHC(void* data);
+void dsda_DrawBigHealthHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/big_health_text.c
+++ b/prboom2/src/dsda/hud_components/big_health_text.c
@@ -37,7 +37,7 @@ static void dsda_DrawComponent(void) {
                      cm, component.vpt, 3, player->health);
 }
 
-void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (heretic)
     patch_delta_x = 10;
   else if (hexen)
@@ -48,10 +48,10 @@ void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt, int* args, in
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateBigHealthTextHC(void) {
+void dsda_UpdateBigHealthTextHC(void* data) {
   return;
 }
 
-void dsda_DrawBigHealthTextHC(void) {
+void dsda_DrawBigHealthTextHC(void* data) {
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_health_text.c
+++ b/prboom2/src/dsda/hud_components/big_health_text.c
@@ -19,7 +19,12 @@
 
 #include "big_health_text.h"
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
+
 static int patch_delta_x;
 
 static void dsda_DrawComponent(void) {
@@ -33,11 +38,14 @@ static void dsda_DrawComponent(void) {
        player->health <= hud_health_green ? CR_GREEN :
        CR_LIGHTBLUE;
 
-  dsda_DrawBigNumber(component.x, component.y, patch_delta_x, 0,
-                     cm, component.vpt, 3, player->health);
+  dsda_DrawBigNumber(local->component.x, local->component.y, patch_delta_x, 0,
+                     cm, local->component.vpt, 3, player->health);
 }
 
 void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   if (heretic)
     patch_delta_x = 10;
   else if (hexen)
@@ -45,13 +53,15 @@ void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt, int* args, in
   else
     patch_delta_x = 14;
 
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateBigHealthTextHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawBigHealthTextHC(void* data) {
+  local = data;
+
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/big_health_text.h
+++ b/prboom2/src/dsda/hud_components/big_health_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_BIG_HEALTH_TEXT__
 #define __DSDA_HUD_COMPONENT_BIG_HEALTH_TEXT__
 
-void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateBigHealthTextHC(void);
-void dsda_DrawBigHealthTextHC(void);
+void dsda_InitBigHealthTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateBigHealthTextHC(void* data);
+void dsda_DrawBigHealthTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/color_test.c
+++ b/prboom2/src/dsda/hud_components/color_test.c
@@ -19,8 +19,12 @@
 
 #include "color_test.h"
 
-static dsda_text_t component;
-static dsda_text_t component_blocky;
+typedef struct {
+  dsda_text_t component;
+  dsda_text_t component_blocky;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   snprintf(
@@ -60,14 +64,17 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitColorTestHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
-  dsda_InitBlockyHC(&component_blocky, x_offset + 64, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
 
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
+  dsda_InitBlockyHC(&local->component_blocky, x_offset + 64, y_offset, vpt);
 
-  dsda_UpdateComponentText(component_blocky.msg, sizeof(component_blocky.msg));
-  dsda_RefreshHudText(&component_blocky);
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
+
+  dsda_UpdateComponentText(local->component_blocky.msg, sizeof(local->component_blocky.msg));
+  dsda_RefreshHudText(&local->component_blocky);
 }
 
 void dsda_UpdateColorTestHC(void* data) {
@@ -75,6 +82,8 @@ void dsda_UpdateColorTestHC(void* data) {
 }
 
 void dsda_DrawColorTestHC(void* data) {
-  dsda_DrawBasicText(&component);
-  dsda_DrawBasicText(&component_blocky);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
+  dsda_DrawBasicText(&local->component_blocky);
 }

--- a/prboom2/src/dsda/hud_components/color_test.c
+++ b/prboom2/src/dsda/hud_components/color_test.c
@@ -59,7 +59,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   );
 }
 
-void dsda_InitColorTestHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitColorTestHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
   dsda_InitBlockyHC(&component_blocky, x_offset + 64, y_offset, vpt);
 
@@ -70,11 +70,11 @@ void dsda_InitColorTestHC(int x_offset, int y_offset, int vpt, int* args, int ar
   dsda_RefreshHudText(&component_blocky);
 }
 
-void dsda_UpdateColorTestHC(void) {
+void dsda_UpdateColorTestHC(void* data) {
   // nothing to do
 }
 
-void dsda_DrawColorTestHC(void) {
+void dsda_DrawColorTestHC(void* data) {
   dsda_DrawBasicText(&component);
   dsda_DrawBasicText(&component_blocky);
 }

--- a/prboom2/src/dsda/hud_components/color_test.h
+++ b/prboom2/src/dsda/hud_components/color_test.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_COLOR_TEST__
 #define __DSDA_HUD_COMPONENT_COLOR_TEST__
 
-void dsda_InitColorTestHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateColorTestHC(void);
-void dsda_DrawColorTestHC(void);
+void dsda_InitColorTestHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateColorTestHC(void* data);
+void dsda_DrawColorTestHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/command_display.c
+++ b/prboom2/src/dsda/hud_components/command_display.c
@@ -212,7 +212,8 @@ void dsda_AddCommandToCommandDisplay(ticcmd_t* cmd) {
     current_command->command = command;
   }
 
-  dsda_UpdateCommandText(&command, current_command, current_command->component, false);
+  if (current_command->component)
+    dsda_UpdateCommandText(&command, current_command, current_command->component, false);
 }
 
 static void dsda_UpdateLocal(void* data) {

--- a/prboom2/src/dsda/hud_components/command_display.c
+++ b/prboom2/src/dsda/hud_components/command_display.c
@@ -130,55 +130,56 @@ void dsda_InitCommandDisplayHC(int x_offset, int y_offset, int vpt, int* args, i
 }
 
 static void dsda_UpdateCommandText(dsda_command_t* command,
-                                   dsda_command_display_t* display_command, dboolean playback) {
+                                   dsda_command_display_t* display_command,
+                                   dsda_text_t* component, dboolean playback) {
   int length;
 
-  length = sprintf(display_command->component.msg, "%s", display_command->color);
+  length = sprintf(component->msg, "%s", display_command->color);
 
   if (playback)
-    length += sprintf(display_command->component.msg + length, " PL  ");
+    length += sprintf(component->msg + length, " PL  ");
   else if (display_command->repeat)
-    length += sprintf(display_command->component.msg + length, "x%-3d ", display_command->repeat + 1);
+    length += sprintf(component->msg + length, "x%-3d ", display_command->repeat + 1);
   else
-    length += sprintf(display_command->component.msg + length, "     ");
+    length += sprintf(component->msg + length, "     ");
 
   if (command->forwardmove > 0)
-    length += sprintf(display_command->component.msg + length, "MF%2d ", command->forwardmove);
+    length += sprintf(component->msg + length, "MF%2d ", command->forwardmove);
   else if (command->forwardmove < 0)
-    length += sprintf(display_command->component.msg + length, "MB%2d ", -command->forwardmove);
+    length += sprintf(component->msg + length, "MB%2d ", -command->forwardmove);
   else
-    length += sprintf(display_command->component.msg + length, "     ");
+    length += sprintf(component->msg + length, "     ");
 
   if (command->sidemove > 0)
-    length += sprintf(display_command->component.msg + length, "SR%2d ", command->sidemove);
+    length += sprintf(component->msg + length, "SR%2d ", command->sidemove);
   else if (command->sidemove < 0)
-    length += sprintf(display_command->component.msg + length, "SL%2d ", -command->sidemove);
+    length += sprintf(component->msg + length, "SL%2d ", -command->sidemove);
   else
-    length += sprintf(display_command->component.msg + length, "     ");
+    length += sprintf(component->msg + length, "     ");
 
   if (command->angleturn > 0)
-    length += sprintf(display_command->component.msg + length, "TL%2d ", command->angleturn);
+    length += sprintf(component->msg + length, "TL%2d ", command->angleturn);
   else if (command->angleturn < 0)
-    length += sprintf(display_command->component.msg + length, "TR%2d ", -command->angleturn);
+    length += sprintf(component->msg + length, "TR%2d ", -command->angleturn);
   else
-    length += sprintf(display_command->component.msg + length, "     ");
+    length += sprintf(component->msg + length, "     ");
 
   if (command->attack)
-    length += sprintf(display_command->component.msg + length, "A");
+    length += sprintf(component->msg + length, "A");
   else
-    length += sprintf(display_command->component.msg + length, " ");
+    length += sprintf(component->msg + length, " ");
 
   if (command->use)
-    length += sprintf(display_command->component.msg + length, "U");
+    length += sprintf(component->msg + length, "U");
   else
-    length += sprintf(display_command->component.msg + length, " ");
+    length += sprintf(component->msg + length, " ");
 
   if (command->change)
-    length += sprintf(display_command->component.msg + length, "C%d", command->change);
+    length += sprintf(component->msg + length, "C%d", command->change);
   else
-    length += sprintf(display_command->component.msg + length, "  ");
+    length += sprintf(component->msg + length, "  ");
 
-  dsda_RefreshHudText(&display_command->component);
+  dsda_RefreshHudText(component);
 }
 
 void dsda_AddCommandToCommandDisplay(ticcmd_t* cmd) {
@@ -197,16 +198,16 @@ void dsda_AddCommandToCommandDisplay(ticcmd_t* cmd) {
     current_command->command = command;
   }
 
-  dsda_UpdateCommandText(&command, current_command, false);
+  dsda_UpdateCommandText(&command, current_command, &current_command->component, false);
 }
 
 void dsda_UpdateCommandDisplayHC(void* data) {
   // nothing to do
 }
 
-static void dsda_DrawCommandDisplayLine(dsda_command_display_t* command, int offset) {
-  command->component.text.y = base_y - 8 * offset;
-  dsda_DrawBasicText(&command->component);
+static void dsda_DrawCommandDisplayLine(dsda_text_t* component, int offset) {
+  component->text.y = base_y - 8 * offset;
+  dsda_DrawBasicText(component);
 }
 
 void dsda_DrawCommandDisplayHC(void* data) {
@@ -220,14 +221,15 @@ void dsda_DrawCommandDisplayHC(void* data) {
 
     dsda_CopyBuildCmd(&next_cmd);
     dsda_TicCmdToCommand(&next_command, &next_cmd);
-    dsda_UpdateCommandText(&next_command, &next_command_display, dsda_BuildPlayback());
-    dsda_DrawCommandDisplayLine(&next_command_display, offset);
+    dsda_UpdateCommandText(&next_command, &next_command_display,
+                           &next_command_display.component, dsda_BuildPlayback());
+    dsda_DrawCommandDisplayLine(&next_command_display.component, offset);
 
     ++offset;
   }
 
   for (i = 0; i < dsda_command_history_size; ++i) {
-    dsda_DrawCommandDisplayLine(command, i + offset);
+    dsda_DrawCommandDisplayLine(&command->component, i + offset);
     command = command->prev;
   }
 }

--- a/prboom2/src/dsda/hud_components/command_display.c
+++ b/prboom2/src/dsda/hud_components/command_display.c
@@ -115,7 +115,7 @@ void dsda_InitCommandHistory(void) {
   command_history[MAX_HISTORY - 1].next = &command_history[0];
 }
 
-void dsda_InitCommandDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitCommandDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   int i;
 
   for (i = 0; i < MAX_HISTORY; ++i) {
@@ -200,7 +200,7 @@ void dsda_AddCommandToCommandDisplay(ticcmd_t* cmd) {
   dsda_UpdateCommandText(&command, current_command, false);
 }
 
-void dsda_UpdateCommandDisplayHC(void) {
+void dsda_UpdateCommandDisplayHC(void* data) {
   // nothing to do
 }
 
@@ -209,7 +209,7 @@ static void dsda_DrawCommandDisplayLine(dsda_command_display_t* command, int off
   dsda_DrawBasicText(&command->component);
 }
 
-void dsda_DrawCommandDisplayHC(void) {
+void dsda_DrawCommandDisplayHC(void* data) {
   int i;
   int offset = 0;
   dsda_command_display_t* command = current_command;

--- a/prboom2/src/dsda/hud_components/command_display.h
+++ b/prboom2/src/dsda/hud_components/command_display.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_COMMAND_DISPLAY__
 #define __DSDA_HUD_COMPONENT_COMMAND_DISPLAY__
 
-void dsda_InitCommandDisplayHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateCommandDisplayHC(void);
-void dsda_DrawCommandDisplayHC(void);
+void dsda_InitCommandDisplayHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateCommandDisplayHC(void* data);
+void dsda_DrawCommandDisplayHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/composite_time.c
+++ b/prboom2/src/dsda/hud_components/composite_time.c
@@ -19,9 +19,12 @@
 
 #include "composite_time.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+  char label[8];
+} local_component_t;
 
-static char label[8];
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   int total_time;
@@ -35,7 +38,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
       str,
       max_size,
       "%s%s%d:%02d %s%d:%05.2f ",
-      label,
+      local->label,
       dsda_TextColor(dsda_tc_exhud_total_time),
       total_time / 35 / 60,
       (total_time % (60 * 35)) / 35,
@@ -48,7 +51,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
       str,
       max_size,
       "%s%s%d:%05.2f ",
-      label,
+      local->label,
       dsda_TextColor(dsda_tc_exhud_level_time),
       leveltime / 35 / 60,
       (float) (leveltime % (60 * 35)) / 35
@@ -56,19 +59,26 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitCompositeTimeHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  if (arg_count < 1 || args[0])
-    snprintf(label, sizeof(label), "%stime ", dsda_TextColor(dsda_tc_exhud_time_label));
-  else
-    label[0] = '\0';
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
 
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  if (arg_count < 1 || args[0])
+    snprintf(local->label, sizeof(local->label), "%stime ", dsda_TextColor(dsda_tc_exhud_time_label));
+  else
+    local->label[0] = '\0';
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateCompositeTimeHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawCompositeTimeHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/composite_time.c
+++ b/prboom2/src/dsda/hud_components/composite_time.c
@@ -55,7 +55,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
     );
 }
 
-void dsda_InitCompositeTimeHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitCompositeTimeHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (arg_count < 1 || args[0])
     snprintf(label, sizeof(label), "%stime ", dsda_TextColor(dsda_tc_exhud_time_label));
   else
@@ -64,11 +64,11 @@ void dsda_InitCompositeTimeHC(int x_offset, int y_offset, int vpt, int* args, in
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateCompositeTimeHC(void) {
+void dsda_UpdateCompositeTimeHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawCompositeTimeHC(void) {
+void dsda_DrawCompositeTimeHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/composite_time.h
+++ b/prboom2/src/dsda/hud_components/composite_time.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_COMPOSITE_TIME__
 #define __DSDA_HUD_COMPONENT_COMPOSITE_TIME__
 
-void dsda_InitCompositeTimeHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateCompositeTimeHC(void);
-void dsda_DrawCompositeTimeHC(void);
+void dsda_InitCompositeTimeHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateCompositeTimeHC(void* data);
+void dsda_DrawCompositeTimeHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/coordinate_display.c
+++ b/prboom2/src/dsda/hud_components/coordinate_display.c
@@ -27,16 +27,21 @@
 #define THRESHOLD_2D 21.35
 #define THRESHOLD_3D 23.58
 
-static dsda_text_t dsda_x_display;
-static dsda_text_t dsda_y_display;
-static dsda_text_t dsda_z_display;
-static dsda_text_t dsda_a_display;
-static dsda_text_t dsda_v_display;
-static dsda_text_t dsda_vx_display;
-static dsda_text_t dsda_vy_display;
-static dsda_text_t dsda_d_display;
-static dsda_text_t dsda_dx_display;
-static dsda_text_t dsda_dy_display;
+typedef struct {
+  dsda_text_t dsda_x_display;
+  dsda_text_t dsda_y_display;
+  dsda_text_t dsda_z_display;
+  dsda_text_t dsda_a_display;
+  dsda_text_t dsda_v_display;
+  dsda_text_t dsda_vx_display;
+  dsda_text_t dsda_vy_display;
+  dsda_text_t dsda_d_display;
+  dsda_text_t dsda_dx_display;
+  dsda_text_t dsda_dy_display;
+} local_component_t;
+
+static local_component_t* local;
+
 static const char* dsda_coordinate_color;
 static const char* dsda_velocity_color;
 static const char* dsda_distance_color;
@@ -154,57 +159,64 @@ static void dsda_WriteDistance(dsda_text_t* text) {
 }
 
 void dsda_InitCoordinateDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   dsda_coordinate_color = dsda_TextColor(dsda_tc_exhud_coords_base);
 
-  dsda_InitTextHC(&dsda_x_display, x_offset, y_offset, vpt);
-  dsda_InitTextHC(&dsda_y_display, x_offset, y_offset + 8, vpt);
-  dsda_InitTextHC(&dsda_z_display, x_offset, y_offset + 16, vpt);
-  dsda_InitTextHC(&dsda_a_display, x_offset, y_offset + 24, vpt);
-  dsda_InitTextHC(&dsda_v_display, x_offset, y_offset + 40, vpt);
-  dsda_InitTextHC(&dsda_vx_display, x_offset, y_offset + 48, vpt);
-  dsda_InitTextHC(&dsda_vy_display, x_offset, y_offset + 56, vpt);
-  dsda_InitTextHC(&dsda_d_display, x_offset, y_offset + 72, vpt);
-  dsda_InitTextHC(&dsda_dx_display, x_offset, y_offset + 80, vpt);
-  dsda_InitTextHC(&dsda_dy_display, x_offset, y_offset + 88, vpt);
+  dsda_InitTextHC(&local->dsda_x_display, x_offset, y_offset, vpt);
+  dsda_InitTextHC(&local->dsda_y_display, x_offset, y_offset + 8, vpt);
+  dsda_InitTextHC(&local->dsda_z_display, x_offset, y_offset + 16, vpt);
+  dsda_InitTextHC(&local->dsda_a_display, x_offset, y_offset + 24, vpt);
+  dsda_InitTextHC(&local->dsda_v_display, x_offset, y_offset + 40, vpt);
+  dsda_InitTextHC(&local->dsda_vx_display, x_offset, y_offset + 48, vpt);
+  dsda_InitTextHC(&local->dsda_vy_display, x_offset, y_offset + 56, vpt);
+  dsda_InitTextHC(&local->dsda_d_display, x_offset, y_offset + 72, vpt);
+  dsda_InitTextHC(&local->dsda_dx_display, x_offset, y_offset + 80, vpt);
+  dsda_InitTextHC(&local->dsda_dy_display, x_offset, y_offset + 88, vpt);
 }
 
 void dsda_UpdateCoordinateDisplayHC(void* data) {
   mobj_t* mo;
 
+  local = data;
+
   mo = players[displayplayer].mo;
 
-  dsda_WriteCoordinate(&dsda_x_display, mo->x, "X");
-  dsda_WriteCoordinate(&dsda_y_display, mo->y, "Y");
-  dsda_WriteCoordinate(&dsda_z_display, mo->z, "Z");
-  dsda_WriteAngle(&dsda_a_display, mo->angle, "A");
-  dsda_WriteVelocity(&dsda_v_display);
-  dsda_WriteCoordinateSimple(&dsda_vx_display, mo->momx, "X", dsda_velocity_color);
-  dsda_WriteCoordinateSimple(&dsda_vy_display, mo->momy, "Y", dsda_velocity_color);
-  dsda_WriteDistance(&dsda_d_display);
-  dsda_WriteCoordinateSimple(&dsda_dx_display, mo->x - mo->PrevX, "X", dsda_distance_color);
-  dsda_WriteCoordinateSimple(&dsda_dy_display, mo->y - mo->PrevY, "Y", dsda_distance_color);
+  dsda_WriteCoordinate(&local->dsda_x_display, mo->x, "X");
+  dsda_WriteCoordinate(&local->dsda_y_display, mo->y, "Y");
+  dsda_WriteCoordinate(&local->dsda_z_display, mo->z, "Z");
+  dsda_WriteAngle(&local->dsda_a_display, mo->angle, "A");
+  dsda_WriteVelocity(&local->dsda_v_display);
+  dsda_WriteCoordinateSimple(&local->dsda_vx_display, mo->momx, "X", dsda_velocity_color);
+  dsda_WriteCoordinateSimple(&local->dsda_vy_display, mo->momy, "Y", dsda_velocity_color);
+  dsda_WriteDistance(&local->dsda_d_display);
+  dsda_WriteCoordinateSimple(&local->dsda_dx_display, mo->x - mo->PrevX, "X", dsda_distance_color);
+  dsda_WriteCoordinateSimple(&local->dsda_dy_display, mo->y - mo->PrevY, "Y", dsda_distance_color);
 
-  dsda_RefreshHudText(&dsda_x_display);
-  dsda_RefreshHudText(&dsda_y_display);
-  dsda_RefreshHudText(&dsda_z_display);
-  dsda_RefreshHudText(&dsda_a_display);
-  dsda_RefreshHudText(&dsda_v_display);
-  dsda_RefreshHudText(&dsda_vx_display);
-  dsda_RefreshHudText(&dsda_vy_display);
-  dsda_RefreshHudText(&dsda_d_display);
-  dsda_RefreshHudText(&dsda_dx_display);
-  dsda_RefreshHudText(&dsda_dy_display);
+  dsda_RefreshHudText(&local->dsda_x_display);
+  dsda_RefreshHudText(&local->dsda_y_display);
+  dsda_RefreshHudText(&local->dsda_z_display);
+  dsda_RefreshHudText(&local->dsda_a_display);
+  dsda_RefreshHudText(&local->dsda_v_display);
+  dsda_RefreshHudText(&local->dsda_vx_display);
+  dsda_RefreshHudText(&local->dsda_vy_display);
+  dsda_RefreshHudText(&local->dsda_d_display);
+  dsda_RefreshHudText(&local->dsda_dx_display);
+  dsda_RefreshHudText(&local->dsda_dy_display);
 }
 
 void dsda_DrawCoordinateDisplayHC(void* data) {
-  dsda_DrawBasicText(&dsda_x_display);
-  dsda_DrawBasicText(&dsda_y_display);
-  dsda_DrawBasicText(&dsda_z_display);
-  dsda_DrawBasicText(&dsda_a_display);
-  dsda_DrawBasicText(&dsda_v_display);
-  dsda_DrawBasicText(&dsda_vx_display);
-  dsda_DrawBasicText(&dsda_vy_display);
-  dsda_DrawBasicText(&dsda_d_display);
-  dsda_DrawBasicText(&dsda_dx_display);
-  dsda_DrawBasicText(&dsda_dy_display);
+  local = data;
+
+  dsda_DrawBasicText(&local->dsda_x_display);
+  dsda_DrawBasicText(&local->dsda_y_display);
+  dsda_DrawBasicText(&local->dsda_z_display);
+  dsda_DrawBasicText(&local->dsda_a_display);
+  dsda_DrawBasicText(&local->dsda_v_display);
+  dsda_DrawBasicText(&local->dsda_vx_display);
+  dsda_DrawBasicText(&local->dsda_vy_display);
+  dsda_DrawBasicText(&local->dsda_d_display);
+  dsda_DrawBasicText(&local->dsda_dx_display);
+  dsda_DrawBasicText(&local->dsda_dy_display);
 }

--- a/prboom2/src/dsda/hud_components/coordinate_display.c
+++ b/prboom2/src/dsda/hud_components/coordinate_display.c
@@ -153,7 +153,7 @@ static void dsda_WriteDistance(dsda_text_t* text) {
   dsda_RefreshHudText(text);
 }
 
-void dsda_InitCoordinateDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitCoordinateDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_coordinate_color = dsda_TextColor(dsda_tc_exhud_coords_base);
 
   dsda_InitTextHC(&dsda_x_display, x_offset, y_offset, vpt);
@@ -168,7 +168,7 @@ void dsda_InitCoordinateDisplayHC(int x_offset, int y_offset, int vpt, int* args
   dsda_InitTextHC(&dsda_dy_display, x_offset, y_offset + 88, vpt);
 }
 
-void dsda_UpdateCoordinateDisplayHC(void) {
+void dsda_UpdateCoordinateDisplayHC(void* data) {
   mobj_t* mo;
 
   mo = players[displayplayer].mo;
@@ -196,7 +196,7 @@ void dsda_UpdateCoordinateDisplayHC(void) {
   dsda_RefreshHudText(&dsda_dy_display);
 }
 
-void dsda_DrawCoordinateDisplayHC(void) {
+void dsda_DrawCoordinateDisplayHC(void* data) {
   dsda_DrawBasicText(&dsda_x_display);
   dsda_DrawBasicText(&dsda_y_display);
   dsda_DrawBasicText(&dsda_z_display);

--- a/prboom2/src/dsda/hud_components/coordinate_display.h
+++ b/prboom2/src/dsda/hud_components/coordinate_display.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_COORDINATE_DISPLAY__
 #define __DSDA_HUD_COMPONENT_COORDINATE_DISPLAY__
 
-void dsda_InitCoordinateDisplayHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateCoordinateDisplayHC(void);
-void dsda_DrawCoordinateDisplayHC(void);
+void dsda_InitCoordinateDisplayHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateCoordinateDisplayHC(void* data);
+void dsda_DrawCoordinateDisplayHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/event_split.c
+++ b/prboom2/src/dsda/hud_components/event_split.c
@@ -40,7 +40,7 @@ static dsda_split_state_t dsda_split_state[DSDA_SPLIT_CLASS_COUNT] = {
 
 static dsda_split_text_t split;
 
-void dsda_InitEventSplitHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitEventSplitHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&split.component, x_offset, y_offset, vpt);
 }
 
@@ -73,7 +73,7 @@ void dsda_AddSplit(dsda_split_class_t split_class, int lifetime) {
   dsda_RefreshHudText(&split.component);
 }
 
-void dsda_UpdateEventSplitHC(void) {
+void dsda_UpdateEventSplitHC(void* data) {
   int i;
 
   if (split.ticks > 0)
@@ -84,7 +84,7 @@ void dsda_UpdateEventSplitHC(void) {
       --dsda_split_state[i].delay;
 }
 
-void dsda_DrawEventSplitHC(void) {
+void dsda_DrawEventSplitHC(void* data) {
   if (split.ticks > 0)
     dsda_DrawBasicText(&split.component);
 }

--- a/prboom2/src/dsda/hud_components/event_split.c
+++ b/prboom2/src/dsda/hud_components/event_split.c
@@ -20,11 +20,6 @@
 #include "event_split.h"
 
 typedef struct {
-  dsda_text_t component;
-  int ticks;
-} dsda_split_text_t;
-
-typedef struct {
   const char* msg;
   int default_delay;
   int delay;
@@ -38,10 +33,19 @@ static dsda_split_state_t dsda_split_state[DSDA_SPLIT_CLASS_COUNT] = {
   [DSDA_SPLIT_SECRET] = { "Secret", 0, 0 },
 };
 
-static dsda_split_text_t split;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
+
+static int ticks;
 
 void dsda_InitEventSplitHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&split.component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_AddSplit(dsda_split_class_t split_class, int lifetime) {
@@ -59,25 +63,27 @@ void dsda_AddSplit(dsda_split_class_t split_class, int lifetime) {
 
   split_state->delay = split_state->default_delay;
 
-  split.ticks = lifetime;
+  ticks = lifetime;
 
   // To match the timer, we use the leveltime value at the end of the frame
   minutes = (leveltime + 1) / 35 / 60;
   seconds = (float)((leveltime + 1) % (60 * 35)) / 35;
   snprintf(
-    split.component.msg, sizeof(split.component.msg), "%s%d:%05.2f - %s",
+    local->component.msg, sizeof(local->component.msg), "%s%d:%05.2f - %s",
     dsda_TextColor(dsda_tc_exhud_event_split),
     minutes, seconds, split_state->msg
   );
 
-  dsda_RefreshHudText(&split.component);
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_UpdateEventSplitHC(void* data) {
   int i;
 
-  if (split.ticks > 0)
-    --split.ticks;
+  local = data;
+
+  if (ticks > 0)
+    --ticks;
 
   for (i = 0; i < DSDA_SPLIT_CLASS_COUNT; ++i)
     if (dsda_split_state[i].delay > 0)
@@ -85,6 +91,8 @@ void dsda_UpdateEventSplitHC(void* data) {
 }
 
 void dsda_DrawEventSplitHC(void* data) {
-  if (split.ticks > 0)
-    dsda_DrawBasicText(&split.component);
+  local = data;
+
+  if (ticks > 0)
+    dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/event_split.h
+++ b/prboom2/src/dsda/hud_components/event_split.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_EVENT_SPLIT__
 #define __DSDA_HUD_COMPONENT_EVENT_SPLIT__
 
-void dsda_InitEventSplitHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateEventSplitHC(void);
-void dsda_DrawEventSplitHC(void);
+void dsda_InitEventSplitHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateEventSplitHC(void* data);
+void dsda_DrawEventSplitHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/fps.c
+++ b/prboom2/src/dsda/hud_components/fps.c
@@ -34,15 +34,15 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   );
 }
 
-void dsda_InitFPSHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitFPSHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateFPSHC(void) {
+void dsda_UpdateFPSHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawFPSHC(void) {
+void dsda_DrawFPSHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/fps.c
+++ b/prboom2/src/dsda/hud_components/fps.c
@@ -19,7 +19,11 @@
 
 #include "fps.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   extern int dsda_render_stats_fps;
@@ -35,14 +39,21 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitFPSHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateFPSHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawFPSHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/fps.h
+++ b/prboom2/src/dsda/hud_components/fps.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_FPS__
 #define __DSDA_HUD_COMPONENT_FPS__
 
-void dsda_InitFPSHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateFPSHC(void);
-void dsda_DrawFPSHC(void);
+void dsda_InitFPSHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateFPSHC(void* data);
+void dsda_DrawFPSHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/health_text.c
+++ b/prboom2/src/dsda/hud_components/health_text.c
@@ -19,7 +19,11 @@
 
 #include "health_text.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   player_t* player;
@@ -39,14 +43,21 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitHealthTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateHealthTextHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawHealthTextHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/health_text.c
+++ b/prboom2/src/dsda/hud_components/health_text.c
@@ -38,15 +38,15 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   );
 }
 
-void dsda_InitHealthTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitHealthTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateHealthTextHC(void) {
+void dsda_UpdateHealthTextHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawHealthTextHC(void) {
+void dsda_DrawHealthTextHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/health_text.h
+++ b/prboom2/src/dsda/hud_components/health_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_HEALTH_TEXT__
 #define __DSDA_HUD_COMPONENT_HEALTH_TEXT__
 
-void dsda_InitHealthTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateHealthTextHC(void);
-void dsda_DrawHealthTextHC(void);
+void dsda_InitHealthTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateHealthTextHC(void* data);
+void dsda_DrawHealthTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/keys.c
+++ b/prboom2/src/dsda/hud_components/keys.c
@@ -21,7 +21,11 @@
 
 #define PATCH_DELTA_Y 10
 
-static dsda_patch_component_t component;
+typedef struct {
+  dsda_patch_component_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static int key_patch_num[NUMCARDS];
 
@@ -82,7 +86,7 @@ void drawKey(player_t* player, int* x, int* y, const char* (*key)(player_t*)) {
   name = key(player);
 
   if (name)
-    V_DrawNamePatch(*x, *y, FG, name, CR_DEFAULT, component.vpt);
+    V_DrawNamePatch(*x, *y, FG, name, CR_DEFAULT, local->component.vpt);
 
   *y += PATCH_DELTA_Y;
 }
@@ -93,15 +97,15 @@ static void dsda_DrawComponent(void) {
 
   player = &players[displayplayer];
 
-  x = component.x;
-  y = component.y;
+  x = local->component.x;
+  y = local->component.y;
 
   if (hexen) {
     int i;
 
     for (i = 0; i < NUMCARDS; ++i)
       if (player->cards[i]) {
-        V_DrawNumPatch(x, y, 0, key_patch_num[i], CR_DEFAULT, component.vpt);
+        V_DrawNumPatch(x, y, 0, key_patch_num[i], CR_DEFAULT, local->component.vpt);
         x += R_NumPatchWidth(key_patch_num[i]) + 4;
       }
 
@@ -114,6 +118,9 @@ static void dsda_DrawComponent(void) {
 }
 
 void dsda_InitKeysHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   if (hexen) {
     int i;
 
@@ -121,13 +128,15 @@ void dsda_InitKeysHC(int x_offset, int y_offset, int vpt, int* args, int arg_cou
       key_patch_num[i] = R_NumPatchForSpriteIndex(HEXEN_SPR_KEY1 + i);
   }
 
-  dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
+  dsda_InitPatchHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateKeysHC(void* data) {
-  return;
+  local = data;
 }
 
 void dsda_DrawKeysHC(void* data) {
+  local = data;
+
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/keys.c
+++ b/prboom2/src/dsda/hud_components/keys.c
@@ -113,7 +113,7 @@ static void dsda_DrawComponent(void) {
   drawKey(player, &x, &y, dsda_Key3Name);
 }
 
-void dsda_InitKeysHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitKeysHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (hexen) {
     int i;
 
@@ -124,10 +124,10 @@ void dsda_InitKeysHC(int x_offset, int y_offset, int vpt, int* args, int arg_cou
   dsda_InitPatchHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateKeysHC(void) {
+void dsda_UpdateKeysHC(void* data) {
   return;
 }
 
-void dsda_DrawKeysHC(void) {
+void dsda_DrawKeysHC(void* data) {
   dsda_DrawComponent();
 }

--- a/prboom2/src/dsda/hud_components/keys.h
+++ b/prboom2/src/dsda/hud_components/keys.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_KEYS__
 #define __DSDA_HUD_COMPONENT_KEYS__
 
-void dsda_InitKeysHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateKeysHC(void);
-void dsda_DrawKeysHC(void);
+void dsda_InitKeysHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateKeysHC(void* data);
+void dsda_DrawKeysHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/level_splits.c
+++ b/prboom2/src/dsda/hud_components/level_splits.c
@@ -21,8 +21,12 @@
 
 #include "level_splits.h"
 
-static dsda_text_t time_component;
-static dsda_text_t total_component;
+typedef struct {
+  dsda_text_t time_component;
+  dsda_text_t total_component;
+} local_component_t;
+
+static local_component_t* local;
 
 extern int leveltime, totalleveltimes;
 
@@ -65,16 +69,16 @@ static void dsda_UpdateIntermissionTime(dsda_split_t* split) {
   }
 
   snprintf(
-    time_component.msg,
-    sizeof(time_component.msg),
+    local->time_component.msg,
+    sizeof(local->time_component.msg),
     "%s%d:%05.2f",
     color, leveltime / 35 / 60,
     (float)(leveltime % (60 * 35)) / 35
   );
 
-  strcat(time_component.msg, delta);
+  strcat(local->time_component.msg, delta);
 
-  dsda_RefreshHudText(&time_component);
+  dsda_RefreshHudText(&local->time_component);
 }
 
 static void dsda_UpdateIntermissionTotal(dsda_split_t* split) {
@@ -112,36 +116,41 @@ static void dsda_UpdateIntermissionTotal(dsda_split_t* split) {
   }
 
   snprintf(
-    total_component.msg,
-    sizeof(total_component.msg),
+    local->total_component.msg,
+    sizeof(local->total_component.msg),
     "%s%d:%02d",
     color, totalleveltimes / 35 / 60,
     (totalleveltimes / 35) % 60
   );
 
-  strcat(total_component.msg, delta);
+  strcat(local->total_component.msg, delta);
 
-  dsda_RefreshHudText(&total_component);
+  dsda_RefreshHudText(&local->total_component);
 }
 
 void dsda_InitLevelSplitsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&time_component, x_offset, y_offset, vpt);
-  dsda_InitTextHC(&total_component, x_offset, y_offset + 8, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->time_component, x_offset, y_offset, vpt);
+  dsda_InitTextHC(&local->total_component, x_offset, y_offset + 8, vpt);
 }
 
 void dsda_UpdateLevelSplitsHC(void* data) {
-  // nothing to do
+  local = data;
 }
 
 void dsda_DrawLevelSplitsHC(void* data) {
   char* s;
   dsda_split_t* split;
 
+  local = data;
+
   split = dsda_CurrentSplit();
 
   dsda_UpdateIntermissionTime(split);
   dsda_UpdateIntermissionTotal(split);
 
-  dsda_DrawBasicText(&time_component);
-  dsda_DrawBasicText(&total_component);
+  dsda_DrawBasicText(&local->time_component);
+  dsda_DrawBasicText(&local->total_component);
 }

--- a/prboom2/src/dsda/hud_components/level_splits.c
+++ b/prboom2/src/dsda/hud_components/level_splits.c
@@ -124,16 +124,16 @@ static void dsda_UpdateIntermissionTotal(dsda_split_t* split) {
   dsda_RefreshHudText(&total_component);
 }
 
-void dsda_InitLevelSplitsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitLevelSplitsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&time_component, x_offset, y_offset, vpt);
   dsda_InitTextHC(&total_component, x_offset, y_offset + 8, vpt);
 }
 
-void dsda_UpdateLevelSplitsHC(void) {
+void dsda_UpdateLevelSplitsHC(void* data) {
   // nothing to do
 }
 
-void dsda_DrawLevelSplitsHC(void) {
+void dsda_DrawLevelSplitsHC(void* data) {
   char* s;
   dsda_split_t* split;
 

--- a/prboom2/src/dsda/hud_components/level_splits.h
+++ b/prboom2/src/dsda/hud_components/level_splits.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_LEVEL_SPLITS__
 #define __DSDA_HUD_COMPONENT_LEVEL_SPLITS__
 
-void dsda_InitLevelSplitsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateLevelSplitsHC(void);
-void dsda_DrawLevelSplitsHC(void);
+void dsda_InitLevelSplitsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateLevelSplitsHC(void* data);
+void dsda_DrawLevelSplitsHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/line_display.c
+++ b/prboom2/src/dsda/hud_components/line_display.c
@@ -19,40 +19,51 @@
 
 #include "line_display.h"
 
-static dsda_text_t line_display[LINE_ACTIVATION_INDEX_MAX];
+typedef struct {
+  dsda_text_t line_display[LINE_ACTIVATION_INDEX_MAX];
+} local_component_t;
+
+static local_component_t* local;
 
 void dsda_InitLineDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   int i;
 
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   for (i = 0; i < LINE_ACTIVATION_INDEX_MAX; ++i)
-    dsda_InitTextHC(&line_display[i], x_offset, y_offset + i * 8, vpt);
+    dsda_InitTextHC(&local->line_display[i], x_offset, y_offset + i * 8, vpt);
 }
 
 void dsda_UpdateLineDisplayHC(void* data) {
   int* line_ids;
   int i;
 
+  local = data;
+
   line_ids = dsda_PlayerActivatedLines();
 
   for (i = 0; line_ids[i] != -1; ++i) {
-    snprintf(line_display[i].msg, sizeof(line_display[i].msg), "%s%d",
+    snprintf(local->line_display[i].msg, sizeof(local->line_display[i].msg), "%s%d",
              dsda_TextColor(dsda_tc_exhud_line_activation), line_ids[i]);
-    dsda_RefreshHudText(&line_display[i]);
+    dsda_RefreshHudText(&local->line_display[i]);
   }
 
   if (line_ids[0] != -1 && i < LINE_ACTIVATION_INDEX_MAX) {
-    line_display[i].msg[0] = '\0';
-    dsda_RefreshHudText(&line_display[i]);
+    local->line_display[i].msg[0] = '\0';
+    dsda_RefreshHudText(&local->line_display[i]);
   }
 }
 
 void dsda_DrawLineDisplayHC(void* data) {
   int i;
 
+  local = data;
+
   for (i = 0; i < LINE_ACTIVATION_INDEX_MAX; ++i) {
-    if (!line_display[i].msg[0])
+    if (!local->line_display[i].msg[0])
       break;
 
-    dsda_DrawBasicText(&line_display[i]);
+    dsda_DrawBasicText(&local->line_display[i]);
   }
 }

--- a/prboom2/src/dsda/hud_components/line_display.c
+++ b/prboom2/src/dsda/hud_components/line_display.c
@@ -21,14 +21,14 @@
 
 static dsda_text_t line_display[LINE_ACTIVATION_INDEX_MAX];
 
-void dsda_InitLineDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitLineDisplayHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   int i;
 
   for (i = 0; i < LINE_ACTIVATION_INDEX_MAX; ++i)
     dsda_InitTextHC(&line_display[i], x_offset, y_offset + i * 8, vpt);
 }
 
-void dsda_UpdateLineDisplayHC(void) {
+void dsda_UpdateLineDisplayHC(void* data) {
   int* line_ids;
   int i;
 
@@ -46,7 +46,7 @@ void dsda_UpdateLineDisplayHC(void) {
   }
 }
 
-void dsda_DrawLineDisplayHC(void) {
+void dsda_DrawLineDisplayHC(void* data) {
   int i;
 
   for (i = 0; i < LINE_ACTIVATION_INDEX_MAX; ++i) {

--- a/prboom2/src/dsda/hud_components/line_display.h
+++ b/prboom2/src/dsda/hud_components/line_display.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_LINE_DISPLAY__
 #define __DSDA_HUD_COMPONENT_LINE_DISPLAY__
 
-void dsda_InitLineDisplayHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateLineDisplayHC(void);
-void dsda_DrawLineDisplayHC(void);
+void dsda_InitLineDisplayHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateLineDisplayHC(void* data);
+void dsda_DrawLineDisplayHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/local_time.c
+++ b/prboom2/src/dsda/hud_components/local_time.c
@@ -21,30 +21,41 @@
 
 #include "local_time.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   size_t length;
   time_t now;
-  struct tm* local;
+  struct tm* local_tm;
 
   length = snprintf(str, max_size, "%s", dsda_TextColor(dsda_tc_exhud_local_time));
 
   now = time(NULL);
-  local = localtime(&now);
+  local_tm = localtime(&now);
 
-  strftime(str + length, max_size - length, "%H:%M:%S", local);
+  strftime(str + length, max_size - length, "%H:%M:%S", local_tm);
 }
 
 void dsda_InitLocalTimeHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateLocalTimeHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawLocalTimeHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/local_time.c
+++ b/prboom2/src/dsda/hud_components/local_time.c
@@ -36,15 +36,15 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   strftime(str + length, max_size - length, "%H:%M:%S", local);
 }
 
-void dsda_InitLocalTimeHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitLocalTimeHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateLocalTimeHC(void) {
+void dsda_UpdateLocalTimeHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawLocalTimeHC(void) {
+void dsda_DrawLocalTimeHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/local_time.h
+++ b/prboom2/src/dsda/hud_components/local_time.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_LOCAL_TIME__
 #define __DSDA_HUD_COMPONENT_LOCAL_TIME__
 
-void dsda_InitLocalTimeHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateLocalTimeHC(void);
-void dsda_DrawLocalTimeHC(void);
+void dsda_InitLocalTimeHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateLocalTimeHC(void* data);
+void dsda_DrawLocalTimeHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/minimap.c
+++ b/prboom2/src/dsda/hud_components/minimap.c
@@ -21,7 +21,7 @@
 
 static int x, y, width, height, scale;
 
-void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   x = x_offset;
   y = dsda_HudComponentY(y_offset, vpt);
   width = args[0];
@@ -52,11 +52,11 @@ void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_
   V_GetWideRect(&x, &y, &width, &height, vpt);
 }
 
-void dsda_UpdateMinimapHC(void) {
+void dsda_UpdateMinimapHC(void* data) {
   // nothing to do
 }
 
-void dsda_DrawMinimapHC(void) {
+void dsda_DrawMinimapHC(void* data) {
   AM_Drawer(true);
 }
 

--- a/prboom2/src/dsda/hud_components/minimap.c
+++ b/prboom2/src/dsda/hud_components/minimap.c
@@ -19,54 +19,63 @@
 
 #include "minimap.h"
 
-static int x, y, width, height, scale;
+typedef struct {
+  int x, y, width, height, scale;
+} local_component_t;
+
+static local_component_t* local;
 
 void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  x = x_offset;
-  y = dsda_HudComponentY(y_offset, vpt);
-  width = args[0];
-  height = args[1];
-  scale = args[2];
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
 
-  if (x < 0)
-    x = 0;
+  local->x = x_offset;
+  local->y = dsda_HudComponentY(y_offset, vpt);
+  local->width = args[0];
+  local->height = args[1];
+  local->scale = args[2];
 
-  if (width <= 0 || width > 320)
-    width = 48;
+  if (local->x < 0)
+    local->x = 0;
 
-  if (x + width > 320)
-    x = 320 - width;
+  if (local->width <= 0 || local->width > 320)
+    local->width = 48;
 
-  if (y < 0)
-    y = 0;
+  if (local->x + local->width > 320)
+    local->x = 320 - local->width;
 
-  if (height <= 0 || height > 200)
-    height = 48;
+  if (local->y < 0)
+    local->y = 0;
 
-  if (y + height > 200)
-    y = 200 - height;
+  if (local->height <= 0 || local->height > 200)
+    local->height = 48;
 
-  if (scale < 64)
-    scale = 1024;
+  if (local->y + local->height > 200)
+    local->y = 200 - local->height;
 
-  V_GetWideRect(&x, &y, &width, &height, vpt);
+  if (local->scale < 64)
+    local->scale = 1024;
+
+  V_GetWideRect(&local->x, &local->y, &local->width, &local->height, vpt);
 }
 
 void dsda_UpdateMinimapHC(void* data) {
-  // nothing to do
+  local = data;
 }
 
 void dsda_DrawMinimapHC(void* data) {
+  local = data;
+
   AM_Drawer(true);
 }
 
 void dsda_CopyMinimapCoordinates(int* f_x, int* f_y, int* f_w, int* f_h) {
-  *f_x = x;
-  *f_y = y;
-  *f_w = width;
-  *f_h = height;
+  *f_x = local->x;
+  *f_y = local->y;
+  *f_w = local->width;
+  *f_h = local->height;
 }
 
 int dsda_MinimapScale(void) {
-  return scale;
+  return local->scale;
 }

--- a/prboom2/src/dsda/hud_components/minimap.c
+++ b/prboom2/src/dsda/hud_components/minimap.c
@@ -70,6 +70,9 @@ void dsda_DrawMinimapHC(void* data) {
 }
 
 void dsda_CopyMinimapCoordinates(int* f_x, int* f_y, int* f_w, int* f_h) {
+  if (!local)
+    return;
+
   *f_x = local->x;
   *f_y = local->y;
   *f_w = local->width;
@@ -77,5 +80,8 @@ void dsda_CopyMinimapCoordinates(int* f_x, int* f_y, int* f_w, int* f_h) {
 }
 
 int dsda_MinimapScale(void) {
+  if (!local)
+    return 1024;
+
   return local->scale;
 }

--- a/prboom2/src/dsda/hud_components/minimap.h
+++ b/prboom2/src/dsda/hud_components/minimap.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_MINIMAP__
 #define __DSDA_HUD_COMPONENT_MINIMAP__
 
-void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateMinimapHC(void);
-void dsda_DrawMinimapHC(void);
+void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateMinimapHC(void* data);
+void dsda_DrawMinimapHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/ready_ammo_text.c
+++ b/prboom2/src/dsda/hud_components/ready_ammo_text.c
@@ -19,7 +19,11 @@
 
 #include "ready_ammo_text.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   player_t* player;
@@ -49,14 +53,21 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitReadyAmmoTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateReadyAmmoTextHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawReadyAmmoTextHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/ready_ammo_text.c
+++ b/prboom2/src/dsda/hud_components/ready_ammo_text.c
@@ -48,15 +48,15 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   }
 }
 
-void dsda_InitReadyAmmoTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitReadyAmmoTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateReadyAmmoTextHC(void) {
+void dsda_UpdateReadyAmmoTextHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawReadyAmmoTextHC(void) {
+void dsda_DrawReadyAmmoTextHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/ready_ammo_text.h
+++ b/prboom2/src/dsda/hud_components/ready_ammo_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_READY_AMMO_TEXT__
 #define __DSDA_HUD_COMPONENT_READY_AMMO_TEXT__
 
-void dsda_InitReadyAmmoTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateReadyAmmoTextHC(void);
-void dsda_DrawReadyAmmoTextHC(void);
+void dsda_InitReadyAmmoTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateReadyAmmoTextHC(void* data);
+void dsda_DrawReadyAmmoTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/render_stats.c
+++ b/prboom2/src/dsda/hud_components/render_stats.c
@@ -21,7 +21,11 @@
 
 #include "render_stats.h"
 
-static dsda_text_t component[2];
+typedef struct {
+  dsda_text_t component[2];
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateCurrentComponentText(char* str, size_t max_size) {
   extern dsda_render_stats_t dsda_render_stats;
@@ -71,18 +75,25 @@ static void dsda_UpdateMaxComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitRenderStatsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  dsda_InitTextHC(&component[0], x_offset, y_offset, vpt);
-  dsda_InitTextHC(&component[1], x_offset, y_offset + 8, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  dsda_InitTextHC(&local->component[0], x_offset, y_offset, vpt);
+  dsda_InitTextHC(&local->component[1], x_offset, y_offset + 8, vpt);
 }
 
 void dsda_UpdateRenderStatsHC(void* data) {
-  dsda_UpdateCurrentComponentText(component[0].msg, sizeof(component[0].msg));
-  dsda_UpdateMaxComponentText(component[1].msg, sizeof(component[1].msg));
-  dsda_RefreshHudText(&component[0]);
-  dsda_RefreshHudText(&component[1]);
+  local = data;
+
+  dsda_UpdateCurrentComponentText(local->component[0].msg, sizeof(local->component[0].msg));
+  dsda_UpdateMaxComponentText(local->component[1].msg, sizeof(local->component[1].msg));
+  dsda_RefreshHudText(&local->component[0]);
+  dsda_RefreshHudText(&local->component[1]);
 }
 
 void dsda_DrawRenderStatsHC(void* data) {
-  dsda_DrawBasicText(&component[0]);
-  dsda_DrawBasicText(&component[1]);
+  local = data;
+
+  dsda_DrawBasicText(&local->component[0]);
+  dsda_DrawBasicText(&local->component[1]);
 }

--- a/prboom2/src/dsda/hud_components/render_stats.c
+++ b/prboom2/src/dsda/hud_components/render_stats.c
@@ -70,19 +70,19 @@ static void dsda_UpdateMaxComponentText(char* str, size_t max_size) {
   );
 }
 
-void dsda_InitRenderStatsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitRenderStatsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   dsda_InitTextHC(&component[0], x_offset, y_offset, vpt);
   dsda_InitTextHC(&component[1], x_offset, y_offset + 8, vpt);
 }
 
-void dsda_UpdateRenderStatsHC(void) {
+void dsda_UpdateRenderStatsHC(void* data) {
   dsda_UpdateCurrentComponentText(component[0].msg, sizeof(component[0].msg));
   dsda_UpdateMaxComponentText(component[1].msg, sizeof(component[1].msg));
   dsda_RefreshHudText(&component[0]);
   dsda_RefreshHudText(&component[1]);
 }
 
-void dsda_DrawRenderStatsHC(void) {
+void dsda_DrawRenderStatsHC(void* data) {
   dsda_DrawBasicText(&component[0]);
   dsda_DrawBasicText(&component[1]);
 }

--- a/prboom2/src/dsda/hud_components/render_stats.h
+++ b/prboom2/src/dsda/hud_components/render_stats.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_RENDER_STATS__
 #define __DSDA_HUD_COMPONENT_RENDER_STATS__
 
-void dsda_InitRenderStatsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateRenderStatsHC(void);
-void dsda_DrawRenderStatsHC(void);
+void dsda_InitRenderStatsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateRenderStatsHC(void* data);
+void dsda_DrawRenderStatsHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/speed_text.c
+++ b/prboom2/src/dsda/hud_components/speed_text.c
@@ -19,9 +19,12 @@
 
 #include "speed_text.h"
 
-static dsda_text_t component;
+typedef struct {
+  dsda_text_t component;
+  char label[9];
+} local_component_t;
 
-static char label[9];
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   int speed;
@@ -32,7 +35,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
     str,
     max_size,
     "%s%s%d%%",
-    label,
+    local->label,
     speed < 100 ? dsda_TextColor(dsda_tc_exhud_speed_slow)
                 : speed == 100 ? dsda_TextColor(dsda_tc_exhud_speed_normal)
                                : dsda_TextColor(dsda_tc_exhud_speed_fast),
@@ -41,19 +44,26 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitSpeedTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  if (arg_count < 1 || args[0])
-    snprintf(label, sizeof(label), "%sSPEED ", dsda_TextColor(dsda_tc_exhud_speed_label));
-  else
-    label[0] = '\0';
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
 
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  if (arg_count < 1 || args[0])
+    snprintf(local->label, sizeof(local->label), "%sSPEED ", dsda_TextColor(dsda_tc_exhud_speed_label));
+  else
+    local->label[0] = '\0';
+
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateSpeedTextHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawSpeedTextHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/speed_text.c
+++ b/prboom2/src/dsda/hud_components/speed_text.c
@@ -40,7 +40,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   );
 }
 
-void dsda_InitSpeedTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitSpeedTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   if (arg_count < 1 || args[0])
     snprintf(label, sizeof(label), "%sSPEED ", dsda_TextColor(dsda_tc_exhud_speed_label));
   else
@@ -49,11 +49,11 @@ void dsda_InitSpeedTextHC(int x_offset, int y_offset, int vpt, int* args, int ar
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateSpeedTextHC(void) {
+void dsda_UpdateSpeedTextHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawSpeedTextHC(void) {
+void dsda_DrawSpeedTextHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/speed_text.h
+++ b/prboom2/src/dsda/hud_components/speed_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_SPEED_TEXT__
 #define __DSDA_HUD_COMPONENT_SPEED_TEXT__
 
-void dsda_InitSpeedTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateSpeedTextHC(void);
-void dsda_DrawSpeedTextHC(void);
+void dsda_InitSpeedTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateSpeedTextHC(void* data);
+void dsda_DrawSpeedTextHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/stat_totals.c
+++ b/prboom2/src/dsda/hud_components/stat_totals.c
@@ -97,7 +97,7 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
   }
 }
 
-void dsda_InitStatTotalsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitStatTotalsHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   include_kills = args[0];
   include_items = args[1];
   include_secrets = args[2];
@@ -121,11 +121,11 @@ void dsda_InitStatTotalsHC(int x_offset, int y_offset, int vpt, int* args, int a
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateStatTotalsHC(void) {
+void dsda_UpdateStatTotalsHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawStatTotalsHC(void) {
+void dsda_DrawStatTotalsHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/stat_totals.h
+++ b/prboom2/src/dsda/hud_components/stat_totals.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_STAT_TOTALS__
 #define __DSDA_HUD_COMPONENT_STAT_TOTALS__
 
-void dsda_InitStatTotalsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateStatTotalsHC(void);
-void dsda_DrawStatTotalsHC(void);
+void dsda_InitStatTotalsHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateStatTotalsHC(void* data);
+void dsda_DrawStatTotalsHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/tracker.c
+++ b/prboom2/src/dsda/hud_components/tracker.c
@@ -32,14 +32,14 @@ extern dsda_tracker_t dsda_tracker[TRACKER_LIMIT];
 
 dsda_text_t component[TRACKER_LIMIT];
 
-void dsda_InitTrackerHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitTrackerHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   int i;
 
   for (i = 0; i < TRACKER_LIMIT; ++i)
     dsda_InitTextHC(&component[i], x_offset, y_offset + i * 8, vpt);
 }
 
-void dsda_UpdateTrackerHC(void) {
+void dsda_UpdateTrackerHC(void* data) {
   int i;
 
   for (i = 0; i < TRACKER_LIMIT; ++i) {
@@ -68,7 +68,7 @@ void dsda_UpdateTrackerHC(void) {
   }
 }
 
-void dsda_DrawTrackerHC(void) {
+void dsda_DrawTrackerHC(void* data) {
   int i;
 
   for (i = 0; i < TRACKER_LIMIT; ++i)

--- a/prboom2/src/dsda/hud_components/tracker.c
+++ b/prboom2/src/dsda/hud_components/tracker.c
@@ -30,47 +30,58 @@
 
 extern dsda_tracker_t dsda_tracker[TRACKER_LIMIT];
 
-dsda_text_t component[TRACKER_LIMIT];
+typedef struct {
+  dsda_text_t component[TRACKER_LIMIT];
+} local_component_t;
+
+static local_component_t* local;
 
 void dsda_InitTrackerHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   int i;
 
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
   for (i = 0; i < TRACKER_LIMIT; ++i)
-    dsda_InitTextHC(&component[i], x_offset, y_offset + i * 8, vpt);
+    dsda_InitTextHC(&local->component[i], x_offset, y_offset + i * 8, vpt);
 }
 
 void dsda_UpdateTrackerHC(void* data) {
   int i;
 
+  local = data;
+
   for (i = 0; i < TRACKER_LIMIT; ++i) {
     switch (dsda_tracker[i].type) {
       case dsda_tracker_nothing:
-        dsda_NullHC(component[i].msg, sizeof(component[i].msg));
+        dsda_NullHC(local->component[i].msg, sizeof(local->component[i].msg));
         break;
       case dsda_tracker_line:
-        dsda_LineTrackerHC(component[i].msg, sizeof(component[i].msg), dsda_tracker[i].id);
+        dsda_LineTrackerHC(local->component[i].msg, sizeof(local->component[i].msg), dsda_tracker[i].id);
         break;
       case dsda_tracker_line_distance:
-        dsda_LineDistanceTrackerHC(component[i].msg, sizeof(component[i].msg), dsda_tracker[i].id);
+        dsda_LineDistanceTrackerHC(local->component[i].msg, sizeof(local->component[i].msg), dsda_tracker[i].id);
         break;
       case dsda_tracker_sector:
-        dsda_SectorTrackerHC(component[i].msg, sizeof(component[i].msg), dsda_tracker[i].id);
+        dsda_SectorTrackerHC(local->component[i].msg, sizeof(local->component[i].msg), dsda_tracker[i].id);
         break;
       case dsda_tracker_mobj:
-        dsda_MobjTrackerHC(component[i].msg, sizeof(component[i].msg), dsda_tracker[i].id, dsda_tracker[i].mobj);
+        dsda_MobjTrackerHC(local->component[i].msg, sizeof(local->component[i].msg), dsda_tracker[i].id, dsda_tracker[i].mobj);
         break;
       case dsda_tracker_player:
-        dsda_PlayerTrackerHC(component[i].msg, sizeof(component[i].msg));
+        dsda_PlayerTrackerHC(local->component[i].msg, sizeof(local->component[i].msg));
         break;
     }
 
-    dsda_RefreshHudText(&component[i]);
+    dsda_RefreshHudText(&local->component[i]);
   }
 }
 
 void dsda_DrawTrackerHC(void* data) {
   int i;
 
+  local = data;
+
   for (i = 0; i < TRACKER_LIMIT; ++i)
-    dsda_DrawBasicText(&component[i]);
+    dsda_DrawBasicText(&local->component[i]);
 }

--- a/prboom2/src/dsda/hud_components/tracker.h
+++ b/prboom2/src/dsda/hud_components/tracker.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_TRACKER__
 #define __DSDA_HUD_COMPONENT_TRACKER__
 
-void dsda_InitTrackerHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateTrackerHC(void);
-void dsda_DrawTrackerHC(void);
+void dsda_InitTrackerHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateTrackerHC(void* data);
+void dsda_DrawTrackerHC(void* data);
 
 #endif

--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -73,16 +73,16 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
     );
 }
 
-void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count) {
+void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   grid = args[0];
   dsda_InitTextHC(&component, x_offset, y_offset, vpt);
 }
 
-void dsda_UpdateWeaponTextHC(void) {
+void dsda_UpdateWeaponTextHC(void* data) {
   dsda_UpdateComponentText(component.msg, sizeof(component.msg));
   dsda_RefreshHudText(&component);
 }
 
-void dsda_DrawWeaponTextHC(void) {
+void dsda_DrawWeaponTextHC(void* data) {
   dsda_DrawBasicText(&component);
 }

--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -19,15 +19,19 @@
 
 #include "weapon_text.h"
 
-static dsda_text_t component;
-static dboolean grid;
+typedef struct {
+  dsda_text_t component;
+  dboolean grid;
+} local_component_t;
+
+static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
   player_t* player;
 
   player = &players[displayplayer];
 
-  if (grid)
+  if (local->grid)
     snprintf(
       str,
       max_size,
@@ -74,15 +78,22 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  grid = args[0];
-  dsda_InitTextHC(&component, x_offset, y_offset, vpt);
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  local->grid = args[0];
+  dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 
 void dsda_UpdateWeaponTextHC(void* data) {
-  dsda_UpdateComponentText(component.msg, sizeof(component.msg));
-  dsda_RefreshHudText(&component);
+  local = data;
+
+  dsda_UpdateComponentText(local->component.msg, sizeof(local->component.msg));
+  dsda_RefreshHudText(&local->component);
 }
 
 void dsda_DrawWeaponTextHC(void* data) {
-  dsda_DrawBasicText(&component);
+  local = data;
+
+  dsda_DrawBasicText(&local->component);
 }

--- a/prboom2/src/dsda/hud_components/weapon_text.h
+++ b/prboom2/src/dsda/hud_components/weapon_text.h
@@ -18,8 +18,8 @@
 #ifndef __DSDA_HUD_COMPONENT_WEAPON_TEXT__
 #define __DSDA_HUD_COMPONENT_WEAPON_TEXT__
 
-void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count);
-void dsda_UpdateWeaponTextHC(void);
-void dsda_DrawWeaponTextHC(void);
+void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt_flags, int* args, int arg_count, void** data);
+void dsda_UpdateWeaponTextHC(void* data);
+void dsda_DrawWeaponTextHC(void* data);
 
 #endif

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2056,12 +2056,6 @@ void P_SpawnPlayer (int n, const mapthing_t* mthing)
   else if (p == &players[consoleplayer])
     playerkeys = 0;
 
-  if (mthing->type - 1 == consoleplayer)
-  {
-    ST_Start(); // wake up the status bar
-    HU_Start(); // wake up the heads up text
-  }
-
   R_SmoothPlaying_Reset(p); // e6y
 }
 


### PR DESCRIPTION
Previously, hud configs were parsed every time the view changed and only one instance of each component could exist. This PR changes it to parse the config only once and store multiple copies as needed. This is a precursor to extracting all the remaining hud components and creating an automap config as well.