### PR TITLE
heretic:sb: fix misplaced paren

### DIFF
--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -267,7 +267,7 @@ void SB_Init(void)
     }
     else
     {
-        LumpLIFEGEM = W_GetNumForName("LIFEGEM0" + consoleplayer);
+        LumpLIFEGEM = W_GetNumForName("LIFEGEM0") + consoleplayer;
     }
     LumpLTFCTOP = W_GetNumForName("LTFCTOP");
     LumpRTFCTOP = W_GetNumForName("RTFCTOP");


### PR DESCRIPTION
Not sure it matters since it only affects netgames, but it's a real logic bug that clang complains about.