### PR TITLE
Fix abs integer truncation warning

### DIFF
--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -46,12 +46,12 @@
 
 typedef struct camera_s
 {
-  long x;
-  long y;
-  long z;
-  long PrevX;
-  long PrevY;
-  long PrevZ;
+  fixed_t x;
+  fixed_t y;
+  fixed_t z;
+  fixed_t PrevX;
+  fixed_t PrevY;
+  fixed_t PrevZ;
   angle_t angle;
   angle_t pitch;
   angle_t PrevAngle;


### PR DESCRIPTION
Alternatively, these types need to be changed to `int`/`int32_t`.  `long` is 64 bit on x86-64 Linux!

-----------------------

Use labs for long arguments.