### PR TITLE
Use union to discard const

### DIFF
--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -384,17 +384,18 @@ dboolean dsda_StartDemoSegment(const char* demo_name) {
 const byte* dsda_EvaluateDemoStartPoint(const byte* demo_p) {
   if (dsda_demo_version && dsda_demo_header_data.flags & DF_FROM_KEYFRAME) {
     dsda_key_frame_t key_frame;
+    union
+    {
+      const byte* cb;
+      byte* b;
+    } u = {demo_p};
 
     memset(&key_frame, 0, sizeof(key_frame));
 
     memcpy(&key_frame.buffer_length, demo_p, sizeof(key_frame.buffer_length));
     demo_p += sizeof(key_frame.buffer_length);
 
-    // Is it worth creating a redundant read-only version?
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
-    key_frame.buffer = demo_p;
-    #pragma GCC diagnostic pop
+    key_frame.buffer = u.b;
 
     dsda_RestoreKeyFrame(&key_frame, false);
     demo_p += key_frame.buffer_length;

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1186,6 +1186,11 @@ static byte *P_DecompressData(const byte **data, int *len)
   byte *output;
   int outlen, err;
   z_stream *zstream;
+  union
+  {
+    const byte* cd;
+    byte* d;
+  } u = {*data};
 
   // first estimate for compression rate:
   // output buffer size == 2.5 * input size
@@ -1197,10 +1202,7 @@ static byte *P_DecompressData(const byte **data, int *len)
   memset(zstream, 0, sizeof(*zstream));
 
   // Evidently next_in is the wrong type for legacy reasons
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdiscarded-qualifiers"
-  zstream->next_in = *data;
-  #pragma GCC diagnostic pop
+  zstream->next_in = u.d;
   zstream->avail_in = *len;
   zstream->next_out = output;
   zstream->avail_out = outlen;


### PR DESCRIPTION
Cleaner than pragmas (sort of), works on all compilers