### PR TITLE
Remove redundant miniseg field

### DIFF
--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -557,8 +557,6 @@ static void P_LoadSegs (int lump)
       //li->v1 = &vertexes[v1];
       //li->v2 = &vertexes[v2];
 
-      li->miniseg = false; // figgi -- there are no minisegs in classic BSP nodes
-
       // e6y: moved down, see below
       //li->length  = GetDistance(li->v2->x - li->v1->x, li->v2->y - li->v1->y);
 
@@ -691,8 +689,6 @@ static void P_LoadSegs_V4(int lump)
     v1 = LittleLong(ml->v1);
     v2 = LittleLong(ml->v2);
 
-    li->miniseg = false; // figgi -- there are no minisegs in classic BSP nodes
-
     li->angle = (LittleShort(ml->angle))<<16;
     li->offset =(LittleShort(ml->offset))<<16;
     linedef = (unsigned short)LittleShort(ml->linedef);
@@ -817,7 +813,6 @@ static void P_LoadGLSegs(int lump)
     {
       ldef = &lines[ml->linedef];
       segs[i].linedef = ldef;
-      segs[i].miniseg = false;
       segs[i].angle = R_PointToAngle2(segs[i].v1->x,segs[i].v1->y,segs[i].v2->x,segs[i].v2->y);
 
       segs[i].sidedef = &sides[ldef->sidenum[ml->side]];
@@ -834,7 +829,6 @@ static void P_LoadGLSegs(int lump)
     }
     else
     {
-      segs[i].miniseg = true;
       segs[i].angle  = 0;
       segs[i].offset  = 0;
       segs[i].linedef = NULL;
@@ -1250,8 +1244,6 @@ static void P_LoadZSegs (const byte *data)
     v1 = LittleLong(ml->v1);
     v2 = LittleLong(ml->v2);
 
-    li->miniseg = false;
-
     linedef = (unsigned short)LittleShort(ml->linedef);
 
     //e6y: check for wrong indexes
@@ -1362,8 +1354,6 @@ static void P_LoadGLZSegs(const byte *data, int type)
       {
         line_t *ldef;
 
-        seg->miniseg = false;
-
         if ((unsigned int) line >= (unsigned int) numlines)
         {
           I_Error("P_LoadGLZSegs: seg %d, %d references a non-existent linedef %d",
@@ -1409,7 +1399,6 @@ static void P_LoadGLZSegs(const byte *data, int type)
       }
       else
       {
-        seg->miniseg = true;
         seg->angle = 0;
         seg->offset = 0;
         seg->linedef = NULL;
@@ -1426,7 +1415,7 @@ static void P_LoadGLZSegs(const byte *data, int type)
 
       seg = &segs[subsectors[i].firstline + j];
 
-      if (!seg->miniseg)
+      if (seg->linedef)
         seg->angle = R_PointToAngle2(segs[i].v1->x, segs[i].v1->y, segs[i].v2->x, segs[i].v2->y);
     }
   }
@@ -3265,7 +3254,7 @@ static void P_RemoveSlimeTrails(void)         // killough 10/98
   {
     const line_t *l;
 
-    if (segs[i].miniseg == true)        //figgi -- skip minisegs
+    if (!segs[i].linedef)
       break;                            //e6y: probably 'continue;'?
 
     l = segs[i].linedef;            // The parent linedef

--- a/prboom2/src/r_bsp.c
+++ b/prboom2/src/r_bsp.c
@@ -434,8 +434,7 @@ static void R_AddLine (seg_t *line)
       maxdrawsegs = newmax;
     }
 
-    if(curline->miniseg == false) // figgi -- skip minisegs
-      curline->linedef->flags |= ML_MAPPED;
+    curline->linedef->flags |= ML_MAPPED;
 
     // proff 11/99: the rest of the calculations is not needed for OpenGL
     ds_p++->curline = curline;
@@ -849,7 +848,7 @@ static void R_Subsector(int num)
   line = &segs[sub->firstline];
   while (count--)
   {
-    if (line->miniseg == false)
+    if (line->linedef)
       R_AddLine (line);
     line++;
     curline = NULL; /* cph 2001/11/18 - must clear curline now we're done with it, so R_ColourMap doesn't try using it for other things */

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -397,10 +397,6 @@ typedef struct
   side_t* sidedef;
   line_t* linedef;
 
-  // figgi -- needed for glnodes
-  dboolean   miniseg;
-
-
   // Sector references.
   // Could be retrieved from linedef, too
   // (but that would be slower -- killough)

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -686,7 +686,7 @@ void R_StoreWallRange(const int start, const int stop)
     maxdrawsegs = newmax;
   }
 
-  if(curline->miniseg == false) // figgi -- skip minisegs
+  if(curline->linedef)
     curline->linedef->flags |= ML_MAPPED;
 
   if (V_IsOpenGLMode())


### PR DESCRIPTION
Measurements on my experimental branch showed that performance on large maps is sensitive to `seg_t` cache performance, so I'm trying to optimize its size a bit.  Removing this field is low-hanging fruit since it's completely redundant (minisegs have a `NULL` linedef, so check that instead).