### PR TITLE
CMake: Track and install DLL dependencies outside vcpkg

### DIFF
--- a/docs/guides/building_on_windows.md
+++ b/docs/guides/building_on_windows.md
@@ -108,27 +108,6 @@ If you use the CMake Tools extension, you will need to:
 "toolchainFile": "C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
 ```
 
-### Installing and Packaging
-
-This section will assume the build directory is `build`, note that by default on Visual Studio the build directory is different.
-
-To install the project, run:
-
-```
-cmake --install build --config Release
-```
-
-This will install all the necessary runtime files to the directory `CMAKE_INSTALL_PREFIX` is set to. This can also be overwritten by passing `--prefix C:/my/custom/prefix`. Prefer a directory that does not need priviledges to write files to, otherwise editing config and saving the game may fail.
-
-To package the project, run:
-
-```
-cd build
-cpack -G ZIP -C Release
-```
-
-This will produce a zip archive in your build directory named `dsda-doom-<version>-win64` which contains everything necessary to run the game.
-
 ## Building with MSYS2
 
 At the time of writing, MSYS2 provides seven different environments. This section assumes you are using UCRT64 (`mingw-w64-ucrt-x86_64-`). If you wish to use another one, refer to [the package naming](https://www.msys2.org/docs/package-naming/) and replace the UCRT64 prefix with the one of your choice.
@@ -177,11 +156,28 @@ cd build
 ./dsda-doom
 ```
 
-While you may be able to run the executable from the MSYS2 terminal with no issue, it is likely going to fail if you click on the executable or run it from another terminal with "X.dll could not be found" errors. Similarly, running CMake's install or packaging with CPack will not copy over the necessary DLLs. You can use the following command to get a list of all the DLLs that need to be copied next to the executable:
+You will only be able to run the executable from the MSYS2 Terminal directly as the necessary DLLs are not copied over to the build directory.
+
+## Installing and Packaging
+
+This section will assume the build directory is `build`, note that by default on Visual Studio the build directory is different.
+
+To install the project, run:
 
 ```
-ldd dsda-doom | grep "bin"
+cmake --install build --config Release
 ```
+
+This will install all the necessary runtime files to the directory `CMAKE_INSTALL_PREFIX` is set to. This can also be overwritten by passing `--prefix C:/my/custom/prefix`. Prefer a directory that does not need priviledges to write files to, otherwise editing config and saving the game may fail.
+
+To package the project, run:
+
+```
+cd build
+cpack -G ZIP -C Release
+```
+
+This will produce a zip archive in your build directory named `dsda-doom-<version>-win64` which contains everything necessary to run the game.
 
 ## Troubleshooting
 

--- a/prboom2/cmake/FindDUMB.cmake
+++ b/prboom2/cmake/FindDUMB.cmake
@@ -23,6 +23,10 @@ This will define the following variables:
   Include directories needed to use DUMB.
 ``DUMB_LIBRARIES``
   Libraries needed to link to DUMB.
+``DUMB_DLL``
+  Path to the DUMB Windows runtime (any config).
+``DUMB_LIBRARY``
+  Path to the DUMB library (any config).
 
 Cache Variables
 ^^^^^^^^^^^^^^^
@@ -31,8 +35,14 @@ The following cache variables may also be set:
 
 ``DUMB_INCLUDE_DIR``
   The directory containing ``dumb.h``.
-``DUMB_LIBRARY``
-  The path to the DUMB library.
+``DUMB_DLL_RELEASE``
+  The path to the DUMB Windows runtime (release config).
+``DUMB_DLL_DEBUG``
+  The path to the DUMB Windows runtime (debug config).
+``DUMB_LIBRARY_RELEASE``
+  The path to the DUMB library (release config).
+``DUMB_LIBRARY_DEBUG``
+  The path to the DUMB library (debug config).
 
 #]=======================================================================]
 
@@ -42,61 +52,122 @@ pkg_check_modules(PC_DUMB QUIET dumb)
 find_path(
   DUMB_INCLUDE_DIR
   NAMES dumb.h
-  HINTS ${PC_DUMB_INCLUDEDIR})
+  HINTS "${PC_DUMB_INCLUDEDIR}"
+)
+
+find_file(
+  DUMB_DLL_RELEASE
+  NAMES dumb.dll libdumb.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_DUMB_PREFIX}"
+)
+
+find_file(
+  DUMB_DLL_DEBUG
+  NAMES dumbd.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_DUMB_PREFIX}"
+)
+
+include(SelectDllConfigurations)
+select_dll_configurations(DUMB)
 
 find_library(
   DUMB_LIBRARY_RELEASE
   NAMES dumb
-  HINTS ${PC_DUMB_LIBDIR})
+  HINTS "${PC_DUMB_LIBDIR}"
+)
 
 find_library(
   DUMB_LIBRARY_DEBUG
   NAMES dumbd
-  HINTS ${PC_DUMB_LIBDIR})
+  HINTS "${PC_DUMB_LIBDIR}"
+)
 
 include(SelectLibraryConfigurations)
 select_library_configurations(DUMB)
 
-if(PC_DUMB_FOUND)
-  get_flags_from_pkg_config("${DUMB_LIBRARY}" "PC_DUMB" "_dumb")
+if(DUMB_DLL OR DUMB_LIBRARY MATCHES ".so|.dylib")
+  set(_dumb_library_type SHARED)
+else()
+  set(_dumb_library_type STATIC)
 endif()
 
+get_flags_from_pkg_config("${_dumb_library_type}" "PC_DUMB" "_dumb")
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(DUMB REQUIRED_VARS "DUMB_LIBRARY"
-                                                     "DUMB_INCLUDE_DIR")
+find_package_handle_standard_args(
+  DUMB
+  REQUIRED_VARS "DUMB_LIBRARY" "DUMB_INCLUDE_DIR"
+)
 
 if(DUMB_FOUND)
   if(NOT TARGET DUMB::DUMB)
-    add_library(DUMB::DUMB UNKNOWN IMPORTED)
+    add_library(DUMB::DUMB ${_dumb_library_type} IMPORTED)
     set_target_properties(
       DUMB::DUMB
-      PROPERTIES IMPORTED_LOCATION "${DUMB_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${DUMB_INCLUDE_DIR}"
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${DUMB_INCLUDE_DIR}"
                  INTERFACE_COMPILE_OPTIONS "${_dumb_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_dumb_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_dumb_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_dumb_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_dumb_link_options}"
+    )
+    if(DUMB_DLL)
+      set_target_properties(
+        DUMB::DUMB 
+        PROPERTIES IMPORTED_LOCATION "${DUMB_DLL}"
+                   IMPORTED_IMPLIB "${DUMB_LIBRARY}"
+      )
+    else()
+      set_target_properties(
+        DUMB::DUMB
+        PROPERTIES IMPORTED_LOCATION "${DUMB_LIBRARY}"
+      )
+    endif()
   endif()
 
   if(DUMB_LIBRARY_RELEASE)
     set_property(
       TARGET DUMB::DUMB
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-    set_target_properties(DUMB::DUMB PROPERTIES IMPORTED_LOCATION_RELEASE
-                                                "${DUMB_LIBRARY_RELEASE}")
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
+    if(DUMB_DLL_RELEASE)
+      set_target_properties(
+        DUMB::DUMB
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${DUMB_DLL_RELEASE}"
+                   IMPORTED_IMPLIB_RELEASE "${DUMB_LIBRARY_RELEASE}"
+      )
+    else()
+      set_target_properties(
+        DUMB::DUMB
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${DUMB_LIBRARY_RELEASE}"
+      )
+    endif()
   endif()
   if(DUMB_LIBRARY_DEBUG)
     set_property(
       TARGET DUMB::DUMB
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-    set_target_properties(DUMB::DUMB PROPERTIES IMPORTED_LOCATION_DEBUG
-                                                "${DUMB_LIBRARY_DEBUG}")
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
+    if(DUMB_DLL_DEBUG)
+      set_target_properties(
+        DUMB::DUMB PROPERTIES IMPORTED_LOCATION_DEBUG "${DUMB_DLL_DEBUG}"
+                              IMPORTED_IMPLIB_DEBUG "${DUMB_LIBRARY_DEBUG}"
+      )
+    else()
+      set_target_properties(
+        DUMB::DUMB 
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${DUMB_LIBRARY_DEBUG}"
+      )
+    endif()
   endif()
 
   set(DUMB_LIBRARIES DUMB::DUMB)
   set(DUMB_INCLUDE_DIRS "${DUMB_INCLUDE_DIR}")
 endif()
 
-mark_as_advanced(DUMB_INCLUDE_DIR DUMB_LIBRARY)
+mark_as_advanced(
+  DUMB_INCLUDE_DIR
+)

--- a/prboom2/cmake/FindFluidSynth.cmake
+++ b/prboom2/cmake/FindFluidSynth.cmake
@@ -31,6 +31,8 @@ The following cache variables may also be set:
 
 ``FluidSynth_INCLUDE_DIR``
   The directory containing ``FluidSynth.h``.
+``FluidSynth_DLL``
+  The path to the FluidSynth Windows runtime.
 ``FluidSynth_LIBRARY``
   The path to the FluidSynth library.
 
@@ -42,37 +44,67 @@ pkg_check_modules(PC_FLUIDSYNTH QUIET fluidsynth)
 find_path(
   FluidSynth_INCLUDE_DIR
   NAMES fluidsynth.h
-  HINTS ${PC_FLUIDSYNTH_INCLUDEDIR})
+  HINTS "${PC_FLUIDSYNTH_INCLUDEDIR}"
+)
+
+find_file(
+  FluidSynth_DLL
+  NAMES fluidsynth.dll libfluidsynth.dll libfluidsynth-3.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_FLUIDSYNTH_PREFIX}"
+)
 
 find_library(
   FluidSynth_LIBRARY
   NAMES fluidsynth libfluidsynth
-  HINTS ${PC_FLUIDSYNTH_LIBDIR})
+  HINTS "${PC_FLUIDSYNTH_LIBDIR}"
+)
 
-if(PC_FLUIDSYNTH_FOUND)
-  get_flags_from_pkg_config("${FluidSynth_LIBRARY}" "PC_FLUIDSYNTH"
-                            "_fluidsynth")
+if(FluidSynth_DLL OR FluidSynth_LIBRARY MATCHES ".so|.dylib")
+  set(_fluidsynth_library_type SHARED)
+else()
+  set(_fluidsynth_library_type STATIC)
 endif()
+
+get_flags_from_pkg_config("${_fluidsynth_library_type}" "PC_FLUIDSYNTH" "_fluidsynth")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  FluidSynth REQUIRED_VARS "FluidSynth_LIBRARY" "FluidSynth_INCLUDE_DIR")
+  FluidSynth
+  REQUIRED_VARS "FluidSynth_LIBRARY" "FluidSynth_INCLUDE_DIR")
 
 if(FluidSynth_FOUND)
   if(NOT TARGET FluidSynth::libfluidsynth)
-    add_library(FluidSynth::libfluidsynth UNKNOWN IMPORTED)
+    add_library(FluidSynth::libfluidsynth ${_fluidsynth_library_type} IMPORTED)
     set_target_properties(
       FluidSynth::libfluidsynth
-      PROPERTIES IMPORTED_LOCATION "${FluidSynth_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${FluidSynth_INCLUDE_DIR}"
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${FluidSynth_INCLUDE_DIR}"
                  INTERFACE_COMPILE_OPTIONS "${_fluidsynth_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_fluidsynth_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_fluidsynth_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_fluidsynth_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_fluidsynth_link_options}"
+    )
+  endif()
+
+  if(FluidSynth_DLL)
+    set_target_properties(
+      FluidSynth::libfluidsynth
+      PROPERTIES IMPORTED_LOCATION "${FluidSynth_DLL}"
+                 IMPORTED_IMPLIB "${FluidSynth_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      FluidSynth::libfluidsynth
+      PROPERTIES IMPORTED_LOCATION "${FluidSynth_LIBRARY}"
+    )
   endif()
 
   set(FluidSynth_LIBRARIES FluidSynth::libfluidsynth)
   set(FluidSynth_INCLUDE_DIRS "${FluidSynth_INCLUDE_DIR}")
 endif()
 
-mark_as_advanced(FluidSynth_INCLUDE_DIR FluidSynth_LIBRARY)
+mark_as_advanced(
+  FluidSynth_INCLUDE_DIR
+  FluidSynth_DLL
+  FluidSynth_LIBRARY
+)

--- a/prboom2/cmake/FindLibMad.cmake
+++ b/prboom2/cmake/FindLibMad.cmake
@@ -31,30 +31,67 @@ The following cache variables may also be set:
 
 ``LibMad_INCLUDE_DIR``
   The directory containing ``LibMad.h``.
+``LibMad_DLL``
+  The path to the LibMad Windows runtime.
 ``LibMad_LIBRARY``
   The path to the LibMad library.
 
 #]=======================================================================]
 
-find_path(LibMad_INCLUDE_DIR NAMES mad.h)
+find_path(
+  LibMad_INCLUDE_DIR
+  NAMES mad.h
+)
 
-find_library(LibMad_LIBRARY NAMES mad)
+find_file(
+  LibMad_DLL
+  NAMES libmad.dll libmad-0.dll
+)
+
+find_library(
+  LibMad_LIBRARY
+  NAMES mad
+)
+
+if(LibMad_DLL OR LibMad_LIBRARY MATCHES ".so|.dylib")
+  set(_libmad_library_type SHARED)
+else()
+  set(_libmad_library_type STATIC)
+endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LibMad REQUIRED_VARS "LibMad_LIBRARY"
-                                                       "LibMad_INCLUDE_DIR")
+find_package_handle_standard_args(
+  LibMad 
+  REQUIRED_VARS "LibMad_LIBRARY" "LibMad_INCLUDE_DIR")
 
 if(LibMad_FOUND)
   if(NOT TARGET LibMad::libmad)
-    add_library(LibMad::libmad UNKNOWN IMPORTED)
+    add_library(LibMad::libmad ${_libmad_library_type} IMPORTED)
+    set_target_properties(
+      LibMad::libmad
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LibMad_INCLUDE_DIR}"
+    )
+  endif()
+
+  if(LibMad_DLL)
+    set_target_properties(
+      LibMad::libmad
+      PROPERTIES IMPORTED_LOCATION "${LibMad_DLL}"
+                 IMPORTED_IMPLIB "${LibMad_LIBRARY}"
+    )
+  else()
     set_target_properties(
       LibMad::libmad
       PROPERTIES IMPORTED_LOCATION "${LibMad_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${LibMad_INCLUDE_DIR}")
+    )
   endif()
 
   set(LibMad_LIBRARIES LibMad::libmad)
   set(LibMad_INCLUDE_DIRS "${LibMad_INCLUDE_DIR}")
 endif()
 
-mark_as_advanced(LibMad_INCLUDE_DIR LibMad_LIBRARY)
+mark_as_advanced(
+  LibMad_INCLUDE_DIR
+  LibMad_DLL
+  LibMad_LIBRARY
+)

--- a/prboom2/cmake/FindPortMidi.cmake
+++ b/prboom2/cmake/FindPortMidi.cmake
@@ -31,6 +31,8 @@ The following cache variables may also be set:
 
 ``PortMidi_INCLUDE_DIR``
   The directory containing ``PortMidi.h``.
+``PortMidi_DLL``
+  The path to the PortMidi Windows runtime.
 ``PortMidi_LIBRARY``
   The path to the PortMidi library.
 
@@ -40,6 +42,8 @@ if(PortMidi_FIND_REQUIRED)
   set(_find_package_search_type "REQUIRED")
 elseif(PortMidi_FIND_QUIETLY)
   set(_find_package_search_type "QUIET")
+else()
+  set(_find_package_search_type "")
 endif()
 
 find_package(PkgConfig QUIET)
@@ -48,24 +52,42 @@ pkg_check_modules(PC_PORTMIDI QUIET portmidi)
 find_path(
   PortMidi_INCLUDE_DIR
   NAMES portmidi.h
-  HINTS ${PC_PORTMIDI_INCLUDEDIR})
+  HINTS "${PC_PORTMIDI_INCLUDEDIR}"
+)
+
+find_file(
+  PortMidi_DLL
+  NAMES portmidi.dll libportmidi.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_PORTMIDI_PREFIX}"
+)
 
 find_library(
   PortMidi_LIBRARY
   NAMES portmidi
-  HINTS ${PC_PORTMIDI_LIBDIR})
+  HINTS "${PC_PORTMIDI_LIBDIR}"
+)
 
-if(PC_PORTMIDI_FOUND)
-  get_flags_from_pkg_config("${PortMidi_LIBRARY}" "PC_PORTMIDI" "_portmidi")
+if(PortMidi_DLL OR PortMidi_LIBRARY MATCHES ".so|.dylib")
+  set(_portmidi_library_type SHARED)
 else()
+  set(_portmidi_library_type STATIC)
+endif()
+
+get_flags_from_pkg_config("${_portmidi_library_type}" "PC_PORTMIDI" "_portmidi")
+
+if(_portmidi_library_type MATCHES "STATIC" AND NOT PC_PORTMIDI_FOUND)
   find_package(Threads ${_find_package_search_type})
   list(APPEND _portmidi_link_libraries Threads::Threads)
   if(WIN32)
     list(APPEND _portmidi_link_libraries winmm)
   elseif(APPLE)
-    list(APPEND _portmidi_link_libraries "-Wl,-framework,CoreAudio"
-         "-Wl,-framework,CoreFoundation" "-Wl,-framework,CoreMIDI"
-         "-Wl,-framework,CoreServices")
+    list(APPEND _portmidi_link_libraries
+         "-Wl,-framework,CoreAudio"
+         "-Wl,-framework,CoreFoundation"
+         "-Wl,-framework,CoreMIDI"
+         "-Wl,-framework,CoreServices"
+    )
   elseif(UNIX)
     find_package(ALSA ${_find_package_search_type})
     list(APPEND _portmidi_link_libraries ALSA::ALSA)
@@ -73,24 +95,43 @@ else()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PortMidi REQUIRED_VARS "PortMidi_LIBRARY"
-                                                         "PortMidi_INCLUDE_DIR")
+find_package_handle_standard_args(
+  PortMidi
+  REQUIRED_VARS "PortMidi_LIBRARY" "PortMidi_INCLUDE_DIR"
+)
 
 if(PortMidi_FOUND)
   if(NOT TARGET PortMidi::portmidi)
-    add_library(PortMidi::portmidi UNKNOWN IMPORTED)
+    add_library(PortMidi::portmidi ${_portmidi_library_type} IMPORTED)
     set_target_properties(
       PortMidi::portmidi
-      PROPERTIES IMPORTED_LOCATION "${PortMidi_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${PortMidi_INCLUDE_DIR}"
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${PortMidi_INCLUDE_DIR}"
                  INTERFACE_COMPILE_OPTIONS "${_portmidi_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_portmidi_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_portmidi_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_portmidi_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_portmidi_link_options}"
+    )
+  endif()
+
+  if (PortMidi_DLL)
+    set_target_properties(
+      PortMidi::portmidi
+      PROPERTIES IMPORTED_LOCATION "${PortMidi_DLL}"
+                 IMPORTED_IMPLIB "${PortMidi_LIBRARY}"
+    )
+  else()
+  set_target_properties(
+    PortMidi::portmidi
+    PROPERTIES IMPORTED_LOCATION "${PortMidi_LIBRARY}"
+  )
   endif()
 
   set(PortMidi_LIBRARIES PortMidi::portmidi)
   set(PortMidi_INCLUDE_DIRS "${PortMidi_INCLUDE_DIR}")
 endif()
 
-mark_as_advanced(PortMidi_INCLUDE_DIR PortMidi_LIBRARY)
+mark_as_advanced(
+  PortMidi_INCLUDE_DIR
+  PortMidi_DLL
+  PortMidi_LIBRARY
+)

--- a/prboom2/cmake/FindSDL2.cmake
+++ b/prboom2/cmake/FindSDL2.cmake
@@ -10,9 +10,11 @@ Imported Targets
 This module provides the following imported targets, if found:
 
 ``SDL2::SDL2``
-  The SDL2 library
+  The SDL2 shared library (may be an alias of the static)
+``SDL2::SDL2-static``
+  The SDL2 static library
 ``SDL2::SDL2main``
-  The SDL2 main library
+  The SDL2main static library
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -22,13 +24,23 @@ This will define the following variables:
 ``SDL2_FOUND``
   True if the system has the SDL2 package.
 ``SDL2_SDL2_FOUND``
-  True if the system has the SDL2 library.
+  True if the system has the SDL2 library (any linkage).
+``SDL2_SDL2-static_FOUND``
+  True if the system has the SDL2 static library.
 ``SDL2_SDL2main_FOUND``
   True if the system has the SDL2main library.
 ``SDL2_INCLUDE_DIRS``
   Include directories needed to use SDL2.
 ``SDL2_LIBRARIES``
   Libraries needed to link to SDL2.
+``SDL2_SDL2_DLL``
+  The path to the SDL2 Windows runtime (any config).
+``SDL2_SDL2_LIBRARY``
+  The path to the SDL2 shared library (any config).
+``SDL2_SDL2-static_LIBRARY``
+  The path to the SDL2 static library (any config).
+``SDL2_SDL2main_LIBRARY``
+  The path to the SDL2main library (any config).
 
 Cache Variables
 ^^^^^^^^^^^^^^^
@@ -37,49 +49,115 @@ The following cache variables may also be set:
 
 ``SDL2_INCLUDE_DIR``
   The directory containing ``SDL2.h``.
-``SDL2_SDL2_LIBRARY``
-  The path to the SDL2 library.
-``SDL2_SDL2main_LIBRARY``
-  The path to the SDL2main library.
+``SDL2_SDL2_DLL_RELEASE``
+  The path to the SDL2 Windows runtime (release config).
+``SDL2_SDL2_DLL_DEBUG``
+  The path to the SDL2 Windows runtime (debug config).
+``SDL2_SDL2_LIBRARY_RELEASE``
+  The path to the SDL2 shared library (release config).
+``SDL2_SDL2_LIBRARY_DEBUG``
+  The path to the SDL2 shared library (debug config).
+``SDL2_SDL2-static_LIBRARY_RELEASE``
+  The path to the SDL2 static library (release config).
+``SDL2_SDL2-static_LIBRARY_DEBUG``
+  The path to the SDL2 static library (debug config).
+``SDL2_SDL2main_LIBRARY_RELEASE``
+  The path to the SDL2main library (release config).
+``SDL2_SDL2main_LIBRARY_DEBUG``
+  The path to the SDL2main library (debug config).
 
 #]=======================================================================]
 
 find_package(PkgConfig QUIET)
-pkg_check_modules(PC_SDL2 QUIET SDL2)
+pkg_check_modules(PC_SDL2 QUIET sdl2)
 
 find_path(
   SDL2_INCLUDE_DIR
   NAMES SDL2/SDL.h
   PATH_SUFFIXES SDL2
-  HINTS ${PC_SDL2_INCLUDEDIR})
+  HINTS "${PC_SDL2_INCLUDEDIR}"
+)
+
+find_file(
+  SDL2_SDL2_DLL_RELEASE
+  NAMES SDL2.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_SDL2_PREFIX}"
+)
+
+find_file(
+  SDL2_SDL2_DLL_DEBUG
+  NAMES SDL2d.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_SDL2_PREFIX}"
+)
+
+include(SelectDllConfigurations)
+select_dll_configurations(SDL2_SDL2)
+
+if(SDL2_SDL2_DLL)
+  set(_sdl2_shared_release_names "SDL2.lib" "libSDL2.dll.a")
+  set(_sdl2_static_release_names "SDL2-static.lib")
+  set(_sdl2_shared_debug_names "SDL2d.lib")
+  set(_sdl2_static_debug_names "SDL2-staticd.lib")
+else()
+  set(_sdl2_shared_release_names "")
+  set(_sdl2_static_release_names "SDL2.lib" "SDL2-static.lib")
+  set(_sdl2_shared_debug_names "")
+  set(_sdl2_static_debug_names "SDL2d.lib" "SDL2-staticd.lib")
+endif()
+
+set(_saved_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(CMAKE_FIND_LIBRARY_SUFFIXES "" ".so" ".dylib" ".dll.a")
 
 find_library(
   SDL2_SDL2_LIBRARY_RELEASE
-  NAMES SDL2 SDL2-static
-  HINTS ${PC_SDL2_LIBDIR})
+  NAMES ${_sdl2_shared_release_names} SDL2
+  HINTS "${PC_SDL2_LIBDIR}"
+)
 
 find_library(
   SDL2_SDL2_LIBRARY_DEBUG
-  NAMES SDL2d SDL2-staticd
-  HINTS ${PC_SDL2_LIBDIR})
+  NAMES ${_sdl2_shared_debug_names} SDL2d
+  HINTS "${PC_SDL2_LIBDIR}"
+)
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES "" ".a")
+
+find_library(
+  SDL2_SDL2-static_LIBRARY_RELEASE
+  NAMES ${_sdl2_static_release_names} SDL2
+  HINTS "${PC_SDL2_LIBDIR}"
+)
+
+find_library(
+  SDL2_SDL2-static_LIBRARY_DEBUG
+  NAMES ${_sdl2_static_debug_names} SDL2d
+  HINTS "${PC_SDL2_LIBDIR}"
+)
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_saved_suffixes})
 
 find_library(
   SDL2_SDL2main_LIBRARY_RELEASE
   NAMES SDL2main
   PATH_SUFFIXES manual-link
-  HINTS ${PC_SDL2_LIBDIR})
+  HINTS "${PC_SDL2_LIBDIR}"
+)
 
 find_library(
   SDL2_SDL2main_LIBRARY_DEBUG
   NAMES SDL2maind
   PATH_SUFFIXES manual-link
-  HINTS ${PC_SDL2_LIBDIR})
+  HINTS "${PC_SDL2_LIBDIR}"
+)
 
 include(SelectLibraryConfigurations)
 select_library_configurations(SDL2_SDL2)
+select_library_configurations(SDL2_SDL2-static)
 select_library_configurations(SDL2_SDL2main)
 
-foreach(_component SDL2 SDL2main)
+foreach(_component SDL2-static SDL2main)
   if(SDL2_${_component}_LIBRARY)
     set(SDL2_${_component}_FOUND "TRUE")
   else()
@@ -87,102 +165,227 @@ foreach(_component SDL2 SDL2main)
   endif()
 endforeach()
 
-if(PC_SDL2_FOUND)
-  get_flags_from_pkg_config("${SDL2_LIBRARY}" "PC_SDL2" "_sdl2")
+if(SDL2_SDL2_LIBRARY)
+  set(SDL2_SDL2_FOUND "TRUE")
+else()
+  set(SDL2_SDL2_FOUND "${SDL2_SDL2-static_FOUND}")
+endif()
+
+get_flags_from_pkg_config("SHARED" "PC_SDL2" "_sdl2")
+get_flags_from_pkg_config("STATIC" "PC_SDL2" "_sdl2_static")
+
+
+if(SDL2_SDL2-static_FOUND AND NOT PC_SDL2_FOUND)
+  if(WIN32)
+    set(_sdl2_static_link_libraries user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 setupapi shell32)
+  elseif(NOT SDL2_SDL2_FOUND)
+    set(SDL2_SDL2-static_LINK_LIBRARIES "" CACHE STRING "Additional libraries to link to SDL2-static.")
+    set(SDL2_SDL2-static_LINK_DIRECTORIES "" CACHE PATH "Additional directories to search libraries in for SDL2-static.")
+    set(_sdl2_static_link_libraries ${SDL2_SDL2-static_LINK_LIBRARIES})
+    set(_sdl2_static_link_directories ${SDL2_SDL2-static_LINK_DIRECTORIES})
+    if(NOT _sdl2_static_link_libraries)
+      message(WARNING
+        "pkg-config is unavailable and only a static version of SDL2 was found.\n"
+        "Link failures are to be expected.\n"
+        "Set `SDL2_SDL2-static_LINK_LIBRARIES` to a list of libraries SDL2 depends on.\n"
+        "Set `SDL2_SDL2-static_LINK_DIRECTORIES` to a list of directories to search for libraries in."
+      )
+    endif()
+  endif()
 endif()
 
 if(PC_SDL2_FOUND)
   set(SDL2_VERSION "${PC_SDL2_VERSION}")
 elseif(EXISTS "${SDL2_INCLUDE_DIR}/SDL_version.h")
   file(READ "${SDL2_INCLUDE_DIR}/SDL_version.h" _sdl_version_h)
-  string(REGEX MATCH "#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)"
-               _sdl2_major_re "${_sdl_version_h}")
+  string(REGEX
+    MATCH "#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)"
+          _sdl2_major_re
+          "${_sdl_version_h}")
   set(_sdl2_major "${CMAKE_MATCH_1}")
-  string(REGEX MATCH "#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)"
-               _sdl2_minor_re "${_sdl_version_h}")
+  string(REGEX
+    MATCH "#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)"
+          _sdl2_minor_re
+          "${_sdl_version_h}")
   set(_sdl2_minor "${CMAKE_MATCH_1}")
-  string(REGEX MATCH "#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)" _sdl2_minor_re
-               "${_sdl_version_h}")
+  string(REGEX
+    MATCH "#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)"
+          _sdl2_minor_re
+          "${_sdl_version_h}")
   set(_sdl2_minor "${CMAKE_MATCH_1}")
-  if(_sdl2_major_re
-     AND _sdl2_minor_re
-     AND _sdl2_minor_re)
+  if(_sdl2_major_re AND _sdl2_minor_re AND _sdl2_minor_re)
     set(${OUT_VAR}
         "${_sdl2_major}.${_sdl2_minor}.${_sdl2_minor}"
         PARENT_SCOPE)
   endif()
 endif()
 
+if(SDL2_SDL2_LIBRARY)
+  set(_SDL2_LIBRARY "${SDL2_SDL2_LIBRARY}")
+else()
+  set(_SDL2_LIBRARY "${SDL2_SDL2-static_LIBRARY}")
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   SDL2
-  REQUIRED_VARS "SDL2_SDL2_LIBRARY" "SDL2_INCLUDE_DIR"
+  REQUIRED_VARS "_SDL2_LIBRARY" "SDL2_INCLUDE_DIR"
   VERSION_VAR "SDL2_VERSION"
-  HANDLE_COMPONENTS)
+  HANDLE_COMPONENTS
+)
 
-if(SDL2_SDL2_FOUND)
+if(SDL2_FOUND)
   set(SDL2_INCLUDE_DIRS "${SDL2_INCLUDE_DIR}" "${SDL2_INCLUDE_DIR}/..")
+  set(SDL2_LIBRARIES SDL2::SDL2)  
+endif()
 
+if(SDL2_SDL2_LIBRARY)
   if(NOT TARGET SDL2::SDL2)
-    add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+    add_library(SDL2::SDL2 SHARED IMPORTED)
     set_target_properties(
       SDL2::SDL2
-      PROPERTIES IMPORTED_LOCATION "${SDL2_SDL2_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
                  INTERFACE_COMPILE_OPTIONS "${_sdl2_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_sdl2_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_sdl2_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_sdl2_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_sdl2_link_options}"
+    )
+  endif()
+
+  if(SDL2_SDL2_DLL)
+    set_target_properties(
+      SDL2::SDL2
+      PROPERTIES IMPORTED_LOCATION "${SDL2_SDL2_DLL}"
+                 IMPORTED_IMPLIB "${SDL2_SDL2_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      SDL2::SDL2
+      PROPERTIES IMPORTED_LOCATION "${SDL2_SDL2_LIBRARY}"
+    )
   endif()
 
   if(SDL2_SDL2_LIBRARY_RELEASE)
     set_property(
       TARGET SDL2::SDL2
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-    set_target_properties(SDL2::SDL2 PROPERTIES IMPORTED_LOCATION_RELEASE
-                                                "${SDL2_SDL2_LIBRARY_RELEASE}")
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
+    if(SDL2_SDL2_DLL_RELEASE)
+      set_target_properties(
+        SDL2::SDL2
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_SDL2_DLL_RELEASE}"
+                   IMPORTED_IMPLIB_RELEASE "${SDL2_SDL2_LIBRARY_RELEASE}"
+      )
+    else()
+      set_target_properties(
+        SDL2::SDL2
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_SDL2_LIBRARY_RELEASE}"
+      )
+    endif()
   endif()
   if(SDL2_SDL2_LIBRARY_DEBUG)
     set_property(
       TARGET SDL2::SDL2
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-    set_target_properties(SDL2::SDL2 PROPERTIES IMPORTED_LOCATION_DEBUG
-                                                "${SDL2_SDL2_LIBRARY_DEBUG}")
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
+    if(SDL2_SDL2_DLL_DEBUG)
+      set_target_properties(
+        SDL2::SDL2
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_SDL2_DLL_DEBUG}"
+                  IMPORTED_IMPLIB_DEBUG "${SDL2_SDL2_LIBRARY_DEBUG}"
+      )
+    else()
+      set_target_properties(
+        SDL2::SDL2
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_SDL2_LIBRARY_DEBUG}"
+      )
+    endif()
+  endif()
+endif()
+
+if(SDL2_SDL2-static_FOUND)
+  if(NOT SDL2::SDL2-static)
+    add_library(SDL2::SDL2-static STATIC IMPORTED)
+    set_target_properties(
+      SDL2::SDL2-static
+      PROPERTIES IMPORTED_LOCATION "${SDL2_SDL2-static_LIBRARY}"
+                 INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+                 INTERFACE_COMPILE_OPTIONS "${_sdl2_static_compile_options}"
+                 INTERFACE_LINK_LIBRARIES "${_sdl2_static_link_libraries}"
+                 INTERFACE_LINK_DIRECTORIES "${_sdl2_static_link_directories}"
+                 INTERFACE_LINK_OPTIONS "${_sdl2_static_link_options}"
+    )
+  endif()
+  if(SDL2_SDL2-static_LIBRARY_RELEASE)
+    set_property(
+      TARGET SDL2::SDL2-static
+      APPEND
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
+    set_target_properties(
+      SDL2::SDL2-static
+      PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_SDL2-static_LIBRARY_RELEASE}"
+    )
+  endif()
+  if(SDL2_SDL2-static_LIBRARY_DEBUG)
+    set_property(
+      TARGET SDL2::SDL2-static
+      APPEND
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
+    set_target_properties(
+      SDL2::SDL2-static
+      PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_SDL2-static_LIBRARY_DEBUG}"
+    )
   endif()
 
-  set(SDL2_LIBRARIES SDL2::SDL2)
+  if(NOT TARGET SDL2::SDL2)
+    add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
+  endif()
 endif()
 
 if(SDL2_SDL2main_FOUND)
+  set(_sdl2main_link_libraries SDL2::SDL2)
+  if(MINGW OR CYGWIN)
+    list(APPEND _sdl2main_link_libraries shell32)
+  endif()
   if(NOT TARGET SDL2::SDL2main)
-    add_library(SDL2::SDL2main UNKNOWN IMPORTED)
+    add_library(SDL2::SDL2main STATIC IMPORTED)
     set_target_properties(
-      SDL2::SDL2main PROPERTIES IMPORTED_LOCATION "${SDL2_SDL2main_LIBRARY}"
-                                INTERFACE_LINK_LIBRARIES "SDL2::SDL2")
+      SDL2::SDL2main
+      PROPERTIES IMPORTED_LOCATION "${SDL2_SDL2main_LIBRARY}"
+                 INTERFACE_LINK_LIBRARIES "${_sdl2main_link_libraries}"
+    )
   endif()
 
   if(SDL2_SDL2main_LIBRARY_RELEASE)
     set_property(
       TARGET SDL2::SDL2main
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
     set_target_properties(
-      SDL2::SDL2main PROPERTIES IMPORTED_LOCATION_RELEASE
-                                "${SDL2_SDL2main_LIBRARY_RELEASE}")
+      SDL2::SDL2main
+      PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_SDL2main_LIBRARY_RELEASE}"
+    )
   endif()
   if(SDL2_SDL2main_LIBRARY_DEBUG)
     set_property(
       TARGET SDL2::SDL2main
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
     set_target_properties(
-      SDL2::SDL2main PROPERTIES IMPORTED_LOCATION_DEBUG
-                                "${SDL2_SDL2main_LIBRARY_DEBUG}")
+      SDL2::SDL2main
+      PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_SDL2main_LIBRARY_DEBUG}"
+    )
   endif()
 
   list(APPEND SDL2_LIBRARIES SDL2::SDL2main)
 endif()
 
-mark_as_advanced(SDL2_INCLUDE_DIR SDL2_SDL2_LIBRARY SDL2_SDL2main_LIBRARY)
+mark_as_advanced(
+  SDL2_INCLUDE_DIR
+)

--- a/prboom2/cmake/FindSDL2_image.cmake
+++ b/prboom2/cmake/FindSDL2_image.cmake
@@ -7,10 +7,12 @@ Finds the SDL2_image library.
 Imported Targets
 ^^^^^^^^^^^^^^^^
 
-This module provides the following imported targets, if found:
+This module provides either of the following imported targets, if found:
 
 ``SDL2_image::SDL2_image``
-  The SDL2_image library
+  The shared SDL2_image library
+``SDL2_image::SDL2_image-static``
+  The static SDL2_image library
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -23,6 +25,10 @@ This will define the following variables:
   Include directories needed to use SDL2_image.
 ``SDL2_image_LIBRARIES``
   Libraries needed to link to SDL2_image.
+``SDL2_image_DLL``
+  The path to the SDL2_image Windows runtime (any config).
+``SDL2_image_LIBRARY``
+  The path to the SDL2_image library (any config).
 
 Cache Variables
 ^^^^^^^^^^^^^^^
@@ -31,8 +37,14 @@ The following cache variables may also be set:
 
 ``SDL2_image_INCLUDE_DIR``
   The directory containing ``SDL2_image.h``.
-``SDL2_image_LIBRARY``
-  The path to the SDL2_image library.
+``SDL2_image_DLL_RELEASE``
+  The path to the SDL2_image Windows runtime (release config).
+``SDL2_image_DLL_DEBUG``
+  The path to the SDL2_image Windows runtime (debug config).
+``SDL2_image_LIBRARY_RELEASE``
+  The path to the SDL2_image library (release config).
+``SDL2_image_LIBRARY_DEBUG``
+  The path to the SDL2_image library (debug config).
 
 #]=======================================================================]
 
@@ -43,73 +55,142 @@ find_path(
   SDL2_image_INCLUDE_DIR
   NAMES SDL_image.h
   PATH_SUFFIXES SDL2
-  HINTS ${PC_SDL2_IMAGE_INCLUDEDIR})
+  HINTS "${PC_SDL2_IMAGE_INCLUDEDIR}"
+)
+
+find_file(
+  SDL2_image_DLL_RELEASE
+  NAMES SDL2_image.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_SDL2_IMAGE_PREFIX}"
+)
+
+find_file(
+  SDL2_image_DLL_DEBUG
+  NAMES SDL2_imaged.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_SDL2_IMAGE_PREFIX}"
+)
+
+include(SelectDllConfigurations)
+select_dll_configurations(SDL2_image)
 
 find_library(
   SDL2_image_LIBRARY_RELEASE
   NAMES SDL2_image SDL2_image-static
-  HINTS ${PC_SDL2_IMAGE_LIBDIR})
+  HINTS "${PC_SDL2_IMAGE_LIBDIR}"
+)
 
 find_library(
   SDL2_image_LIBRARY_DEBUG
   NAMES SDL2_imaged SDL2_image-staticd
-  HINTS ${PC_SDL2_IMAGE_LIBDIR})
+  HINTS "${PC_SDL2_IMAGE_LIBDIR}"
+)
 
 include(SelectLibraryConfigurations)
 select_library_configurations(SDL2_image)
 
-if(PC_SDL2_IMAGE_FOUND)
-  get_flags_from_pkg_config("${SDL2_image_LIBRARY}" "PC_SDL2_IMAGE"
-                            "_sdl2_image")
-elseif(SDL2_image_LIBRARY)
-  set(_sdl2_image_link_libraries
-      ""
-      CACHE FILEPATH "Additional libraries to link to SDL2_image.")
+if(SDL2_image_DLL OR SDL2_image_LIBRARY MATCHES ".so|.dylib")
+  set(_sdl2_image_library_type SHARED)
+else()
+  set(_sdl2_image_library_type STATIC)
+endif()
+
+get_flags_from_pkg_config("${_sdl2_image_library_type}" "PC_SDL2_IMAGE" "_sdl2_image")
+
+if(_sdl2_image_library_type STREQUAL "STATIC" AND NOT PC_SDL2_IMAGE_FOUND)
+  set(SDL2_image_LINK_LIBRARIES "" CACHE STRING "Additional libraries to link to SDL2_image.")
+  set(SDL2_image_LINK_DIRECTORIES "" CACHE PATH "Additional directories to search libraries in for SDL2_image.")
+  set(_sdl2_image_link_libraries ${SDL2_image_LINK_LIBRARIES})
+  set(_sdl2_image_link_directories ${SDL2_image_LINK_DIRECTORIES})
   if(NOT _sdl2_image_link_libraries)
-    message(
-      "pkg-config is unavailable, if SDL2_image is a static library, linking will fail.\n"
-      "Set '_sdl2_image_link_libraries' to the list of libraries to link.")
+    message(WARNING
+      "pkg-config is unavailable and SDL2_image seems to be static, link failures are to be expected.\n"
+      "Set `SDL2_image_LINK_LIBRARIES` to a list of libraries SDL2_image depends on.\n"
+      "Set `SDL2_image_LINK_DIRECTORIES` to a list of directories to search for libraries in."
+    )
   endif()
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  SDL2_image REQUIRED_VARS "SDL2_image_LIBRARY" "SDL2_image_INCLUDE_DIR")
+  SDL2_image
+  REQUIRED_VARS "SDL2_image_LIBRARY" "SDL2_image_INCLUDE_DIR")
 
 if(SDL2_image_FOUND)
-  if(NOT TARGET SDL2_image::SDL2_image)
-    add_library(SDL2_image::SDL2_image UNKNOWN IMPORTED)
+  if(_sdl2_image_library_type STREQUAL "SHARED")
+    set(_sdl2_image_target_name SDL2_image::SDL2_image)
+  else()
+    set(_sdl2_image_target_name SDL2_image::SDL2_image-static)
+  endif()
+  if(NOT TARGET ${_sdl2_image_target_name})
+    add_library(${_sdl2_image_target_name} ${_sdl2_image_library_type} IMPORTED)
     set_target_properties(
-      SDL2_image::SDL2_image
-      PROPERTIES IMPORTED_LOCATION "${SDL2_image_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${SDL2_image_INCLUDE_DIR}"
+      ${_sdl2_image_target_name}
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${SDL2_image_INCLUDE_DIR}"
                  INTERFACE_COMPILE_OPTIONS "${_sdl2_image_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_sdl2_image_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_sdl2_image_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_sdl2_image_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_sdl2_image_link_options}"
+    )
+  endif()
+
+  if(SDL2_image_DLL)
+    set_target_properties(
+      ${_sdl2_image_target_name}
+      PROPERTIES IMPORTED_LOCATION "${SDL2_image_DLL}"
+                 IMPORTED_IMPLIB "${SDL2_image_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      ${_sdl2_image_target_name}
+      PROPERTIES IMPORTED_LOCATION "${SDL2_image_LIBRARY}"
+    )
   endif()
 
   if(SDL2_image_LIBRARY_RELEASE)
     set_property(
-      TARGET SDL2_image::SDL2_image
+      TARGET ${_sdl2_image_target_name}
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-    set_target_properties(
-      SDL2_image::SDL2_image PROPERTIES IMPORTED_LOCATION_RELEASE
-                                        "${SDL2_image_LIBRARY_RELEASE}")
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
+    if(SDL2_image_DLL_RELEASE)
+      set_target_properties(
+        ${_sdl2_image_target_name}
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_image_DLL_RELEASE}"
+                   IMPORTED_IMPLIB_RELEASE "${SDL2_image_LIBRARY_RELEASE}"
+      )
+    else()
+      set_target_properties(
+        ${_sdl2_image_target_name}
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_image_LIBRARY_RELEASE}"
+      )
+    endif()
   endif()
   if(SDL2_image_LIBRARY_DEBUG)
     set_property(
-      TARGET SDL2_image::SDL2_image
+      TARGET ${_sdl2_image_target_name}
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-    set_target_properties(
-      SDL2_image::SDL2_image PROPERTIES IMPORTED_LOCATION_DEBUG
-                                        "${SDL2_image_LIBRARY_DEBUG}")
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
+    if(SDL2_image_DLL_DEBUG)
+      set_target_properties(
+        ${_sdl2_image_target_name}
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_image_DLL_DEBUG}"
+                   IMPORTED_IMPLIB_DEBUG "${SDL2_image_LIBRARY_DEBUG}"
+      )
+    else()
+      set_target_properties(
+        ${_sdl2_image_target_name}
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_image_LIBRARY_DEBUG}"
+      )
+    endif()
   endif()
 
-  set(SDL2_image_LIBRARIES SDL2_image::SDL2_image)
+  set(SDL2_image_LIBRARIES ${_sdl2_image_target_name})
   set(SDL2_image_INCLUDE_DIRS "${SDL2_image_INCLUDE_DIR}")
 endif()
 
-mark_as_advanced(SDL2_image_INCLUDE_DIR SDL2_image_LIBRARY)
+mark_as_advanced(
+  SDL2_image_INCLUDE_DIR
+)

--- a/prboom2/cmake/FindSDL2_mixer.cmake
+++ b/prboom2/cmake/FindSDL2_mixer.cmake
@@ -7,10 +7,12 @@ Finds the SDL2_mixer library.
 Imported Targets
 ^^^^^^^^^^^^^^^^
 
-This module provides the following imported targets, if found:
+This module provides either of the following imported targets, if found:
 
 ``SDL2_mixer::SDL2_mixer``
-  The SDL2_mixer library
+  The shared SDL2_mixer library
+``SDL2_mixer::SDL2_mixer-static``
+  The static SDL2_mixer library
 
 Result Variables
 ^^^^^^^^^^^^^^^^
@@ -31,8 +33,14 @@ The following cache variables may also be set:
 
 ``SDL2_mixer_INCLUDE_DIR``
   The directory containing ``SDL2_mixer.h``.
-``SDL2_mixer_LIBRARY``
-  The path to the SDL2_mixer library.
+``SDL2_mixer_DLL_RELEASE``
+  The path to the SDL2_mixer Windows runtime (release config).
+``SDL2_mixer_DLL_DEBUG``
+  The path to the SDL2_mixer Windows runtime (debug config).
+``SDL2_mixer_LIBRARY_RELEASE``
+  The path to the SDL2_mixer library (release config).
+``SDL2_mixer_LIBRARY_DEBUG``
+  The path to the SDL2_mixer library (debug config).
 
 #]=======================================================================]
 
@@ -43,73 +51,142 @@ find_path(
   SDL2_mixer_INCLUDE_DIR
   NAMES SDL_mixer.h
   PATH_SUFFIXES SDL2
-  HINTS ${PC_SDL2_MIXER_INCLUDEDIR})
+  HINTS "${PC_SDL2_MIXER_INCLUDEDIR}"
+)
+
+find_file(
+  SDL2_mixer_DLL_RELEASE
+  NAMES SDL2_mixer.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_SDL2_MIXER_PREFIX}"
+)
+
+find_file(
+  SDL2_mixer_DLL_DEBUG
+  NAMES SDL2_mixerd.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_SDL2_MIXER_PREFIX}"
+)
+
+include(SelectDllConfigurations)
+select_dll_configurations(SDL2_mixer)
 
 find_library(
   SDL2_mixer_LIBRARY_RELEASE
   NAMES SDL2_mixer SDL2_mixer-static
-  HINTS ${PC_SDL2_MIXER_LIBDIR})
+  HINTS "${PC_SDL2_MIXER_LIBDIR}"
+)
 
 find_library(
   SDL2_mixer_LIBRARY_DEBUG
   NAMES SDL2_mixerd SDL2_mixer-staticd
-  HINTS ${PC_SDL2_MIXER_LIBDIR})
+  HINTS "${PC_SDL2_MIXER_LIBDIR}"
+)
 
 include(SelectLibraryConfigurations)
 select_library_configurations(SDL2_mixer)
 
-if(PC_SDL2_MIXER_FOUND)
-  get_flags_from_pkg_config("${SDL2_mixer_LIBRARY}" "PC_SDL2_MIXER"
-                            "_sdl2_mixer")
-elseif(SDL2_mixer_LIBRARY)
-  set(_sdl2_mixer_link_libraries
-      ""
-      CACHE FILEPATH "Additional libraries to link to SDL2_mixer.")
+if(SDL2_mixer_DLL OR SDL2_mixer_LIBRARY MATCHES ".so|.dylib")
+  set(_sdl2_mixer_library_type SHARED)
+else()
+  set(_sdl2_mixer_library_type STATIC)
+endif()
+
+get_flags_from_pkg_config("${_sdl2_mixer_library_type}" "PC_SDL2_MIXER" "_sdl2_mixer")
+
+if(_SDL2_mixer_library_type STREQUAL "STATIC" AND NOT PC_SDL2_MIXER_FOUND)
+  set(SDL2_mixer_LINK_LIBRARIES "" CACHE STRING "Additional libraries to link to SDL2_mixer.")
+  set(SDL2_mixer_LINK_DIRECTORIES "" CACHE PATH "Additional directories to search libraries in for SDL2_mixer.")
+  set(_sdl2_mixer_link_libraries ${SDL2_mixer_LINK_LIBRARIES})
+  set(_sdl2_mixer_link_directories ${SDL2_mixer_LINK_DIRECTORIES})
   if(NOT _sdl2_mixer_link_libraries)
-    message(
-      "pkg-config is unavailable, if SDL2_mixer is a static library, linking will fail.\n"
-      "Set '_sdl2_mixer_link_libraries' to the list of libraries to link.")
+    message(WARNING
+      "pkg-config is unavailable and SDL2_mixer seems to be static, link failures are to be expected.\n"
+      "Set `SDL2_mixer_LINK_LIBRARIES` to a list of libraries SDL2_mixer depends on.\n"
+      "Set `SDL2_mixer_LINK_DIRECTORIES` to a list of directories to search for libraries in."
+    )
   endif()
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  SDL2_mixer REQUIRED_VARS "SDL2_mixer_LIBRARY" "SDL2_mixer_INCLUDE_DIR")
+  SDL2_mixer
+  REQUIRED_VARS "SDL2_mixer_LIBRARY" "SDL2_mixer_INCLUDE_DIR")
 
 if(SDL2_mixer_FOUND)
-  if(NOT TARGET SDL2_mixer::SDL2_mixer)
-    add_library(SDL2_mixer::SDL2_mixer UNKNOWN IMPORTED)
+  if(_sdl2_mixer_library_type STREQUAL "SHARED")
+    set(_sdl2_mixer_target_name SDL2_mixer::SDL2_mixer)
+  else()
+    set(_sdl2_mixer_target_name SDL2_mixer::SDL2_mixer-static)
+  endif()
+  if(NOT TARGET ${_sdl2_mixer_target_name})
+    add_library(${_sdl2_mixer_target_name} ${_sdl2_mixer_library_type} IMPORTED)
     set_target_properties(
-      SDL2_mixer::SDL2_mixer
-      PROPERTIES IMPORTED_LOCATION "${SDL2_mixer_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${SDL2_mixer_INCLUDE_DIR}"
+      ${_sdl2_mixer_target_name}
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${SDL2_mixer_INCLUDE_DIR}"
                  INTERFACE_COMPILE_OPTIONS "${_sdl2_mixer_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_sdl2_mixer_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_sdl2_mixer_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_sdl2_mixer_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_sdl2_mixer_link_options}"
+    )
+  endif()
+
+  if(SDL2_mixer_DLL)
+    set_target_properties(
+      ${_sdl2_mixer_target_name}
+      PROPERTIES IMPORTED_LOCATION "${SDL2_mixer_DLL}"
+                 IMPORTED_IMPLIB "${SDL2_mixer_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      ${_sdl2_mixer_target_name}
+      PROPERTIES IMPORTED_LOCATION "${SDL2_mixer_LIBRARY}"
+    )
   endif()
 
   if(SDL2_mixer_LIBRARY_RELEASE)
     set_property(
-      TARGET SDL2_mixer::SDL2_mixer
+      TARGET ${_sdl2_mixer_target_name}
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-    set_target_properties(
-      SDL2_mixer::SDL2_mixer PROPERTIES IMPORTED_LOCATION_RELEASE
-                                        "${SDL2_mixer_LIBRARY_RELEASE}")
+      PROPERTY IMPORTED_CONFIGURATIONS RELEASE
+    )
+    if(SDL2_mixer_DLL_RELEASE)
+      set_target_properties(
+        ${_sdl2_mixer_target_name}
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_mixer_DLL_RELEASE}"
+                   IMPORTED_IMPLIB_RELEASE "${SDL2_mixer_LIBRARY_RELEASE}"
+      )
+    else()
+      set_target_properties(
+        ${_sdl2_mixer_target_name}
+        PROPERTIES IMPORTED_LOCATION_RELEASE "${SDL2_mixer_LIBRARY_RELEASE}"
+      )
+    endif()
   endif()
   if(SDL2_mixer_LIBRARY_DEBUG)
     set_property(
-      TARGET SDL2_mixer::SDL2_mixer
+      TARGET ${_sdl2_mixer_target_name}
       APPEND
-      PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
-    set_target_properties(
-      SDL2_mixer::SDL2_mixer PROPERTIES IMPORTED_LOCATION_DEBUG
-                                        "${SDL2_mixer_LIBRARY_DEBUG}")
+      PROPERTY IMPORTED_CONFIGURATIONS DEBUG
+    )
+    if(SDL2_mixer_DLL_DEBUG)
+      set_target_properties(
+        ${_sdl2_mixer_target_name}
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_mixer_DLL_DEBUG}"
+                   IMPORTED_IMPLIB_DEBUG "${SDL2_mixer_LIBRARY_DEBUG}"
+      )
+    else()
+      set_target_properties(
+        ${_sdl2_mixer_target_name}
+        PROPERTIES IMPORTED_LOCATION_DEBUG "${SDL2_mixer_LIBRARY_DEBUG}"
+      )
+    endif()
   endif()
 
-  set(SDL2_mixer_LIBRARIES SDL2_mixer::SDL2_mixer)
+  set(SDL2_mixer_LIBRARIES ${_sdl2_mixer_target_name})
   set(SDL2_mixer_INCLUDE_DIRS "${SDL2_mixer_INCLUDE_DIR}")
 endif()
 
-mark_as_advanced(SDL2_mixer_INCLUDE_DIR SDL2_mixer_LIBRARY)
+mark_as_advanced(
+  SDL2_mixer_INCLUDE_DIR
+)

--- a/prboom2/cmake/FindVorbis.cmake
+++ b/prboom2/cmake/FindVorbis.cmake
@@ -37,6 +37,12 @@ The following cache variables may also be set:
 
 ``Vorbis_INCLUDE_DIR``
   The directory containing ``vorbis/vorbis.h``.
+``Vorbis_Vorbis_DLL``
+  The path to the vorbis Windows runtime.
+``Vorbis_Enc_DLL``
+  The path to the vorbisenc Windows runtime.
+``Vorbis_File_DLL``
+  The path to the vorbisfile Windows runtime.
 ``Vorbis_Vorbis_LIBRARY``
   The path to the vorbis library.
 ``Vorbis_Enc_LIBRARY``
@@ -50,6 +56,8 @@ if(Vorbis_FIND_REQUIRED)
   set(_find_package_search_type "REQUIRED")
 elseif(Vorbis_FIND_QUIETLY)
   set(_find_package_search_type "QUIET")
+else()
+  set(_find_package_search_type "")
 endif()
 
 find_package(PkgConfig QUIET)
@@ -60,35 +68,69 @@ pkg_check_modules(PC_VORBISFILE QUIET vorbisfile)
 find_path(
   Vorbis_INCLUDE_DIR
   NAMES vorbis/codec.h
-  HINTS ${PC_VORBIS_INCLUDEDIR})
+  HINTS "${PC_VORBIS_INCLUDEDIR}"
+)
+
+find_file(
+  Vorbis_Vorbis_DLL
+  NAMES vorbis.dll libvorbis.dll libvorbis-0.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_VORBIS_PREFIX}"
+)
+
+find_file(
+  Vorbis_Enc_DLL
+  NAMES vorbisenc.dll libvorbisenc.dll libvorbisenc-2.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_VORBISENC_PREFIX}"
+)
+
+find_file(
+  Vorbis_File_DLL
+  NAMES vorbisfile.dll libvorbisfile.dll libvorbisfile-3.dll 
+  PATH_SUFFIXES bin
+  HINTS "${PC_VORBISFILE_PREFIX}"
+)
 
 find_library(
   Vorbis_Vorbis_LIBRARY
   NAMES vorbis
-  HINTS ${PC_VORBIS_LIBDIR})
+  HINTS "${PC_VORBIS_LIBDIR}"
+)
 
 find_library(
   Vorbis_Enc_LIBRARY
   NAMES vorbisenc
-  HINTS ${PC_VORBISENC_LIBDIR})
+  HINTS "${PC_VORBISENC_LIBDIR}"
+)
 
 find_library(
   Vorbis_File_LIBRARY
   NAMES vorbisfile
-  HINTS ${PC_VORBISFILE_LIBDIR})
+  HINTS "${PC_VORBISFILE_LIBDIR}"
+)
 
-if(PC_VORBIS_FOUND)
-  get_flags_from_pkg_config("${Vorbis_Vorbis_LIBRARY}" "PC_VORBIS" "_vorbis")
+if(Vorbis_Vorbis_DLL OR Vorbis_Vorbis_LIBRARY MATCHES ".so|.dylib")
+  set(_vorbis_library_type SHARED)
+else()
+  set(_vorbis_library_type STATIC)
 endif()
 
-if(PC_VORBISENC_FOUND)
-  get_flags_from_pkg_config("${Vorbis_Enc_LIBRARY}" "PC_VORBISENC" "_vorbisenc")
+if(Vorbis_Enc_DLL OR Vorbis_Enc_LIBRARY MATCHES ".so|.dylib")
+  set(_vorbisenc_library_type SHARED)
+else()
+  set(_vorbisenc_library_type STATIC)
 endif()
 
-if(PC_VORBISFILE_FOUND)
-  get_flags_from_pkg_config("${Vorbis_File_LIBRARY}" "PC_VORBISFILE"
-                            "_vorbisfile")
+if(Vorbis_File_DLL OR Vorbis_File_LIBRARY MATCHES ".so|.dylib")
+  set(_vorbisfile_library_type SHARED)
+else()
+  set(_vorbisfile_library_type STATIC)
 endif()
+
+get_flags_from_pkg_config("${_vorbis_library_type}" "PC_VORBIS" "_vorbis")
+get_flags_from_pkg_config("${_vorbisenc_library_type}" "PC_VORBISENC" "_vorbisenc")
+get_flags_from_pkg_config("${_vorbisfile_library_type}" "PC_VORBISFILE" "_vorbisfile")
 
 find_library(_has_math_lib NAMES m)
 if(_has_math_lib)
@@ -99,66 +141,101 @@ list(APPEND _vorbis_link_libraries Ogg::ogg)
 set(_vorbisenc_link_libraries Vorbis::vorbis)
 set(_vorbisfile_link_libraries Vorbis::vorbis)
 
-if(Vorbis_Vorbis_LIBRARY)
-  set(Vorbis_Vorbis_FOUND "TRUE")
-else()
-  set(Vorbis_Vorbis_FOUND "FALSE")
-endif()
-
-if(Vorbis_Enc_LIBRARY)
-  set(Vorbis_Enc_FOUND "TRUE")
-else()
-  set(Vorbis_Enc_FOUND "FALSE")
-endif()
-
-if(Vorbis_File_LIBRARY)
-  set(Vorbis_File_FOUND "TRUE")
-else()
-  set(Vorbis_File_FOUND "FALSE")
-endif()
+foreach(_component "Vorbis" "Enc" "File")  
+  if(Vorbis_${_component}_LIBRARY)
+    set(Vorbis_${_component}_FOUND "TRUE")
+  else()
+    set(Vorbis_${_component}_FOUND "FALSE")
+  endif()
+endforeach()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Vorbis
-  REQUIRED_VARS "Vorbis_File_LIBRARY" "Vorbis_Vorbis_LIBRARY"
+  REQUIRED_VARS "Vorbis_File_LIBRARY"
+                "Vorbis_Vorbis_LIBRARY"
                 "Vorbis_INCLUDE_DIR"
-  HANDLE_COMPONENTS)
+  HANDLE_COMPONENTS
+)
 
 if(Vorbis_Vorbis_FOUND AND NOT TARGET Vorbis::vorbis)
-  add_library(Vorbis::vorbis UNKNOWN IMPORTED)
+  add_library(Vorbis::vorbis ${_vorbis_library_type} IMPORTED)
   set_target_properties(
     Vorbis::vorbis
-    PROPERTIES IMPORTED_LOCATION "${Vorbis_Vorbis_LIBRARY}"
-               INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_INCLUDE_DIR}"
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_INCLUDE_DIR}"
                INTERFACE_COMPILE_OPTIONS "${_vorbis_compile_options}"
                INTERFACE_LINK_LIBRARIES "${_vorbis_link_libraries}"
                INTERFACE_LINK_DIRECTORIES "${_vorbis_link_directories}"
-               INTERFACE_LINK_OPTIONS "${_vorbis_link_options}")
+               INTERFACE_LINK_OPTIONS "${_vorbis_link_options}"
+  )
+  if(Vorbis_Vorbis_DLL)
+    set_target_properties(
+      Vorbis::vorbis
+      PROPERTIES IMPORTED_LOCATION "${Vorbis_Vorbis_DLL}"
+                 IMPORTED_IMPLIB "${Vorbis_Vorbis_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      Vorbis::vorbis
+      PROPERTIES IMPORTED_LOCATION "${Vorbis_Vorbis_LIBRARY}"
+    )
+  endif()
 endif()
 
 if(Vorbis_Enc_FOUND AND NOT TARGET Vorbis::vorbisenc)
-  add_library(Vorbis::vorbisenc UNKNOWN IMPORTED)
+  add_library(Vorbis::vorbisenc ${_vorbisenc_library_type} IMPORTED)
   set_target_properties(
     Vorbis::vorbisenc
-    PROPERTIES IMPORTED_LOCATION "${Vorbis_Enc_LIBRARY}"
-               INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_INCLUDE_DIR}"
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_INCLUDE_DIR}"
                INTERFACE_COMPILE_OPTIONS "${_vorbisenc_compile_options}"
                INTERFACE_LINK_LIBRARIES "${_vorbisenc_link_libraries}"
                INTERFACE_LINK_DIRECTORIES "${_vorbisenc_link_directories}"
-               INTERFACE_LINK_OPTIONS "${_vorbisenc_link_options}")
+               INTERFACE_LINK_OPTIONS "${_vorbisenc_link_options}"
+  )
+  if(Vorbis_Enc_DLL)
+    set_target_properties(
+      Vorbis::vorbisenc
+      PROPERTIES IMPORTED_LOCATION "${Vorbis_Enc_DLL}"
+                 IMPORTED_IMPLIB "${Vorbis_Enc_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      Vorbis::vorbisenc
+      PROPERTIES IMPORTED_LOCATION "${Vorbis_Enc_LIBRARY}"
+    )
+  endif()
 endif()
 
 if(Vorbis_File_FOUND AND NOT TARGET Vorbis::vorbisfile)
-  add_library(Vorbis::vorbisfile UNKNOWN IMPORTED)
+  add_library(Vorbis::vorbisfile ${_vorbisfile_library_type} IMPORTED)
   set_target_properties(
     Vorbis::vorbisfile
-    PROPERTIES IMPORTED_LOCATION "${Vorbis_File_LIBRARY}"
-               INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_INCLUDE_DIR}"
+    PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Vorbis_INCLUDE_DIR}"
                INTERFACE_COMPILE_OPTIONS "${_vorbisfile_compile_options}"
                INTERFACE_LINK_LIBRARIES "${_vorbisfile_link_libraries}"
                INTERFACE_LINK_DIRECTORIES "${_vorbisfile_link_directories}"
-               INTERFACE_LINK_OPTIONS "${_vorbisfile_link_options}")
+               INTERFACE_LINK_OPTIONS "${_vorbisfile_link_options}"
+  )
+  if(Vorbis_File_DLL)
+    set_target_properties(
+      Vorbis::vorbisfile
+      PROPERTIES IMPORTED_LOCATION "${Vorbis_File_DLL}"
+                 IMPORTED_IMPLIB "${Vorbis_File_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      Vorbis::vorbisfile
+      PROPERTIES IMPORTED_LOCATION "${Vorbis_File_LIBRARY}"
+    )
+  endif()
 endif()
 
-mark_as_advanced(Vorbis_INCLUDE_DIR Vorbis_Vorbis_LIBRARY Vorbis_Enc_LIBRARY
-                 Vorbis_File_LIBRARY)
+mark_as_advanced(
+  Vorbis_INCLUDE_DIR
+  Vorbis_Vorbis_DLL
+  Vorbis_Enc_DLL
+  Vorbis_File_DLL
+  Vorbis_Vorbis_LIBRARY
+  Vorbis_Enc_LIBRARY
+  Vorbis_File_LIBRARY
+)

--- a/prboom2/cmake/Findlibzip.cmake
+++ b/prboom2/cmake/Findlibzip.cmake
@@ -27,6 +27,8 @@ The following cache variables may also be set:
 
 ``libzip_INCLUDE_DIR``
   The directory containing ``zip.h``.
+``libzip_DLL``
+  The path to the libzip Windows runtime.
 ``libzip_LIBRARY``
   The path to the libzip library.
 
@@ -38,42 +40,79 @@ pkg_check_modules(PC_LIBZIP QUIET libzip)
 find_path(
   libzip_INCLUDE_DIR
   NAMES zip.h
-  HINTS ${PC_LIBZIP_INCLUDEDIR})
+  HINTS "${PC_LIBZIP_INCLUDEDIR}"
+)
+
+find_file(
+  libzip_DLL
+  NAMES zip.dll libzip.dll
+  PATH_SUFFIXES bin
+  HINTS "${PC_LIBZIP_PREFIX}"
+)
 
 find_library(
   libzip_LIBRARY
   NAMES zip
-  HINTS ${PC_LIBZIP_LIBDIR})
+  HINTS "${PC_LIBZIP_LIBDIR}"
+)
 
-if(PC_LIBZIP_FOUND)
-  get_flags_from_pkg_config("${libzip_LIBRARY}" "PC_LIBZIP" "_libzip")
-elseif(libzip_LIBRARY)
-  set(_libzip_link_libraries
-      ""
-      CACHE FILEPATH "Additional libraries to link to libzip.")
+if(libzip_DLL OR libzip_LIBRARY MATCHES ".so|.dylib")
+  set(_libzip_library_type SHARED)
+else()
+  set(_libzip_library_type STATIC)
+endif()
+
+get_flags_from_pkg_config("${_libzip_library_type}" "PC_LIBZIP" "_libzip")
+
+if(_libzip_library_type STREQUAL "STATIC" AND NOT PC_LIBZIP_FOUND)
+  set(libzip_LINK_LIBRARIES "" CACHE STRING "Additional libraries to link to libzip.")
+  set(libzip_LINK_DIRECTORIES "" CACHE PATH "Additional directories to search libraries in for libzip.")
+  set(_libzip_link_libraries ${libzip_LINK_LIBRARIES})
+  set(_libzip_link_directories ${libzip_LINK_DIRECTORIES})
   if(NOT _libzip_link_libraries)
-    message(
-      "pkg-config is unavailable, if libzip is a static library, linking will fail.\n"
-      "Set '_libzip_link_libraries' to the list of libraries to link.")
+    message(WARNING
+      "pkg-config is unavailable and libzip seems to be static, link failures are to be expected.\n"
+      "Set `libzip_LINK_LIBRARIES` to a list of libraries libzip depends on.\n"
+      "Set `libzip_LINK_DIRECTORIES` to a list of directories to search for libraries in."
+    )
   endif()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(libzip REQUIRED_VARS "libzip_LIBRARY"
-                                                       "libzip_INCLUDE_DIR")
+find_package_handle_standard_args(
+  libzip
+  REQUIRED_VARS "libzip_LIBRARY" "libzip_INCLUDE_DIR"
+)
 
 if(libzip_FOUND)
   if(NOT TARGET libzip::zip)
-    add_library(libzip::zip UNKNOWN IMPORTED)
+    add_library(libzip::zip ${_libzip_library_type} IMPORTED)
     set_target_properties(
       libzip::zip
-      PROPERTIES IMPORTED_LOCATION "${libzip_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${libzip_INCLUDE_DIR}"
+      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${libzip_INCLUDE_DIR}"
                  INTERFACE_COMPILE_OPTIONS "${_libzip_compile_options}"
                  INTERFACE_LINK_LIBRARIES "${_libzip_link_libraries}"
                  INTERFACE_LINK_DIRECTORIES "${_libzip_link_directories}"
-                 INTERFACE_LINK_OPTIONS "${_libzip_link_options}")
+                 INTERFACE_LINK_OPTIONS "${_libzip_link_options}"
+    )
+  endif()
+
+  if(libzip_DLL)
+    set_target_properties(
+      libzip::zip
+      PROPERTIES IMPORTED_LOCATION "${libzip_DLL}"
+                 IMPORTED_IMPLIB "${libzip_LIBRARY}"
+    )
+  else()
+    set_target_properties(
+      libzip::zip
+      PROPERTIES IMPORTED_LOCATION "${libzip_LIBRARY}"
+    )
   endif()
 endif()
 
-mark_as_advanced(libzip_INCLUDE_DIR libzip_LIBRARY)
+mark_as_advanced(
+  libzip_INCLUDE_DIR
+  libzip_DLL
+  libzip_LIBRARY
+)

--- a/prboom2/cmake/PkgConfigHelper.cmake
+++ b/prboom2/cmake/PkgConfigHelper.cmake
@@ -1,7 +1,23 @@
 # Helper for Find modules
 
-function(get_flags_from_pkg_config _library _pc_prefix _out_prefix)
-  if("${_library}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+function(get_flags_from_pkg_config _library_type _pc_prefix _out_prefix)
+  if(NOT ${_pc_prefix}_FOUND)
+    set(${_out_prefix}_compile_options
+        ""
+        PARENT_SCOPE)
+    set(${_out_prefix}_link_libraries
+        ""
+        PARENT_SCOPE)
+    set(${_out_prefix}_link_options
+        ""
+        PARENT_SCOPE)
+    set(${_out_prefix}_link_directories
+        ""
+        PARENT_SCOPE)
+    return()
+  endif()
+
+  if("${_library_type}" STREQUAL "STATIC")
     set(_cflags ${_pc_prefix}_STATIC_CFLAGS_OTHER)
     set(_link_libraries ${_pc_prefix}_STATIC_LIBRARIES)
     set(_link_options ${_pc_prefix}_STATIC_LDFLAGS_OTHER)

--- a/prboom2/cmake/SelectDllConfigurations.cmake
+++ b/prboom2/cmake/SelectDllConfigurations.cmake
@@ -1,0 +1,38 @@
+# Similar to CMake's SelectLibraryConfigurations but adapted to DLLs
+
+macro(select_dll_configurations basename)
+  if(NOT ${basename}_DLL_RELEASE)
+    set(${basename}_DLL_RELEASE
+        "${basename}_DLL_RELEASE-NOTFOUND"
+        CACHE FILEPATH "Path to the release DLL.")
+  endif()
+  if(NOT ${basename}_DLL_DEBUG)
+    set(${basename}_DLL_DEBUG
+        "${basename}_DLL_DEBUG-NOTFOUND"
+        CACHE FILEPATH "Path to the debug DLL.")
+  endif()
+
+  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(${basename}_DLL_DEBUG
+     AND ${basename}_DLL_RELEASE
+     AND NOT ${basename}_DLL_DEBUG STREQUAL ${basename}_DLL_RELEASE
+     AND (_isMultiConfig OR CMAKE_BUILD_TYPE))
+    # if the generator is multi-config or if CMAKE_BUILD_TYPE is set for
+    # single-config generators, set optimized and debug libraries
+    set(${basename}_DLL "")
+    foreach(_libname IN LISTS ${basename}_DLL_RELEASE)
+      list(APPEND ${basename}_DLL optimized "${_libname}")
+    endforeach()
+    foreach(_libname IN LISTS ${basename}_DLL_DEBUG)
+      list(APPEND ${basename}_DLL debug "${_libname}")
+    endforeach()
+  elseif(${basename}_DLL_RELEASE)
+    set(${basename}_DLL ${${basename}_DLL_RELEASE})
+  elseif(${basename}_DLL_DEBUG)
+    set(${basename}_DLL ${${basename}_DLL_DEBUG})
+  else()
+    set(${basename}_DLL "${basename}_DLL-NOTFOUND")
+  endif()
+
+  mark_as_advanced(${basename}_DLL_RELEASE ${basename}_DLL_DEBUG)
+endmacro()

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -598,7 +598,20 @@ function(AddGameExecutable TARGET SOURCES)
     else()
         set(DSDA_BINARY_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
     endif()
-    install(TARGETS ${TARGET} COMPONENT "Game executable" RUNTIME DESTINATION "${DSDA_BINARY_INSTALL_DIR}")
+
+    if(CMAKE_VERSION VERSION_GREATER 3.20 AND NOT VCPKG_TOOLCHAIN AND WIN32)
+        install(
+            TARGETS ${TARGET}
+            RUNTIME_DEPENDENCIES 
+                PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+                POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+                DIRECTORIES $<TARGET_FILE_DIR:${TARGET}> $ENV{PATH}
+            RUNTIME DESTINATION "${DSDA_BINARY_INSTALL_DIR}"
+            COMPONENT "Game executable"
+        )
+    else()
+        install(TARGETS ${TARGET} COMPONENT "Game executable" RUNTIME DESTINATION "${DSDA_BINARY_INSTALL_DIR}")
+    endif()
 
     target_link_libraries(${TARGET} PRIVATE
         ${OPENGL_gl_LIBRARY}


### PR DESCRIPTION
When using vpckg, dependent DLLs are copied to the build directory and installed alongside the executable (using `X_VCPKG_APPLOCAL_DEPS_INSTALL`). This PR aims to provide similar support for non-vcpkg users on Windows (MSYS2, manually-built dependencies).

To achieve this, every Find module had to be reworked to capture whether the library is `SHARED` or `STATIC`. For this to work:
- First, we search for a DLL using `find_file` with a list of the possible names it may have (it is not uncommon that vcpkg and MSYS2 will name them differently).
- We call `find_library` as usual.
- If a DLL is found or the library ends in `.dylib` or `.so`, it is safe to assume it is shared, otherwise assume static.
- When creating the target, if a DLL is found add it as the `IMPORTED_LOCATION` and the library as `IMPORTED_IMPLIB`.

For libraries such as Dumb or SDL2* that may have a debug variant also installed. Search for both a `_DLL_RELEASE` and `_DLL_DEBUG` variant and use a custom module similar to `SelectLibraryConfigurations` but for DLLs.

The SDL2 Find module has been updated to better match what upstream is doing, that is:
- When a static library is found, provide `SDL2::SDL2-static`.
- When a shared library is found, provide `SDL2::SDL2`.
- If only the static library is found, make `SDL2::SDL2` an alias of `SDL2::SDL2-static`.

During install, use the `RUNTIME_DEPENDENCIES` argument to capture all the dependencies and install them along the executable. This is specifically run:
- Only on `WIN32` platforms, while dependency tracking works for other platforms, it does not set RPATH, may just copy a bunch of shared libraries to `/usr/local/lib` if you're not careful. And it already works great *without*.
- When vcpkg is *not* provided. vcpkg provides its own mechanism to achieve that, and trying to use `RUNTIME_DEPENDENCIES` on top of it breaks.
- When CMake's version is =>3.21. This avoids bumping the minimum version all the way up to 3.21 when only Windows users benefit from it.

One drawback is that unlike vcpkg, DLLs are not copied to the build directory. This is okay for MSYS2 users as the required DLLs are in the PATH when ran from an MSYS Terminal. I tried using the `$<TARGET_RUNTIME_DLLS:tgt>` generator expression, but it does not list transitive dependencies unfortunately.

The build guide for Windows has also been updated accordingly.

---

I was able to test the changes on:
- Windows using vcpkg (static and shared)
- Windows using MSYS2 UCRT64
- macOS using vcpkg (static)
- macOS using Homebrew (shared)
- Ubuntu using vcpkg (static)
- Ubuntu using system libraries