### PR TITLE
CMake: Better install on Windows

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -162,8 +162,16 @@ if(WITH_PORTMIDI)
     endif()
 endif()
 
-set(DOOMWADDIR "${CMAKE_INSTALL_PREFIX}/share/games/doom" CACHE PATH "Path to look for WAD files")
-set(DSDAPWADDIR "${DOOMWADDIR}" CACHE PATH "Path to install DSDA-Doom internal WAD")
+if(WIN32)
+    set(DEFAULT_WAD_DIR ".")
+else()
+    set(DEFAULT_WAD_DIR "${CMAKE_INSTALL_DATADIR}/games/doom")
+endif()
+
+set(DSDAPWADDIR "${DEFAULT_WAD_DIR}" CACHE STRING "Path to install DSDA-Doom internal WAD, relative to CMAKE_INSTALL_PREFIX.")
+set(DOOMWADDIR "${CMAKE_INSTALL_PREFIX}/${DEFAULT_WAD_DIR}" CACHE PATH "Path to look for WAD files.")
+
+set(FULL_PWAD_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${DSDAPWADDIR}")
 
 option(SIMPLECHECKS "Enable checks which only impose significant overhead if a posible error is detected" ON)
 

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -209,3 +209,7 @@ add_subdirectory(src)
 if(NOT CMAKE_CROSSCOMPILING)
     export(TARGETS ${CROSS_EXPORTS} FILE "${CMAKE_BINARY_DIR}/ImportExecutables.cmake")
 endif()
+
+if(WIN32)
+    include(CPack)
+endif()

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -30,6 +30,10 @@ if(WITH_VORBISFILE)
     list(APPEND VCPKG_MANIFEST_FEATURES "libvorbis")
 endif()
 
+# Automatically install dependencies
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+set(X_VCPKG_APPLOCAL_DEPS_INSTALL TRUE)
+
 project("dsda-doom" VERSION 0.25.6)
 
 # Set a default build type if none was specified

--- a/prboom2/cmake/config.h.cin
+++ b/prboom2/cmake/config.h.cin
@@ -5,7 +5,7 @@
 #cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
 
 #cmakedefine DOOMWADDIR "@DOOMWADDIR@"
-#cmakedefine DSDAPWADDIR "@DSDAPWADDIR@"
+#cmakedefine DSDAPWADDIR "@FULL_PWAD_INSTALL_DIR@"
 
 #cmakedefine WORDS_BIGENDIAN
 

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -589,7 +589,12 @@ function(AddGameExecutable TARGET SOURCES)
         )
     endif()
 
-    install(TARGETS ${TARGET} COMPONENT "Game executable" RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+    if(WIN32)
+        set(DSDA_BINARY_INSTALL_DIR ".")
+    else()
+        set(DSDA_BINARY_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
+    endif()
+    install(TARGETS ${TARGET} COMPONENT "Game executable" RUNTIME DESTINATION "${DSDA_BINARY_INSTALL_DIR}")
 
     target_link_libraries(${TARGET} PRIVATE
         ${OPENGL_gl_LIBRARY}


### PR DESCRIPTION
On Windows, using the `GNUInstallDirs` does not play well with dsda. It is typical to have a flat layout instead such as:
```
dsda-doom/
|- dsda-doom.exe
|- dsda-doom.wad
```

Setting `X_VCPKG_APPLOCAL_DEPS_INSTALL` lets vcpkg copy the needed dlls when installing, this also applies to CPack since it uses the install command under the hood. For this to work properly, `CMP0077` needs to be set to NEW, and setting the variable must happen before the call to `project()`

Additionally, for CPack to work properly, `dsda-doom.wad` needs to be installed using a path relative to the install prefix instead of an absolute path. For this to work, it is preferable to limit `DSDAPWADDIR` to be a path under the install prefix (you probably would not want to install it outside of the prefix anyway).

This latter change **will** break buildscripts that set `DSDAPWADDIR` to a full path. But it's a trivial change (e.g. Homebrew's recipe will just need to change `#{libexec}` to `libexec`), and it is an option only really meant to be used by package managers.