### PR TITLE
Docs: Update dependencies lists.

### DIFF
--- a/docs/guides/building_on_macos.md
+++ b/docs/guides/building_on_macos.md
@@ -13,7 +13,7 @@ On arm64 machines, brew will be installed in `/opt/homebrew`.
 ## Install Build Dependencies
 Install cmake, SDL2 and additional dependencies for DSDA-Doom:
 ```
-brew install cmake pcre sdl2 sdl2_image sdl2_mixer fluid-synth portmidi mad dumb libvorbis
+brew install cmake pkgconf dumb fluid-synth libvorbis libzip mad portmidi sdl2 sdl2_image sdl2_mixer
 ```
 ## Build DSDA-Doom
 Make a clone of the DSDA-Doom Git repository:

--- a/docs/guides/building_on_windows.md
+++ b/docs/guides/building_on_windows.md
@@ -144,7 +144,7 @@ pacman -S mingw-w64-ucrt-x86_64-gcc cmake git ninja pkgconf
 Additionally, you will need the following external libraries:
 
 ```
-pacman -S mingw-w64-ucrt-x86_64-dumb mingw-w64-ucrt-x86_64-fluidsynth mingw-w64-ucrt-x86_64-libmad mingw-w64-ucrt-x86_64-libvorbis mingw-w64-ucrt-x86_64-portmidi mingw-w64-ucrt-x86_64-SDL2 mingw-w64-ucrt-x86_64-SDL2_image mingw-w64-ucrt-x86_64-SDL2_mixer
+pacman -S mingw-w64-ucrt-x86_64-dumb mingw-w64-ucrt-x86_64-fluidsynth mingw-w64-ucrt-x86_64-libmad mingw-w64-ucrt-x86_64-libvorbis mingw-w64-ucrt-x86_64-libzip mingw-w64-ucrt-x86_64-portmidi mingw-w64-ucrt-x86_64-SDL2 mingw-w64-ucrt-x86_64-SDL2_image mingw-w64-ucrt-x86_64-SDL2_mixer
 ```
 
 ### Building


### PR DESCRIPTION
Updates the build guides to account for changes in the dependencies:
- Add `libzip` to all guides.
- On the macOS guide specifically:
  - Remove `pcre` since it's no longer needed.
  - Add `pkgconf` to help searching dependencies without CMake configs.