### PR TITLE
gl_sky: fix precision loss detected by clang warning

### DIFF
--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -437,7 +437,7 @@ void gld_DrawScreenSkybox(void)
   {
     #define WRAPANGLE (ANGLE_MAX/4)
 
-    float fU1, fU2, fV1, fV2;
+    double fU1, fU2, fV1, fV2;
     GLWall *wall = &SkyBox.wall;
     angle_t angle;
     int i, k;
@@ -479,12 +479,12 @@ void gld_DrawScreenSkybox(void)
 
     if (wall->flag == GLDWF_SKYFLIP)
     {
-      fU1 = -((float)angle + SkyBox.x_offset) / (WRAPANGLE - 1);
+      fU1 = -((double)angle + SkyBox.x_offset) / (WRAPANGLE - 1);
       fU2 = fU1 + 1.0f / k;
     }
     else
     {
-      fU2 = ((float)angle + SkyBox.x_offset) / (WRAPANGLE - 1);
+      fU2 = ((double)angle + SkyBox.x_offset) / (WRAPANGLE - 1);
       fU1 = fU2 + 1.0f / k;
     }
 
@@ -594,7 +594,7 @@ static void SkyVertex(vbo_vertex_t *vbo, int r, int c)
   static fixed_t scale = 10000 << FRACBITS;
   static angle_t maxSideAngle = ANG180 / 3;
 
-  angle_t topAngle= (angle_t)(c / (float)columns * ANGLE_MAX);
+  angle_t topAngle= (angle_t)(c / (double)columns * ANGLE_MAX);
   angle_t sideAngle = maxSideAngle * (rows - r) / rows;
   fixed_t height = finesine[sideAngle>>ANGLETOFINESHIFT];
   fixed_t realRadius = FixedMul(scale, finecosine[sideAngle>>ANGLETOFINESHIFT]);


### PR DESCRIPTION
Note sure how much of a difference this makes in practice, but some of these integer values were getting rounded off when cast to float (especially `ANGLE_MAX`).

-------------

Float doesn't have enough significand bits to represent large 32-bit integers, so use double instead.