### PR TITLE
gl_sky: use BindSkyTexture for sky caps

### DIFF
--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -339,7 +339,7 @@ void gld_DrawSkyCaps(void)
   {
     if (dsda_MouseLook())
     {
-      gld_BindTexture(SkyBox.wall.gltexture, 0);
+      gld_BindSkyTexture(SkyBox.wall.gltexture);
 
       glMatrixMode(GL_TEXTURE);
       glPushMatrix();


### PR DESCRIPTION
This ensures indexed light mode lookups are done.

Closes #155