### PR TITLE
Fix macOS CI.

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -123,7 +123,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew upgrade
           brew install \
             cmake \
             ninja \


### PR DESCRIPTION
Fixes #328 

---

Seems like running `brew upgrade` in CI does not work because of `go`.

Since `brew install` automatically upgrades the dependencies of the installed packages, we can get away with not running `brew upgrade`.