### PR TITLE
build: remove -Wcast-align for now

### DIFF
--- a/prboom2/cmake/GetAvailableFlags.cmake
+++ b/prboom2/cmake/GetAvailableFlags.cmake
@@ -30,17 +30,16 @@ function(get_supported_warnings outvar)
 
   set(_warnings
       "-Wall"
-      "-Wno-missing-field-initializers"
       "-Wwrite-strings"
       "-Wundef"
-      "-Wcast-align"
+      "-Wtype-limits"
       "-Wcast-qual"
       "-Wpointer-arith"
       "-Wno-unused-function"
       "-Wno-switch"
       "-Wno-sign-compare"
       "-Wno-format-truncation"
-      "-Wtype-limits")
+      "-Wno-missing-field-initializers")
   check_flags_list("${_warnings}" "_supported_warnings")
 
   # The following warnings do not apply to C++ and should be treated separately


### PR DESCRIPTION
There is too much code doing alignment-breaking casts at the moment.

Also reorder flags list so all -Wno- options occur at the end