### PR TITLE
Fix various incorrect format specifiers

### DIFF
--- a/prboom2/src/MUSIC/oplplayer.c
+++ b/prboom2/src/MUSIC/oplplayer.c
@@ -1362,7 +1362,7 @@ static const void *I_OPL_RegisterSong(const void *data, unsigned len)
     // time numbers we have to traverse the tracks and everything
     if (mf.len < 100)
     {
-        lprintf (LO_WARN, "I_OPL_RegisterSong: Very short MIDI (%I64i bytes)\n", (long long)mf.len);
+        lprintf (LO_WARN, "I_OPL_RegisterSong: Very short MIDI (%llu bytes)\n", (unsigned long long)mf.len);
         return NULL;
     }
 

--- a/prboom2/src/dsda/exdemo.c
+++ b/prboom2/src/dsda/exdemo.c
@@ -410,7 +410,7 @@ static void DemoEx_GetFeatures(const wadinfo_t* header) {
   if (!str)
     return;
 
-  if (sscanf(str, "%*[^\n]\n%llx-%32s", &exdemo.features, signature) == 2) {
+  if (sscanf(str, "%*[^\n]\n%" PRIx64 "-%32s", &exdemo.features, signature) == 2) {
     byte features[FEATURE_SIZE];
     dsda_cksum_t cksum;
 
@@ -444,7 +444,7 @@ static void DemoEx_AddFeatures(wadtbl_t* wadtbl) {
   buffer_length = strlen(cksum.string) + strlen(description) + 24;
   buffer = Z_Calloc(buffer_length, 1);
 
-  snprintf(buffer, buffer_length, "%s\n0x%016llx-%s", description, features, cksum.string);
+  snprintf(buffer, buffer_length, "%s\n0x%016" PRIx64 "-%s", description, features, cksum.string);
 
   AddPWADTableLump(wadtbl, DEMOEX_FEATURE_LUMPNAME, buffer, buffer_length);
 

--- a/prboom2/src/info.h
+++ b/prboom2/src/info.h
@@ -5761,7 +5761,7 @@ typedef enum
  * Definition of the state (frames) structure                       *
  ********************************************************************/
 
-typedef int64_t statearg_t;
+typedef long long int statearg_t;
 
 typedef struct
 {


### PR DESCRIPTION
This fixes various GCC warnings.  `%I64` is an MSVC-specific extension.  `long long int` and `long int` might have the same size on x86-64, but the compiler considers them distinct types and warns that you used the wrong specifier.  There is a standard `printf` specifier for `size_t` (`%zu`), but MSVC doesn't support it, so the cast in `oplplayer.c` is still required.