### PR TITLE
Pragma cleanup

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -72,11 +72,6 @@
 #include "e6y.h"
 #include "i_system.h"
 
-#ifdef __GNUG__
-#pragma implementation "i_system.h"
-#endif
-#include "i_system.h"
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/prboom2/src/d_items.c
+++ b/prboom2/src/d_items.c
@@ -36,9 +36,6 @@
 #include "doomtype.h"
 #include "info.h"
 
-#ifdef __GNUG__
-#pragma implementation "d_items.h"
-#endif
 #include "d_items.h"
 
 

--- a/prboom2/src/d_items.h
+++ b/prboom2/src/d_items.h
@@ -37,10 +37,6 @@
 
 #include "doomdef.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 //
 // Internal weapon flags
 //

--- a/prboom2/src/d_main.h
+++ b/prboom2/src/d_main.h
@@ -38,10 +38,6 @@
 #include "d_event.h"
 #include "w_wad.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /* CPhipps - removed wadfiles[] stuff to w_wad.h */
 
 //jff 1/24/98 make command line copies of play modes available

--- a/prboom2/src/d_net.h
+++ b/prboom2/src/d_net.h
@@ -36,10 +36,6 @@
 
 #include "d_player.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 // Create any new ticcmds
 void FakeNetUpdate (void);
 

--- a/prboom2/src/d_player.h
+++ b/prboom2/src/d_player.h
@@ -53,11 +53,6 @@
 // as commands per game tick.
 #include "d_ticcmd.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
-
 //
 // Player states.
 //

--- a/prboom2/src/d_think.h
+++ b/prboom2/src/d_think.h
@@ -36,10 +36,6 @@
 #ifndef __D_THINK__
 #define __D_THINK__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /*
  * Experimental stuff.
  * To compile this as "ANSI C with classes"

--- a/prboom2/src/d_ticcmd.h
+++ b/prboom2/src/d_ticcmd.h
@@ -36,10 +36,6 @@
 
 #include "doomtype.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 typedef struct {
   byte actions;
   byte save_slot;

--- a/prboom2/src/doomdef.c
+++ b/prboom2/src/doomdef.c
@@ -33,10 +33,6 @@
  *-----------------------------------------------------------------------------
  */
 
-#ifdef __GNUG__
-#pragma implementation "doomdef.h"
-#endif
-
 #include "doomdef.h"
 
 // Location for any defines turned variables.

--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -32,9 +32,6 @@
  *-----------------------------------------------------------------------------
  */
 
-#ifdef __GNUG__
-#pragma implementation "doomstat.h"
-#endif
 #include "doomstat.h"
 
 #include "dsda/map_format.h"

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -42,10 +42,6 @@
 // We need the playr data structure as well.
 #include "d_player.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 // ------------------------
 // Command line parameters.
 //

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -384,17 +384,18 @@ dboolean dsda_StartDemoSegment(const char* demo_name) {
 const byte* dsda_EvaluateDemoStartPoint(const byte* demo_p) {
   if (dsda_demo_version && dsda_demo_header_data.flags & DF_FROM_KEYFRAME) {
     dsda_key_frame_t key_frame;
+    union
+    {
+      const byte* cb;
+      byte* b;
+    } u = {demo_p};
 
     memset(&key_frame, 0, sizeof(key_frame));
 
     memcpy(&key_frame.buffer_length, demo_p, sizeof(key_frame.buffer_length));
     demo_p += sizeof(key_frame.buffer_length);
 
-    // Is it worth creating a redundant read-only version?
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
-    key_frame.buffer = demo_p;
-    #pragma GCC diagnostic pop
+    key_frame.buffer = u.b;
 
     dsda_RestoreKeyFrame(&key_frame, false);
     demo_p += key_frame.buffer_length;

--- a/prboom2/src/dstrings.c
+++ b/prboom2/src/dstrings.c
@@ -32,9 +32,6 @@
  *-----------------------------------------------------------------------------
  */
 
-#ifdef __GNUG__
-#pragma implementation "dstrings.h"
-#endif
 #include "dstrings.h"
 
 

--- a/prboom2/src/i_system.h
+++ b/prboom2/src/i_system.h
@@ -43,10 +43,6 @@
 
 #include "m_fixed.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 #ifdef _MSC_VER
 #define    F_OK    0    /* Check for file existence */
 #define    W_OK    2    /* Check for write permission */

--- a/prboom2/src/i_video.h
+++ b/prboom2/src/i_video.h
@@ -44,10 +44,6 @@
 #include "v_video.h"
 #include "SDL.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 extern SDL_Window *sdl_window;
 extern SDL_Renderer *sdl_renderer;
 

--- a/prboom2/src/info.c
+++ b/prboom2/src/info.c
@@ -44,9 +44,6 @@
 #include "p_enemy.h"
 #include "p_pspr.h"
 
-#ifdef __GNUG__
-#pragma implementation "info.h"
-#endif
 #include "info.h"
 
 void A_BetaSkullAttack(); // killough 10/98: beta lost souls attacked different

--- a/prboom2/src/m_bbox.c
+++ b/prboom2/src/m_bbox.c
@@ -34,9 +34,6 @@
  *
  *-----------------------------------------------------------------------------*/
 
-#ifdef __GNUG__
-#pragma implementation "m_bbox.h"
-#endif
 #include "m_bbox.h"
 
 void M_ClearBox (fixed_t *box)

--- a/prboom2/src/m_swap.h
+++ b/prboom2/src/m_swap.h
@@ -35,10 +35,6 @@
 #ifndef __M_SWAP__
 #define __M_SWAP__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /* CPhipps - now the endianness handling, converting input or output to/from
  * the machine's endianness to that wanted for this type of I/O
  *

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -49,9 +49,6 @@
 #include "p_pspr.h"
 #include "p_user.h"
 
-#ifdef __GNUG__
-#pragma implementation "p_inter.h"
-#endif
 #include "p_inter.h"
 #include "e6y.h"//e6y
 

--- a/prboom2/src/p_inter.h
+++ b/prboom2/src/p_inter.h
@@ -37,10 +37,6 @@
 #include "d_player.h"
 #include "p_mobj.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /* Ty 03/09/98 Moved to an int in p_inter.c for deh and externalization */
 #define MAXHEALTH maxhealth
 

--- a/prboom2/src/p_pspr.h
+++ b/prboom2/src/p_pspr.h
@@ -49,10 +49,6 @@
 
 #include "info.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /*
  * Frame flags:
  * handles maximum brightness (torches, muzzle flare, light sources)

--- a/prboom2/src/p_saveg.h
+++ b/prboom2/src/p_saveg.h
@@ -34,10 +34,6 @@
 #ifndef __P_SAVEG__
 #define __P_SAVEG__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 #include "doomtype.h"
 
 #define SAVEVERSION 1

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1186,6 +1186,11 @@ static byte *P_DecompressData(const byte **data, int *len)
   byte *output;
   int outlen, err;
   z_stream *zstream;
+  union
+  {
+    const byte* cd;
+    byte* d;
+  } u = {*data};
 
   // first estimate for compression rate:
   // output buffer size == 2.5 * input size
@@ -1197,10 +1202,7 @@ static byte *P_DecompressData(const byte **data, int *len)
   memset(zstream, 0, sizeof(*zstream));
 
   // Evidently next_in is the wrong type for legacy reasons
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
-  zstream->next_in = *data;
-  #pragma GCC diagnostic pop
+  zstream->next_in = u.d;
   zstream->avail_in = *len;
   zstream->next_out = output;
   zstream->avail_out = outlen;

--- a/prboom2/src/p_setup.h
+++ b/prboom2/src/p_setup.h
@@ -36,10 +36,6 @@
 
 #include "p_mobj.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 void P_SetupLevel(int episode, int map, int playermask, skill_t skill);
 void P_Init(void);               /* Called by startup code. */
 

--- a/prboom2/src/p_tick.h
+++ b/prboom2/src/p_tick.h
@@ -36,10 +36,6 @@
 #include "d_think.h"
 #include "p_mobj.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /* Called by C_Ticker, can call G_PlayerExited.
  * Carries out all thinking of monsters and players. */
 

--- a/prboom2/src/r_bsp.h
+++ b/prboom2/src/r_bsp.h
@@ -34,10 +34,6 @@
 #ifndef __R_BSP__
 #define __R_BSP__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 extern seg_t    *curline;
 extern side_t   *sidedef;
 extern line_t   *linedef;

--- a/prboom2/src/r_data.h
+++ b/prboom2/src/r_data.h
@@ -40,10 +40,6 @@
 #include "r_state.h"
 #include "r_patch.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 // A single patch from a texture definition, basically
 // a rectangular area within the texture rectangle.
 typedef struct

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -48,10 +48,6 @@
 // SECTORS do store MObjs anyway.
 #include "p_mobj.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 // Silhouette, needed for clipping Segs (mainly)
 // and sprites representing things.
 #define SIL_NONE    0

--- a/prboom2/src/r_draw.h
+++ b/prboom2/src/r_draw.h
@@ -36,10 +36,6 @@
 
 #include "r_defs.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 enum column_pipeline_e {
   RDC_PIPELINE_STANDARD,
   RDC_PIPELINE_TRANSLUCENT,

--- a/prboom2/src/r_main.h
+++ b/prboom2/src/r_main.h
@@ -37,10 +37,6 @@
 #include "d_player.h"
 #include "r_data.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 extern int r_frame_count;
 
 //

--- a/prboom2/src/r_plane.h
+++ b/prboom2/src/r_plane.h
@@ -36,10 +36,6 @@
 
 #include "r_data.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /* killough 10/98: special mask indicates sky flat comes from sidedef */
 #define PL_SKYFLAT (0x80000000)
 

--- a/prboom2/src/r_segs.h
+++ b/prboom2/src/r_segs.h
@@ -34,10 +34,6 @@
 #ifndef __R_SEGS__
 #define __R_SEGS__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 void R_RenderMaskedSegRange(drawseg_t *ds, int x1, int x2);
 void R_StoreWallRange(const int start, const int stop);
 

--- a/prboom2/src/r_sky.c
+++ b/prboom2/src/r_sky.c
@@ -34,9 +34,6 @@
  *
  *-----------------------------------------------------------------------------*/
 
-#ifdef __GNUG__
-#pragma implementation "r_sky.h"
-#endif
 #include "r_sky.h"
 #include "r_main.h"
 #include "e6y.h"

--- a/prboom2/src/r_sky.h
+++ b/prboom2/src/r_sky.h
@@ -36,10 +36,6 @@
 
 #include "m_fixed.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 /* The sky map is 256*128*4 maps. */
 #define ANGLETOSKYSHIFT         22
 

--- a/prboom2/src/r_state.h
+++ b/prboom2/src/r_state.h
@@ -39,11 +39,6 @@
 #include "d_player.h"
 #include "r_data.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
-
 //
 // Refresh internal data structures,
 //  for rendering.

--- a/prboom2/src/r_things.h
+++ b/prboom2/src/r_things.h
@@ -34,10 +34,6 @@
 #ifndef __R_THINGS__
 #define __R_THINGS__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 #include "r_draw.h"
 
 #define MINZ        (FRACUNIT*4)

--- a/prboom2/src/s_advsound.h
+++ b/prboom2/src/s_advsound.h
@@ -37,10 +37,6 @@
 #include "p_mobj.h"
 #include "sounds.h"
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 //
 //MUSINFO lump
 //

--- a/prboom2/src/s_sound.h
+++ b/prboom2/src/s_sound.h
@@ -34,10 +34,6 @@
 #ifndef __S_SOUND__
 #define __S_SOUND__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 #include "doomtype.h"
 #include "p_mobj.h"
 #include "r_defs.h"

--- a/prboom2/src/scanner.cpp
+++ b/prboom2/src/scanner.cpp
@@ -201,18 +201,13 @@ void Scanner::ExpandState()
 
 void Scanner::SaveState(Scanner &savedstate)
 {
-	#pragma GCC diagnostic push
-	#pragma GCC diagnostic ignored "-Wclass-memaccess"
-
 	// This saves the entire parser state except for the data pointer.
 	if (savedstate.string != NULL) free(savedstate.string);
 	if (savedstate.nextState.string != NULL) free(savedstate.nextState.string);
-	memcpy(&savedstate, this, sizeof(*this));
+	savedstate = *this;
 	savedstate.string = strdup(string);
 	savedstate.nextState.string = strdup(nextState.string);
 	savedstate.data = NULL;
-
-	#pragma GCC diagnostic pop
 }
 
 void Scanner::RestoreState(Scanner &savedstate)

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -40,9 +40,6 @@
 #include "doomstat.h"
 #include "doomtype.h"
 
-#ifdef __GNUG__
-#pragma implementation "w_wad.h"
-#endif
 #include "w_wad.h"
 #include "z_zone.h"
 #include "lprintf.h"

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -47,9 +47,6 @@
 #include "doomstat.h"
 #include "doomtype.h"
 
-#ifdef __GNUG__
-#pragma implementation "w_wad.h"
-#endif
 #include "w_wad.h"
 #include "z_zone.h"
 #include "lprintf.h"

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -51,9 +51,6 @@
 #include "m_file.h"
 #include "r_main.h"
 
-#ifdef __GNUG__
-#pragma implementation "w_wad.h"
-#endif
 #include "w_wad.h"
 #include "lprintf.h"
 #include "e6y.h"

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -35,10 +35,6 @@
 #ifndef __W_WAD__
 #define __W_WAD__
 
-#ifdef __GNUG__
-#pragma interface
-#endif
-
 #include <stddef.h>
 
 //


### PR DESCRIPTION
This tries to remove a lot of ugly pragmas where possible:

- According to the manual, the GCC interface/implementation pragmas only apply to C++ and have been deprecated since GCC 2.7.2, which was released in *1995*.  Just remove them.
- scanner.cpp went out of its way to memcpy a non-trival class and disable the relevant warning.  Just use the copy assignment operator instead, which generates *identical* assembly on gcc/clang. :man_shrugging:
- Use union type punning to brute-force discard `const`.  This is somewhat less ugly than a bunch of pragmas, and works on all compilers.  Unions are basically the escape hatch for doing questionable casts that would otherwise trigger warnings or undefined behavior.