### PR TITLE
CMake: Add an option to enable LTO when available.

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.9)
 
 option(WITH_DUMB "Use DUMB if available" ON)
 if(WITH_DUMB)
@@ -65,6 +65,16 @@ option(CMAKE_FIND_PACKAGE_PREFER_CONFIG "Search for package config before using 
 if(VCPKG_TOOLCHAIN)
     set(ENV{PKG_CONFIG_PATH} "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/pkgconfig")
 endif()
+
+if(POLICY CMP0069)
+    cmake_policy(SET CMP0069 NEW)
+endif()
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT HAVE_LTO)
+
+include(CMakeDependentOption)
+cmake_dependent_option(ENABLE_LTO "Use link-time optimisation" ON "HAVE_LTO" OFF)
 
 set(PACKAGE_NAME "${PROJECT_NAME}")
 set(PACKAGE_TARNAME "dsda-doom")

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -549,6 +549,7 @@ function(AddGameExecutable TARGET SOURCES)
 
     set_target_properties(${TARGET} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${DSDA_OUTPUT_PATH}
+        INTERPROCEDURAL_OPTIMIZATION ${ENABLE_LTO}
     )
 
     if(HAVE_LIBSDL2_IMAGE)


### PR DESCRIPTION
Add an option in CMake `ENABLE_LTO` to control LTO. This option is automatically hidden and set to `OFF` when the compiler does not support it.

This would bump the minimum CMake version to 3.9.

---

Resolves #298.