### PR TITLE
seg_t: shrink length field

### DIFF
--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -3307,7 +3307,7 @@ static void R_CalcSegsLength(void)
     int64_t dx = (int64_t)li->v2->px - li->v1->px;
     int64_t dy = (int64_t)li->v2->py - li->v1->py;
     length = sqrt((double)dx*dx + (double)dy*dy);
-    li->length = (int64_t)length;
+    li->halflength = (uint32_t)(length / 2.0);
     // [crispy] re-calculate angle used for rendering
     li->pangle = R_PointToAngleEx2(li->v1->px, li->v1->py, li->v2->px, li->v2->py);
   }

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -390,19 +390,17 @@ typedef struct msecnode_s
 typedef struct
 {
   vertex_t *v1, *v2;
-  fixed_t offset;
-  angle_t angle;
-  angle_t pangle; // re-calculated angle used for rendering
-  int64_t length; // fix long wall wobble
   side_t* sidedef;
   line_t* linedef;
-
   // Sector references.
   // Could be retrieved from linedef, too
   // (but that would be slower -- killough)
   // backsector is NULL for one sided lines
-
   sector_t *frontsector, *backsector;
+  fixed_t offset;
+  angle_t angle;
+  angle_t pangle; // re-calculated angle used for rendering
+  uint32_t halflength; // fix long wall wobble
 } seg_t;
 
 typedef struct ssline_s

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -718,7 +718,7 @@ void R_StoreWallRange(const int start, const int stop)
   dy = ((int64_t)curline->v2->py - curline->v1->py) >> shift_bits;
   dx1 = ((int64_t)viewx - curline->v1->px) >> shift_bits;
   dy1 = ((int64_t)viewy - curline->v1->py) >> shift_bits;
-  len = curline->length >> shift_bits;
+  len = curline->halflength; // No need to shift
 
   dist = (((dy * dx1 - dx * dy1) / len) << shift_bits);
   rw_distance = (fixed_t)BETWEEN(INT_MIN, INT_MAX, dist);


### PR DESCRIPTION
Another easy `seg_t` optimization.  The `length` field can be reduce to a `uint32_t` based on the following observation:

- The maximum hypotenuse of a seg is `sqrt(2) * (INT32_MAX - INT32_MIN)` i.e. `sqrt(2) * UINT32_MAX`
- The hypotenuse is always shifted to the right by 1 before using it, so the result can be pre-divided by `2.0`
- `2.0` is greater than `sqrt(2)`, so the result always fits in `uint32_t`.

This also reorders the fields to ensure there is no struct padding on any platform.

4 bytes (and a bit shift :upside_down_face:) saved for free.