### PR TITLE
CMake: Avoid using C-only warnings on C++ files.

### DIFF
--- a/prboom2/cmake/GetAvailableFlags.cmake
+++ b/prboom2/cmake/GetAvailableFlags.cmake
@@ -28,24 +28,28 @@ function(get_supported_warnings outvar)
     return()
   endif()
 
-  include(CheckCCompilerFlag)
   set(_warnings
       "-Wall"
       "-Wno-missing-field-initializers"
       "-Wwrite-strings"
       "-Wundef"
-      "-Wbad-function-cast"
       "-Wcast-align"
       "-Wcast-qual"
-      "-Wdeclaration-after-statement"
       "-Wpointer-arith"
       "-Wno-unused-function"
       "-Wno-switch"
       "-Wno-sign-compare"
-      "-Wno-pointer-sign"
-      "-Wtype-limits"
-      "-Wabsolute-value")
+      "-Wtype-limits")
   check_flags_list("${_warnings}" "_supported_warnings")
+
+  # The following warnings do not apply to C++ and should be treated separately
+  set(_c_only_warnings "-Wabsolute-value" "-Wno-pointer-sign"
+                       "-Wdeclaration-after-statement" "-Wbad-function-cast")
+  check_flags_list("${_c_only_warnings}" "_supported_c_warnings")
+  foreach(_c_warning IN LISTS _supported_c_warnings)
+    list(APPEND _supported_warnings $<$<COMPILE_LANGUAGE:C>:${_c_warning}>)
+  endforeach()
+
   set("${outvar}"
       "${_supported_warnings}"
       PARENT_SCOPE)


### PR DESCRIPTION
Following #275, warnings were applied to C++ files. Unfortunately some of them do not apply to C++ with GCC providing the message: `warning: command-line option '-Wbad-function-cast' is valid for C/ObjC but not for C++`.

To address this, wrap the C-only warnings in the `$<$<COMPILE_LANGUAGE:C>:flag>` expression, so they only apply to C files.

Thanks @kraflab for pointing it out and providing the list of warnings affected!