### PR TITLE
Fix compilation with clang-cl

### DIFF
--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -41,7 +41,7 @@
 #endif
 
 // killough 4/25/98: Make gcc extensions mean nothing on other compilers
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(__clang__)
 #define __attribute__(x)
 #endif
 

--- a/prboom2/src/dsda/utility.h
+++ b/prboom2/src/dsda/utility.h
@@ -23,7 +23,7 @@
 #include "d_ticcmd.h"
 #include "tables.h"
 
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(__clang__)
 #define __attribute__(x)
 #endif
 

--- a/prboom2/src/lprintf.h
+++ b/prboom2/src/lprintf.h
@@ -46,7 +46,7 @@ typedef enum
   LO_DEBUG=8,
 } OutputLevels;
 
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(__clang__)
 #define __attribute__(x)
 #endif
 

--- a/prboom2/src/z_zone.h
+++ b/prboom2/src/z_zone.h
@@ -39,7 +39,7 @@
 #ifndef __Z_ZONE__
 #define __Z_ZONE__
 
-#ifndef __GNUC__
+#if !defined(__GNUC__) && !defined(__clang__)
 #define __attribute__(x)
 #endif
 


### PR DESCRIPTION
`clang-cl` allows using MS dev tools with the clang compiler. It defines `_MSC_VER` but still relies on `__attribute__` extensions in its headers. Perhaps we should move these macros into one header and remake them like in Choco: https://github.com/chocolate-doom/chocolate-doom/blob/4bfbd986b2831945250930c2c7e80896254cab16/src/doomtype.h#L68 