### PR TITLE
Enum cleanup

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -206,16 +206,14 @@ void gld_MultisamplingSet(void)
 
 int gld_LoadGLDefs(const char * defsLump)
 {
-  enum
+  typedef enum
   {
     TAG_SKYBOX,
     TAG_DETAIL,
-
-    TAG_MAX
-  };
+  } gldef_type_e;
 
   // these are the core types available in the *DEFS lump
-  static const char *CoreKeywords[TAG_MAX + 1] =
+  static const char *CoreKeywords[] =
   {
     "skybox",
     "detail",
@@ -232,7 +230,8 @@ int gld_LoadGLDefs(const char * defsLump)
     // Get actor class name.
     while (SC_GetString())
     {
-      switch (SC_MatchString(CoreKeywords))
+      gldef_type_e type = SC_MatchString(CoreKeywords);
+      switch (type)
       {
       case TAG_SKYBOX:
         result = true;

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -6287,7 +6287,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
         dboolean raise_or_lower;
         byte index;
 
-        static floor_e ceiling_type[2][7] = {
+        static ceiling_e ceiling_type[2][7] = {
           {
             ceilLowerByValue,
             ceilLowerToHighest,
@@ -6412,7 +6412,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
       break;
     case zl_generic_stairs:
       {
-        stairs_e type;
+        stair_e type;
 
         type = (args[3] & 1) ? stairBuildUp : stairBuildDown;
         buttonSuccess = EV_BuildZDoomStairs(args[0], type, line,


### PR DESCRIPTION
Fixes various warnings caused by enums being mixed up with each other or plain integers.