### PR TITLE
Update docs for LTO, and turn it off by default.

### DIFF
--- a/docs/guides/building_on_macos.md
+++ b/docs/guides/building_on_macos.md
@@ -22,20 +22,16 @@ git clone https://github.com/kraflab/dsda-doom.git
 ```
 Prepare the build folder, generate the build system, and compile:
 ```
-cd dsda-doom/prboom2
-mkdir build
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make
+cd dsda-doom
+cmake -Sprboom2 -Bbuild -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=ON
+cmake --build build
 ```
-Note: Instead of `make`, consider using `make -j4` or `make -j$(nproc)` to speed up compiling.
 
 The newly built binaries are located in the build folder.
 
 ## Collect DYLIB Files
 Create a release folder next to the build folder and copy the Binaries and .wad files to it:
 ```
-cd ..
 mkdir release
 cp ./build/dsda-doom ./release/dsda-doom
 cp ./build/*.wad ./release/

--- a/docs/guides/building_on_windows.md
+++ b/docs/guides/building_on_windows.md
@@ -64,7 +64,7 @@ Run the CMake configuration:
 
 ```
 cd dsda-doom
-cmake -Sprboom2 -Bbuild -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
+cmake -Sprboom2 -Bbuild -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" -DENABLE_LTO=ON
 ```
 
 During this step, vcpkg will build all the dependencies. If vcpkg does not get invoked or CMake fails at finding the dependencies, delete the build directory and make sure the path to the `vcpkg.cmake` toolchain is correct.
@@ -161,6 +161,8 @@ Run the CMake configuration:
 cd dsda-doom
 cmake -Sprboom2 -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release
 ```
+
+CMake does not appear to support LTO properly for MinGW GCC which results in much longer linking time. Consider only enabling it when making a release.
 
 And finally, build the project:
 

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -74,7 +74,7 @@ include(CheckIPOSupported)
 check_ipo_supported(RESULT HAVE_LTO)
 
 include(CMakeDependentOption)
-cmake_dependent_option(ENABLE_LTO "Use link-time optimisation" ON "HAVE_LTO" OFF)
+cmake_dependent_option(ENABLE_LTO "Use link-time optimisation" OFF "HAVE_LTO" OFF)
 
 set(PACKAGE_NAME "${PROJECT_NAME}")
 set(PACKAGE_TARNAME "dsda-doom")


### PR DESCRIPTION
- Turn LTO off by default.
- Update the documentation to include LTO:
  - Enable LTO for macOS and MSVC
  - Add a notice about the issues with LTO when using MinGW GCC.