### PR TITLE
Add level table

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -217,6 +217,8 @@ set(COMMON_SRC
     dsda/udmf.h
     dsda/utility.c
     dsda/utility.h
+    dsda/wad_stats.c
+    dsda/wad_stats.h
     dsda/zipfile.c
     dsda/zipfile.h
     dstrings.c

--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -81,6 +81,7 @@
 #include "dsda/split_tracker.h"
 #include "dsda/text_file.h"
 #include "dsda/time.h"
+#include "dsda/wad_stats.h"
 
 /* Most of the following has been rewritten by Lee Killough
  *
@@ -192,6 +193,7 @@ static void I_EssentialQuit (void)
   dsda_ExportTextFile();
   dsda_WriteAnalysis();
   dsda_WriteSplits();
+  dsda_SaveWadStats();
 }
 
 static void I_Quit (void)

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -104,6 +104,7 @@
 #include "dsda/sndinfo.h"
 #include "dsda/time.h"
 #include "dsda/utility.h"
+#include "dsda/wad_stats.h"
 #include "dsda/zipfile.h"
 #include "dsda/gl/render_scale.h"
 
@@ -1812,6 +1813,9 @@ static void D_DoomMainSetup(void)
   PostProcessDeh();
   dsda_AppendZDoomMobjInfo();
   dsda_ApplyDefaultMapFormat();
+
+  lprintf(LO_DEBUG, "dsda_InitWadStats: Setting up wad stats.\n");
+  dsda_InitWadStats();
 
   lprintf(LO_INFO, "\n"); // Separator after file loading
 

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -230,6 +230,7 @@ extern  int totalsecret;
 extern  int basetic;
 extern  int leveltime;       // level time in tics
 extern  int totalleveltimes; // sum of intermission times in tics at second resolution
+extern  int levels_completed;
 
 // --------------------------------------
 // DEMO playback/recording related stuff.

--- a/prboom2/src/dsda.c
+++ b/prboom2/src/dsda.c
@@ -297,6 +297,7 @@ void dsda_WatchDeath(mobj_t* thing) {
 void dsda_WatchKill(player_t* player, mobj_t* target) {
   player->killcount++;
   if (target->intflags & MIF_SPAWNED_BY_ICON) player->maxkilldiscount++;
+  dsda_WadStatsKill();
 }
 
 void dsda_WatchResurrection(mobj_t* target, mobj_t* raiser) {

--- a/prboom2/src/dsda.c
+++ b/prboom2/src/dsda.c
@@ -39,6 +39,7 @@
 #include "dsda/settings.h"
 #include "dsda/split_tracker.h"
 #include "dsda/tracker.h"
+#include "dsda/wad_stats.h"
 #include "dsda.h"
 
 #define TELEFRAG_DAMAGE 10000
@@ -425,6 +426,7 @@ void dsda_WatchAfterLevelSetup(void) {
   dsda_SpawnGhost();
   dsda_ResetTrackers();
   dsda_ResetLineActivationTracker();
+  dsda_WadStatsEnterMap();
 }
 
 void dsda_WatchNewLevel(void) {
@@ -437,6 +439,7 @@ void dsda_WatchLevelCompletion(void) {
   int i;
   int secret_count = 0;
   int kill_count = 0;
+  int missed_monsters = 0;
 
   for (th = thinkercap.next; th != &thinkercap; th = th->next) {
     if (th->function != P_MobjThinker) continue;
@@ -449,7 +452,7 @@ void dsda_WatchLevelCompletion(void) {
       && !(mobj->intflags & MIF_SPAWNED_BY_ICON) \
       && mobj->health > 0
     ) {
-      ++dsda_missed_monsters;
+      ++missed_monsters;
     }
 
     if (dsda_IsWeapon(mobj)) {
@@ -457,6 +460,8 @@ void dsda_WatchLevelCompletion(void) {
       dsda_weapon_collector = false;
     }
   }
+
+  dsda_missed_monsters += missed_monsters;
 
   for (i = 0; i < g_maxplayers; ++i) {
     if (!playeringame[i]) continue;
@@ -477,6 +482,7 @@ void dsda_WatchLevelCompletion(void) {
   dsda_any_map_completed = true;
 
   dsda_RecordSplit();
+  dsda_WadStatsExitMap(missed_monsters);
 }
 
 dboolean dsda_IsWeapon(mobj_t* thing) {

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -84,6 +84,7 @@ static void dsda_ArchiveContext(void) {
 
   P_SAVE_X(leveltime);
   P_SAVE_X(totalleveltimes);
+  P_SAVE_X(levels_completed);
 
   logictic_value = logictic;
   P_SAVE_X(logictic_value);
@@ -115,6 +116,7 @@ static void dsda_UnArchiveContext(void) {
 
   P_LOAD_X(leveltime);
   P_LOAD_X(totalleveltimes);
+  P_LOAD_X(levels_completed);
 
   P_LOAD_X(logictic_value);
   basetic = gametic - logictic_value;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -263,8 +263,9 @@ void dsda_WadStatsExitMap(int missed_monsters) {
     }
 
     if (skill >= current_map_stats->best_skill) {
-      if (current_map_stats->best_time == -1 || current_map_stats->best_time > leveltime)
-        current_map_stats->best_time = leveltime;
+      if (levels_completed == 1)
+        if (current_map_stats->best_time == -1 || current_map_stats->best_time > leveltime)
+          current_map_stats->best_time = leveltime;
 
       current_map_stats->max_kills = totalkills;
       current_map_stats->max_items = totalitems;
@@ -274,10 +275,11 @@ void dsda_WadStatsExitMap(int missed_monsters) {
         if (totalkills - missed_monsters > current_map_stats->best_kills)
           current_map_stats->best_kills = totalkills - missed_monsters;
 
-        if (current_map_stats->best_kills == current_map_stats->max_kills &&
-            current_map_stats->best_secrets == current_map_stats->max_secrets &&
-            (current_map_stats->best_max_time == -1 || current_map_stats->best_max_time > leveltime))
-          current_map_stats->best_max_time = leveltime;
+        if (levels_completed == 1)
+          if (current_map_stats->best_kills == current_map_stats->max_kills &&
+              current_map_stats->best_secrets == current_map_stats->max_secrets &&
+              (current_map_stats->best_max_time == -1 || current_map_stats->best_max_time > leveltime))
+            current_map_stats->best_max_time = leveltime;
       }
 
       if (players[consoleplayer].itemcount > current_map_stats->best_items)

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -70,6 +70,15 @@ static int C_DECL dicmp_map_stats(const void* a, const void* b) {
   const map_stats_t* m1 = (const map_stats_t *) a;
   const map_stats_t* m2 = (const map_stats_t *) b;
 
+  if (m1->episode == -1 && m2->episode == -1)
+    return m1->lump[0] - m2->lump[0];
+
+  if (m1->episode == -1)
+    return 1;
+
+  if (m2->episode == -1)
+    return -1;
+
   return (m1->episode == m2->episode) ?
          (m1->map == m2->map) ?
          m1->lump[0] - m2->lump[0] : m1->map - m2->map : m1->episode - m2->episode;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -137,6 +137,7 @@ static void dsda_CreateWadStats(void) {
 
       ms->best_time = -1;
       ms->best_max_time = -1;
+      ms->best_sk5_time = -1;
       ms->max_kills = -1;
       ms->max_items = -1;
       ms->max_secrets = -1;
@@ -177,13 +178,13 @@ static void dsda_LoadWadStats(void) {
 
         if (
           sscanf(
-            lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d",
+            lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
             ms.lump, &ms.episode, &ms.map,
-            &ms.best_skill, &ms.best_time, &ms.best_max_time,
+            &ms.best_skill, &ms.best_time, &ms.best_max_time, &ms.best_sk5_time,
             &ms.total_exits, &ms.total_kills,
             &ms.best_kills, &ms.best_items, &ms.best_secrets,
             &ms.max_kills, &ms.max_items, &ms.max_secrets
-          ) == 14
+          ) == 15
         ) {
           map_count += 1;
           dsda_EnsureMapCount(map_count);
@@ -219,9 +220,9 @@ void dsda_SaveWadStats(void) {
     map_stats_t* ms;
 
     ms = &wad_stats.maps[i];
-    fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+    fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
             ms->lump, ms->episode, ms->map,
-            ms->best_skill, ms->best_time, ms->best_max_time,
+            ms->best_skill, ms->best_time, ms->best_max_time, ms->best_sk5_time,
             ms->total_exits, ms->total_kills,
             ms->best_kills, ms->best_items, ms->best_secrets,
             ms->max_kills, ms->max_items, ms->max_secrets);
@@ -268,6 +269,10 @@ void dsda_WadStatsExitMap(int missed_monsters) {
       if (levels_completed == 1)
         if (current_map_stats->best_time == -1 || current_map_stats->best_time > leveltime)
           current_map_stats->best_time = leveltime;
+
+      if (levels_completed == 1 && skill == 5)
+        if (current_map_stats->best_sk5_time == -1 || current_map_stats->best_sk5_time > leveltime)
+          current_map_stats->best_sk5_time = leveltime;
 
       current_map_stats->max_kills = totalkills;
       current_map_stats->max_items = totalitems;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -257,23 +257,41 @@ void dsda_WadStatsExitMap(int missed_monsters) {
   if (!current_map_stats)
     return;
 
-  skill = gameskill + 1;
-  if (skill > current_map_stats->best_skill)
-    current_map_stats->best_skill = skill;
+  if (!nomonsters) {
+    skill = gameskill + 1;
+    if (skill > current_map_stats->best_skill) {
+      if (current_map_stats->best_skill < 4) {
+        current_map_stats->best_time = -1;
+        current_map_stats->best_max_time = -1;
+      }
 
-  if (skill >= current_map_stats->best_skill && skill != 5) {
-    current_map_stats->max_kills = totalkills;
-    current_map_stats->max_items = totalitems;
-    current_map_stats->max_secrets = totalsecret;
+      current_map_stats->best_skill = skill;
+    }
 
-    if (totalkills - missed_monsters > current_map_stats->best_kills)
-      current_map_stats->best_kills = totalkills - missed_monsters;
+    if (skill >= current_map_stats->best_skill) {
+      if (current_map_stats->best_time == -1 || current_map_stats->best_time > leveltime)
+        current_map_stats->best_time = leveltime;
 
-    if (players[consoleplayer].itemcount > current_map_stats->best_items)
-      current_map_stats->best_items = players[consoleplayer].itemcount;
+      current_map_stats->max_kills = totalkills;
+      current_map_stats->max_items = totalitems;
+      current_map_stats->max_secrets = totalsecret;
 
-    if (players[consoleplayer].secretcount > current_map_stats->best_secrets)
-      current_map_stats->best_secrets = players[consoleplayer].secretcount;
+      if (!respawnmonsters) {
+        if (totalkills - missed_monsters > current_map_stats->best_kills)
+          current_map_stats->best_kills = totalkills - missed_monsters;
+
+        if (current_map_stats->best_kills == current_map_stats->max_kills &&
+            current_map_stats->best_secrets == current_map_stats->max_secrets &&
+            (current_map_stats->best_max_time == -1 || current_map_stats->best_max_time > leveltime))
+          current_map_stats->best_max_time = leveltime;
+      }
+
+      if (players[consoleplayer].itemcount > current_map_stats->best_items)
+        current_map_stats->best_items = players[consoleplayer].itemcount;
+
+      if (players[consoleplayer].secretcount > current_map_stats->best_secrets)
+        current_map_stats->best_secrets = players[consoleplayer].secretcount;
+    }
   }
 
   ++current_map_stats->total_exits;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -262,7 +262,7 @@ void dsda_WadStatsExitMap(int missed_monsters) {
       current_map_stats->best_skill = skill;
     }
 
-    if (skill >= current_map_stats->best_skill) {
+    if (skill >= current_map_stats->best_skill || skill == 4) {
       if (levels_completed == 1)
         if (current_map_stats->best_time == -1 || current_map_stats->best_time > leveltime)
           current_map_stats->best_time = leveltime;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -291,6 +291,14 @@ void dsda_WadStatsExitMap(int missed_monsters) {
   ++current_map_stats->total_exits;
 }
 
+void dsda_WadStatsKill(void) {
+  if (!current_map_stats)
+    return;
+
+  ++current_map_stats->total_kills;
+  ++wad_stats.total_kills;
+}
+
 void dsda_InitWadStats(void) {
   dsda_LoadWadStats();
 

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -135,6 +135,8 @@ static void dsda_CreateWadStats(void) {
         ms->map = -1;
       }
 
+      ms->best_time = -1;
+      ms->best_max_time = -1;
       ms->max_kills = -1;
       ms->max_items = -1;
       ms->max_secrets = -1;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -169,10 +169,9 @@ static void dsda_LoadWadStats(void) {
 
       if (
         sscanf(
-          lines[1], "%d %d %d %d",
-          &wad_stats.total_exits, &wad_stats.total_kills,
-          &wad_stats.total_items, &wad_stats.total_secrets
-        ) != 4
+          lines[1], "%d %d",
+          &wad_stats.total_exits, &wad_stats.total_kills
+        ) != 2
       )
         I_Error("Encountered invalid wad stats: %s", path);
 
@@ -181,13 +180,13 @@ static void dsda_LoadWadStats(void) {
 
         if (
           sscanf(
-            lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
+            lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d",
             ms.lump, &ms.episode, &ms.map,
             &ms.best_skill, &ms.best_time, &ms.best_max_time,
-            &ms.total_exits, &ms.total_kills, &ms.total_items, &ms.total_secrets,
+            &ms.total_exits, &ms.total_kills,
             &ms.best_kills, &ms.best_items, &ms.best_secrets,
             &ms.max_kills, &ms.max_items, &ms.max_secrets
-          ) == 16
+          ) == 14
         ) {
           map_count += 1;
           dsda_EnsureMapCount(map_count);
@@ -217,18 +216,17 @@ void dsda_SaveWadStats(void) {
     lprintf(LO_WARN, "dsda_SaveWadStats: Failed to save wad stats file \"%s\".", path);
 
   fprintf(file, "%d\n", current_version);
-  fprintf(file, "%d %d %d %d\n",
-          wad_stats.total_exits, wad_stats.total_kills,
-          wad_stats.total_items, wad_stats.total_secrets);
+  fprintf(file, "%d %d\n",
+          wad_stats.total_exits, wad_stats.total_kills);
 
   for (i = 0; i < wad_stats.map_count; ++i) {
     map_stats_t* ms;
 
     ms = &wad_stats.maps[i];
-    fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+    fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
             ms->lump, ms->episode, ms->map,
             ms->best_skill, ms->best_time, ms->best_max_time,
-            ms->total_exits, ms->total_kills, ms->total_items, ms->total_secrets,
+            ms->total_exits, ms->total_kills,
             ms->best_kills, ms->best_items, ms->best_secrets,
             ms->max_kills, ms->max_items, ms->max_secrets);
   }

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -234,9 +234,6 @@ void dsda_SaveWadStats(void) {
 static map_stats_t* dsda_MapStats(int episode, int map) {
   int i;
 
-  if (demoplayback)
-    return NULL;
-
   for (i = 0; i < wad_stats.map_count; ++i)
     if (wad_stats.maps[i].episode == episode && wad_stats.maps[i].map == map)
       return &wad_stats.maps[i];
@@ -251,7 +248,7 @@ void dsda_WadStatsEnterMap(void) {
 void dsda_WadStatsExitMap(int missed_monsters) {
   int skill;
 
-  if (!current_map_stats)
+  if (!current_map_stats || demoplayback)
     return;
 
   if (!nomonsters) {
@@ -301,7 +298,7 @@ void dsda_WadStatsExitMap(int missed_monsters) {
 }
 
 void dsda_WadStatsKill(void) {
-  if (!current_map_stats)
+  if (!current_map_stats || demoplayback)
     return;
 
   ++current_map_stats->total_kills;

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -179,13 +179,13 @@ static void dsda_LoadWadStats(void) {
 
         if (
           sscanf(
-            lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
+            lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
             ms.lump, &ms.episode, &ms.map,
-            &ms.best_skill, &ms.best_time, &ms.best_max_time, &ms.total_time,
+            &ms.best_skill, &ms.best_time, &ms.best_max_time,
             &ms.total_exits, &ms.total_kills, &ms.total_items, &ms.total_secrets,
             &ms.best_kills, &ms.best_items, &ms.best_secrets,
             &ms.max_kills, &ms.max_items, &ms.max_secrets
-          ) != 17
+          ) == 16
         ) {
           map_count += 1;
           dsda_EnsureMapCount(map_count);
@@ -223,9 +223,9 @@ void dsda_SaveWadStats(void) {
     map_stats_t* ms;
 
     ms = &wad_stats.maps[i];
-    fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
+    fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
             ms->lump, ms->episode, ms->map,
-            ms->best_skill, ms->best_time, ms->best_max_time, ms->total_time,
+            ms->best_skill, ms->best_time, ms->best_max_time,
             ms->total_exits, ms->total_kills, ms->total_items, ms->total_secrets,
             ms->best_kills, ms->best_items, ms->best_secrets,
             ms->max_kills, ms->max_items, ms->max_secrets);

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -167,12 +167,7 @@ static void dsda_LoadWadStats(void) {
       if (version > current_version)
         I_Error("Encountered unsupported wad stats version: %s", path);
 
-      if (
-        sscanf(
-          lines[1], "%d %d",
-          &wad_stats.total_exits, &wad_stats.total_kills
-        ) != 2
-      )
+      if (sscanf(lines[1], "%d", &wad_stats.total_kills) != 1)
         I_Error("Encountered invalid wad stats: %s", path);
 
       for (i = 2; lines[i] && *lines[i]; ++i) {
@@ -216,8 +211,7 @@ void dsda_SaveWadStats(void) {
     lprintf(LO_WARN, "dsda_SaveWadStats: Failed to save wad stats file \"%s\".", path);
 
   fprintf(file, "%d\n", current_version);
-  fprintf(file, "%d %d\n",
-          wad_stats.total_exits, wad_stats.total_kills);
+  fprintf(file, "%d\n", wad_stats.total_kills);
 
   for (i = 0; i < wad_stats.map_count; ++i) {
     map_stats_t* ms;

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -49,6 +49,8 @@ typedef struct {
 
 extern wad_stats_t wad_stats;
 
+void dsda_WadStatsEnterMap(void);
+void dsda_WadStatsExitMap(int missed_monsters);
 void dsda_SaveWadStats(void);
 void dsda_InitWadStats(void);
 

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -46,6 +46,7 @@ extern wad_stats_t wad_stats;
 
 void dsda_WadStatsEnterMap(void);
 void dsda_WadStatsExitMap(int missed_monsters);
+void dsda_WadStatsKill(void);
 void dsda_SaveWadStats(void);
 void dsda_InitWadStats(void);
 

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -1,0 +1,56 @@
+//
+// Copyright(C) 2023 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Wad Stats
+//
+
+#ifndef __DSDA_WAD_STATS__
+#define __DSDA_WAD_STATS__
+
+typedef struct {
+  char lump[9];
+  int episode;
+  int map;
+  int best_skill;
+  int best_time;
+  int best_max_time;
+  int total_time;
+  int total_exits;
+  int total_kills;
+  int total_items;
+  int total_secrets;
+  int best_kills;
+  int best_items;
+  int best_secrets;
+  int max_kills;
+  int max_items;
+  int max_secrets;
+} map_stats_t;
+
+typedef struct {
+  int total_exits;
+  int total_kills;
+  int total_items;
+  int total_secrets;
+  map_stats_t* maps;
+  int maps_size;
+  int map_count;
+} wad_stats_t;
+
+extern wad_stats_t wad_stats;
+
+void dsda_SaveWadStats(void);
+void dsda_InitWadStats(void);
+
+#endif

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -36,7 +36,6 @@ typedef struct {
 } map_stats_t;
 
 typedef struct {
-  int total_exits;
   int total_kills;
   map_stats_t* maps;
   int maps_size;

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -23,8 +23,9 @@ typedef struct {
   int episode;
   int map;
   int best_skill;
-  int best_time; // check pistol start ?
-  int best_max_time; // check pistol start ?
+  int best_time;
+  int best_max_time;
+  int best_sk5_time;
   int total_exits;
   int total_kills;
   int best_kills;

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -23,9 +23,8 @@ typedef struct {
   int episode;
   int map;
   int best_skill;
-  int best_time;
-  int best_max_time;
-  int total_time;
+  int best_time; // check pistol start ?
+  int best_max_time; // check pistol start ?
   int total_exits;
   int total_kills;
   int total_items;

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -27,8 +27,6 @@ typedef struct {
   int best_max_time; // check pistol start ?
   int total_exits;
   int total_kills;
-  int total_items;
-  int total_secrets;
   int best_kills;
   int best_items;
   int best_secrets;
@@ -40,8 +38,6 @@ typedef struct {
 typedef struct {
   int total_exits;
   int total_kills;
-  int total_items;
-  int total_secrets;
   map_stats_t* maps;
   int maps_size;
   int map_count;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -172,6 +172,7 @@ dboolean         demorecording;
 wbstartstruct_t wminfo;               // parms for world map / intermission
 dboolean         haswolflevels = false;// jff 4/18/98 wolf levels present
 int             totalleveltimes;      // CPhipps - total time for all completed levels
+int             levels_completed;
 int             longtics;
 
 dboolean coop_spawns;
@@ -1801,6 +1802,8 @@ void G_PlayerReborn (int player)
 
   for (i=0 ; i<NUMAMMO ; i++)
     p->maxammo[i] = maxammo[i];
+
+  levels_completed = 0;
 }
 
 //
@@ -2053,6 +2056,7 @@ void G_DoCompleted (void)
     totalleveltimes = players[consoleplayer].worldTimer;
   else
     totalleveltimes += leveltime - leveltime % 35;
+  ++levels_completed;
 
   gameaction = ga_nothing;
 
@@ -2969,6 +2973,7 @@ void G_InitNew(skill_t skill, int episode, int map, dboolean prepare)
   dsda_UpdateGameMap(episode, map);
 
   totalleveltimes = 0; // cph
+  levels_completed = 0;
 
   dsda_EvaluateSkipModeInitNew();
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4427,6 +4427,36 @@ dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
   return false;
 }
 
+dboolean M_SetupResponder(int ch, int action, event_t* ev)
+{
+  if (M_SetupCommonSelectResponder(ch, action, ev))
+    return true;
+
+  if (set_keybnd_active) // on a key binding setup screen
+    if (M_KeyBndResponder(ch, action, ev))
+      return true;
+
+  if (set_weapon_active) // on the weapons setup screen
+    if (M_WeaponResponder(ch, action, ev))
+      return true;
+
+  if (set_auto_active) // on the automap setup screen
+    if (M_AutoResponder(ch, action, ev))
+      return true;
+
+  // killough 10/98: consolidate handling into one place:
+  if (set_general_active || set_status_active)
+    if (M_StringResponder(ch, action, ev))
+      return true;
+
+  // Not changing any items on the Setup screens. See if we're
+  // navigating the Setup menus or selecting an item to change.
+  if (M_SetupNavigationResponder(ch, action, ev))
+    return true;
+
+  return false;
+}
+
 dboolean M_Responder (event_t* ev) {
   int    ch, action;
   int    i;
@@ -4910,35 +4940,9 @@ dboolean M_Responder (event_t* ev) {
     }
   }
 
-  // phares 3/26/98 - 4/11/98:
-  // Setup screen key processing
-
-  if (setup_active) {
-    if (M_SetupCommonSelectResponder(ch, action, ev))
+  if (setup_active)
+    if (M_SetupResponder(ch, action, ev))
       return true;
-
-    if (set_keybnd_active) // on a key binding setup screen
-      if (M_KeyBndResponder(ch, action, ev))
-        return true;
-
-    if (set_weapon_active) // on the weapons setup screen
-      if (M_WeaponResponder(ch, action, ev))
-        return true;
-
-    if (set_auto_active) // on the automap setup screen
-      if (M_AutoResponder(ch, action, ev))
-        return true;
-
-    // killough 10/98: consolidate handling into one place:
-    if (set_general_active || set_status_active)
-      if (M_StringResponder(ch, action, ev))
-        return true;
-
-    // Not changing any items on the Setup screens. See if we're
-    // navigating the Setup menus or selecting an item to change.
-    if (M_SetupNavigationResponder(ch, action, ev))
-      return true;
-  }
 
   // From here on, these navigation keys are used on the BIG FONT menus
   // like the Main Menu.

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3303,7 +3303,7 @@ static void M_BuildLevelTable(void)
     entry->m_x = column_x;
   END_LOOP_LEVEL_TABLE_COLUMN
 
-  column_x += 96;
+  column_x += 112;
   INSERT_LEVEL_TABLE_COLUMN("SKILL", column_x)
 
   LOOP_LEVEL_TABLE_COLUMN

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3192,7 +3192,7 @@ void M_DrawGeneral(void)
 // The level table.
 //
 
-#define LEVEL_TABLE_PAGES 2
+#define LEVEL_TABLE_PAGES 3
 
 static setup_menu_t *level_table_page[LEVEL_TABLE_PAGES];
 static setup_menu_t next_page_template = NEXT_PAGE(NULL);
@@ -3329,6 +3329,7 @@ static void M_ResetLevelTable(void)
   const int page_count[LEVEL_TABLE_PAGES] = {
     wad_stats.map_count * 5 + 16,
     wad_stats.map_count * 4 + 16,
+    24,
   };
 
   for (page = 0; page < LEVEL_TABLE_PAGES; ++page)
@@ -3362,6 +3363,8 @@ static void M_PrintTime(dsda_string_t* m_text, int tics)
                     tics / 35 / 60,
                     (float) (tics % (60 * 35)) / 35);
 }
+
+static int wad_stats_summary_page;
 
 static void M_BuildLevelTable(void)
 {
@@ -3522,6 +3525,113 @@ static void M_BuildLevelTable(void)
   END_LOOP_LEVEL_TABLE_COLUMN
 
   INSERT_LEVEL_TABLE_PREV_PAGE
+  INSERT_LEVEL_TABLE_NEXT_PAGE
+  INSERT_FINAL_LEVEL_TABLE_ENTRY
+
+  // -------- //
+
+  M_CalculateWadStatsSummary();
+
+  ++page;
+  base_i = 0;
+  wad_stats_summary_page = page;
+
+  level_table_page[page][base_i].m_text = Z_Strdup("Wad Stats Summary");
+  level_table_page[page][base_i].m_flags = S_TITLE | S_NOSELECT;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Maps: %d / %d",
+                    wad_stats_summary.completed_count, wad_stats.map_count);
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  if (wad_stats_summary.completed_count == wad_stats.map_count)
+    dsda_StringPrintF(&m_text, "Skill: %d", wad_stats_summary.best_skill);
+  else
+    dsda_StringPrintF(&m_text, "Skill: -");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Kill Completion: %d/", wad_stats_summary.best_kills);
+  if (wad_stats_summary.completed_count == wad_stats.map_count)
+    dsda_StringCatF(&m_text, "%d", wad_stats_summary.max_kills);
+  else
+    dsda_StringCat(&m_text, "-");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Item Completion: %d/", wad_stats_summary.best_items);
+  if (wad_stats_summary.completed_count == wad_stats.map_count)
+    dsda_StringCatF(&m_text, "%d", wad_stats_summary.max_items);
+  else
+    dsda_StringCat(&m_text, "-");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Secret Completion: %d/", wad_stats_summary.best_secrets);
+  if (wad_stats_summary.completed_count == wad_stats.map_count)
+    dsda_StringCatF(&m_text, "%d", wad_stats_summary.max_secrets);
+  else
+    dsda_StringCat(&m_text, "-");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Time: ");
+  if (wad_stats_summary.timed_count == wad_stats.map_count)
+    M_CatTime(&m_text, wad_stats_summary.best_time);
+  else
+    dsda_StringCat(&m_text, "- : --");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Max Time: ");
+  if (wad_stats_summary.max_timed_count == wad_stats.map_count)
+    M_CatTime(&m_text, wad_stats_summary.best_max_time);
+  else
+    dsda_StringCat(&m_text, "- : --");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Sk 5 Time: ");
+  if (wad_stats_summary.sk5_timed_count == wad_stats.map_count)
+    M_CatTime(&m_text, wad_stats_summary.best_sk5_time);
+  else
+    dsda_StringCat(&m_text, "- : --");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_PREV_PAGE
   INSERT_FINAL_LEVEL_TABLE_ENTRY
 }
 
@@ -3538,7 +3648,8 @@ void M_DrawLevelTable(void)
   M_DrawBackground(g_menu_flat, 0);
 
   M_DrawTitle(114, 2, "M_LVLTBL", CR_DEFAULT, "LEVEL TABLE", cr_title);
-  M_DrawInstructionString(cr_info_edit, "Press ENTER key to warp");
+  if (current_setup_menu != level_table_page[wad_stats_summary_page])
+    M_DrawInstructionString(cr_info_edit, "Press ENTER key to warp");
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -4385,6 +4496,9 @@ static dboolean M_LevelTableResponder(int ch, int action, event_t* ev)
   {
     int map_index;
     map_stats_t *map;
+
+    if (current_setup_menu == level_table_page[wad_stats_summary_page])
+      return true;
 
     map_index = set_menu_itemon - 1;
     map = &wad_stats.maps[map_index];

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3258,6 +3258,71 @@ static void M_FreeMText(const char *m_text)
   Z_Free(str.s);
 }
 
+typedef struct {
+  int completed_count;
+  int timed_count;
+  int max_timed_count;
+  int sk5_timed_count;
+  int best_skill;
+  int best_kills;
+  int best_items;
+  int best_secrets;
+  int max_kills;
+  int max_items;
+  int max_secrets;
+  int best_time;
+  int best_max_time;
+  int best_sk5_time;
+} wad_stats_summary_t;
+
+static wad_stats_summary_t wad_stats_summary;
+
+static void M_CalculateWadStatsSummary(void)
+{
+  int i;
+  map_stats_t *map;
+
+  memset(&wad_stats_summary, 0, sizeof(wad_stats_summary));
+
+  wad_stats_summary.best_skill = 6;
+
+  for (i = 0; i < wad_stats.map_count; ++i)
+  {
+    map = &wad_stats.maps[i];
+    if (map->episode == -1 || !map->best_skill)
+      continue;
+
+    if (map->best_skill < wad_stats_summary.best_skill)
+      wad_stats_summary.best_skill = map->best_skill;
+
+    ++wad_stats_summary.completed_count;
+    wad_stats_summary.best_kills += map->best_kills;
+    wad_stats_summary.best_items += map->best_items;
+    wad_stats_summary.best_secrets += map->best_secrets;
+    wad_stats_summary.max_kills += map->max_kills;
+    wad_stats_summary.max_items += map->max_items;
+    wad_stats_summary.max_secrets += map->max_secrets;
+
+    if (map->best_time >= 0)
+    {
+      ++wad_stats_summary.timed_count;
+      wad_stats_summary.best_time += map->best_time;
+    }
+
+    if (map->best_max_time >= 0)
+    {
+      ++wad_stats_summary.max_timed_count;
+      wad_stats_summary.best_max_time += map->best_max_time;
+    }
+
+    if (map->best_sk5_time >= 0)
+    {
+      ++wad_stats_summary.sk5_timed_count;
+      wad_stats_summary.best_sk5_time += map->best_sk5_time;
+    }
+  }
+}
+
 static void M_ResetLevelTable(void)
 {
   int i, page;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3220,6 +3220,7 @@ static setup_menu_t *level_table_page[1];
 //static setup_menu_t prev_page_template = PREV_PAGE(NULL);
 static setup_menu_t final_entry_template = FINAL_ENTRY;
 static setup_menu_t new_column_template = NEW_COLUMN;
+static setup_menu_t empty_line_template = EMPTY_LINE;
 
 #define LOOP_LEVEL_TABLE_COLUMN { \
   for (i = 0; i < wad_stats.map_count; ++i) { \
@@ -3232,13 +3233,23 @@ static setup_menu_t new_column_template = NEW_COLUMN;
   base_i += i; \
 }
 
-#define INSERT_NEW_LEVEL_TABLE_COLUMN { \
+#define INSERT_LEVEL_TABLE_COLUMN(heading, x) { \
   level_table_page[0][base_i] = new_column_template; \
+  ++base_i; \
+  level_table_page[0][base_i] = empty_line_template; \
+  level_table_page[0][base_i].m_flags |= S_TITLE; \
+  level_table_page[0][base_i].m_text = heading; \
+  level_table_page[0][base_i].m_x = x; \
   ++base_i; \
 }
 
 #define INSERT_FINAL_LEVEL_TABLE_ENTRY { \
   level_table_page[0][base_i] = final_entry_template; \
+}
+
+#define INSERT_LEVEL_TABLE_EMPTY_LINE { \
+  level_table_page[0][base_i] = empty_line_template; \
+  ++base_i; \
 }
 
 static void M_BuildLevelTable(void)
@@ -3250,25 +3261,33 @@ static void M_BuildLevelTable(void)
     map_stats_t *map;
     dsda_string_t m_text;
 
-    level_table_page[0] = Z_Calloc(wad_stats.map_count * 2 + 3, sizeof(*level_table_page[0]));
+    level_table_page[0] = Z_Calloc(wad_stats.map_count * 2 + 4, sizeof(*level_table_page[0]));
+
+    INSERT_LEVEL_TABLE_EMPTY_LINE
 
     LOOP_LEVEL_TABLE_COLUMN
       dsda_StringPrintF(&m_text, "%s", map->lump);
       entry->m_text = m_text.string;
       entry->m_flags = S_TITLE | S_LEFTJUST;
-      entry->m_x = 8;
+      entry->m_x = 16;
     END_LOOP_LEVEL_TABLE_COLUMN
 
-    INSERT_NEW_LEVEL_TABLE_COLUMN;
+    INSERT_LEVEL_TABLE_COLUMN("SKILL", 128)
 
     LOOP_LEVEL_TABLE_COLUMN
-      dsda_StringPrintF(&m_text, "%d", map->map);
-      entry->m_text = m_text.string;
-      entry->m_flags = S_TITLE | S_LEFTJUST | S_SKIP;
-      entry->m_x = 8 + 64;
+      if (map->best_skill) {
+        dsda_StringPrintF(&m_text, "%d", map->best_skill);
+        entry->m_text = m_text.string;
+      }
+      else {
+        entry->m_text = "-";
+      }
+
+      entry->m_flags = S_TITLE | S_SKIP;
+      entry->m_x = 128;
     END_LOOP_LEVEL_TABLE_COLUMN
 
-    INSERT_FINAL_LEVEL_TABLE_ENTRY;
+    INSERT_FINAL_LEVEL_TABLE_ENTRY
   END_ONCE
 }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4120,6 +4120,28 @@ static dboolean M_StringResponder(int ch, int action, event_t* ev)
   return false;
 }
 
+static dboolean M_LevelTableResponder(int ch, int action, event_t* ev)
+{
+  if (action == MENU_ENTER)
+  {
+    int map_index;
+    map_stats_t *map;
+
+    map_index = set_menu_itemon - 1;
+    map = &wad_stats.maps[map_index];
+
+    G_DeferedInitNew(gameskill, map->episode, map->map);
+
+    M_LeaveSetupMenu();
+    M_ClearMenus();
+    S_StartVoidSound(g_sfx_swtchx);
+
+    return true;
+  }
+
+  return false;
+}
+
 static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
 {
   // changing an entry
@@ -4453,6 +4475,10 @@ static dboolean M_SetupResponder(int ch, int action, event_t* ev)
   // killough 10/98: consolidate handling into one place:
   if (set_general_active || set_status_active)
     if (M_StringResponder(ch, action, ev))
+      return true;
+
+  if (level_table_active)
+    if (M_LevelTableResponder(ch, action, ev))
       return true;
 
   // Not changing any items on the Setup screens. See if we're

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3532,7 +3532,7 @@ static void M_BuildLevelTable(void)
   wad_stats_summary_page = page;
 
   level_table_page[page][base_i].m_text = Z_Strdup("Summary");
-  level_table_page[page][base_i].m_flags = S_TITLE | S_NOSELECT;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_NOSELECT | S_CENTER;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
@@ -3541,13 +3541,13 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Maps");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   dsda_StringPrintF(&m_text, "Skill");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3555,7 +3555,7 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Kill Completion");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3563,7 +3563,7 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Item Completion");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3571,7 +3571,7 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Secret Completion");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3579,7 +3579,7 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Time");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3587,7 +3587,7 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Max Time");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3595,7 +3595,7 @@ static void M_BuildLevelTable(void)
   dsda_StringPrintF(&m_text, "Sk 5 Time");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   level_table_page[page][base_i] = new_column_template;
@@ -3608,7 +3608,7 @@ static void M_BuildLevelTable(void)
                     wad_stats_summary.completed_count, wad_stats.map_count);
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   if (wad_stats_summary.completed_count == wad_stats.map_count)
@@ -3617,7 +3617,7 @@ static void M_BuildLevelTable(void)
     dsda_StringPrintF(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3629,7 +3629,7 @@ static void M_BuildLevelTable(void)
     dsda_StringCat(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3641,7 +3641,7 @@ static void M_BuildLevelTable(void)
     dsda_StringCat(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3653,7 +3653,7 @@ static void M_BuildLevelTable(void)
     dsda_StringCat(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3664,7 +3664,7 @@ static void M_BuildLevelTable(void)
     dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3675,7 +3675,7 @@ static void M_BuildLevelTable(void)
     dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
@@ -3686,7 +3686,7 @@ static void M_BuildLevelTable(void)
     dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
-  level_table_page[page][base_i].m_x = 160;
+  level_table_page[page][base_i].m_x = 162;
   ++base_i;
 
   level_table_page[page][base_i] = new_column_template;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3822,7 +3822,7 @@ dboolean M_ConsoleOpen(void)
 // action based on the state of the system.
 //
 
-dboolean M_KeyBndResponder(int ch, int action, event_t* ev)
+static dboolean M_KeyBndResponder(int ch, int action, event_t* ev)
 {
   // changing an entry
   if (setup_select)
@@ -3947,7 +3947,7 @@ dboolean M_KeyBndResponder(int ch, int action, event_t* ev)
   return false;
 }
 
-dboolean M_WeaponResponder(int ch, int action, event_t* ev)
+static dboolean M_WeaponResponder(int ch, int action, event_t* ev)
 {
   // changing an entry
   if (setup_select)
@@ -3985,7 +3985,7 @@ dboolean M_WeaponResponder(int ch, int action, event_t* ev)
   return false;
 }
 
-dboolean M_AutoResponder(int ch, int action, event_t* ev)
+static dboolean M_AutoResponder(int ch, int action, event_t* ev)
 {
   // changing an entry
   if (setup_select)
@@ -4036,7 +4036,7 @@ dboolean M_AutoResponder(int ch, int action, event_t* ev)
   return false;
 }
 
-dboolean M_StringResponder(int ch, int action, event_t* ev)
+static dboolean M_StringResponder(int ch, int action, event_t* ev)
 {
   // changing an entry
   if (setup_select)
@@ -4107,7 +4107,7 @@ dboolean M_StringResponder(int ch, int action, event_t* ev)
   return false;
 }
 
-dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
+static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
 {
   // changing an entry
   if (setup_select)
@@ -4247,7 +4247,7 @@ dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
   return false;
 }
 
-dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
+static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
 {
   setup_menu_t* ptr1 = current_setup_menu + set_menu_itemon;
   setup_menu_t* ptr2 = NULL;
@@ -4427,7 +4427,7 @@ dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
   return false;
 }
 
-dboolean M_SetupResponder(int ch, int action, event_t* ev)
+static dboolean M_SetupResponder(int ch, int action, event_t* ev)
 {
   if (M_SetupCommonSelectResponder(ch, action, ev))
     return true;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -110,6 +110,8 @@
 #define S_YESNO    0x00000008 // Yes or No item
 #define S_CRITEM   0x00000010 // Message color
 #define S_COLOR    0x00000020 // Automap color
+// #define S_      0x00000040
+// #define S_      0x00000080
 #define S_PREV     0x00000100 // Previous menu exists
 #define S_NEXT     0x00000200 // Next menu exists
 #define S_INPUT    0x00000400 // Composite input binding
@@ -118,13 +120,20 @@
 #define S_SKIP     0x00002000 // Cursor can't land here
 #define S_KEEP     0x00004000 // Don't swap key out
 #define S_END      0x00008000 // Last item in list (dummy)
-#define S_LEVWARN  0x00010000// killough 8/30/98: Always warn about pending change
-#define S_FILE     0x00080000// killough 10/98: Filenames
+#define S_LEVWARN  0x00010000 // killough 8/30/98: Always warn about pending change
+// #define S_      0x00020000
+// #define S_      0x00040000
+#define S_FILE     0x00080000 // killough 10/98: Filenames
 #define S_LEFTJUST 0x00100000 // killough 10/98: items which are left-justified
-#define S_CREDIT   0x00200000  // killough 10/98: credit
-#define S_CHOICE   0x00800000  // this item has several values
+#define S_CREDIT   0x00200000 // killough 10/98: credit
+// #define S_      0x00400000
+#define S_CHOICE   0x00800000 // this item has several values
+// #define S_      0x01000000
 #define S_NAME     0x02000000
 #define S_RESET_Y  0x04000000
+// #define S_      0x08000000
+// #define S_      0x10000000
+// #define S_      0x20000000
 #define S_STR      0x40000000 // need to refactor things...
 #define S_NOCLEAR  0x80000000
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3947,6 +3947,44 @@ dboolean M_KeyBndResponder(int ch, int action, event_t* ev)
   return false;
 }
 
+dboolean M_WeaponResponder(int ch, int action, event_t* ev)
+{
+  setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
+  setup_menu_t *ptr2 = NULL;
+
+  // changing an entry
+  if (setup_select)
+  {
+    if (action != MENU_ENTER)
+    {
+      int old_value;
+
+      ch -= '0'; // out of ascii
+      if (ch < 1 || ch > 9)
+        return true; // ignore
+
+      // see if 'ch' is already assigned elsewhere. if so,
+      // you have to swap assignments.
+      ptr2 = weap_settings1;
+      old_value = dsda_PersistentIntConfig(ptr1->config_id);
+      for (; !(ptr2->m_flags & S_END); ptr2++)
+        if (ptr2->m_flags & S_WEAP && ptr1 != ptr2 &&
+            dsda_PersistentIntConfig(ptr2->config_id) == ch)
+        {
+          dsda_UpdateIntConfig(ptr2->config_id, old_value, true);
+          break;
+        }
+
+      dsda_UpdateIntConfig(ptr1->config_id, ch, true);
+    }
+
+    M_SelectDone(ptr1);       // phares 4/17/98
+    return true;
+  }
+
+  return false;
+}
+
 dboolean M_Responder (event_t* ev) {
   int    ch, action;
   int    i;
@@ -4574,36 +4612,9 @@ dboolean M_Responder (event_t* ev) {
       if (M_KeyBndResponder(ch, action, ev))
         return true;
 
-    // Weapons
-
     if (set_weapon_active) // on the weapons setup screen
-      if (setup_select) // changing an entry
-      {
-        if (action != MENU_ENTER)
-        {
-          int old_value;
-
-          ch -= '0'; // out of ascii
-          if (ch < 1 || ch > 9)
-            return true; // ignore
-
-          // see if 'ch' is already assigned elsewhere. if so,
-          // you have to swap assignments.
-          ptr2 = weap_settings1;
-          old_value = dsda_PersistentIntConfig(ptr1->config_id);
-          for (; !(ptr2->m_flags & S_END); ptr2++)
-            if (ptr2->m_flags & S_WEAP && ptr1 != ptr2 &&
-                dsda_PersistentIntConfig(ptr2->config_id) == ch)
-            {
-              dsda_UpdateIntConfig(ptr2->config_id, old_value, true);
-              break;
-            }
-          dsda_UpdateIntConfig(ptr1->config_id, ch, true);
-        }
-
-        M_SelectDone(ptr1);       // phares 4/17/98
+      if (M_WeaponResponder(ch, action, ev))
         return true;
-      }
 
     // Automap
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3261,7 +3261,7 @@ static void M_ResetLevelTable(void)
   int i, page;
   const int page_count[LEVEL_TABLE_PAGES] = {
     wad_stats.map_count * 5 + 16,
-    wad_stats.map_count * 3 + 16,
+    wad_stats.map_count * 4 + 16,
   };
 
   for (page = 0; page < LEVEL_TABLE_PAGES; ++page)
@@ -3387,7 +3387,7 @@ static void M_BuildLevelTable(void)
     entry->m_x = column_x;
   END_LOOP_LEVEL_TABLE_COLUMN
 
-  column_x += 128;
+  column_x += 120;
   INSERT_LEVEL_TABLE_COLUMN("TIME", column_x)
 
   LOOP_LEVEL_TABLE_COLUMN
@@ -3406,7 +3406,7 @@ static void M_BuildLevelTable(void)
     }
   END_LOOP_LEVEL_TABLE_COLUMN
 
-  column_x += 96;
+  column_x += 80;
   INSERT_LEVEL_TABLE_COLUMN("MAX TIME", column_x)
 
   LOOP_LEVEL_TABLE_COLUMN
@@ -3417,6 +3417,25 @@ static void M_BuildLevelTable(void)
       dsda_StringPrintF(&m_text, "%d:%05.2f",
                         map->best_max_time / 35 / 60,
                         (float) (map->best_max_time % (60 * 35)) / 35);
+      entry->m_text = m_text.string;
+      entry->m_flags |= S_TC_SEL;
+    }
+    else {
+      entry->m_text = Z_Strdup("- : --");
+    }
+  END_LOOP_LEVEL_TABLE_COLUMN
+
+  column_x += 80;
+  INSERT_LEVEL_TABLE_COLUMN("SK 5 TIME", column_x)
+
+  LOOP_LEVEL_TABLE_COLUMN
+    entry->m_flags = S_LABEL | S_SKIP;
+    entry->m_x = column_x;
+
+    if (map->best_sk5_time >= 0) {
+      dsda_StringPrintF(&m_text, "%d:%05.2f",
+                        map->best_sk5_time / 35 / 60,
+                        (float) (map->best_sk5_time % (60 * 35)) / 35);
       entry->m_text = m_text.string;
       entry->m_flags |= S_TC_SEL;
     }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3350,13 +3350,6 @@ static void M_ResetLevelTable(void)
   }
 }
 
-static void M_CatTime(dsda_string_t* m_text, int tics)
-{
-  dsda_StringCatF(m_text, "%d:%05.2f",
-                  tics / 35 / 60,
-                  (float) (tics % (60 * 35)) / 35);
-}
-
 static void M_PrintTime(dsda_string_t* m_text, int tics)
 {
   dsda_StringPrintF(m_text, "%d:%05.2f",

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -121,7 +121,7 @@
 #define S_KEEP     0x00004000 // Don't swap key out
 #define S_END      0x00008000 // Last item in list (dummy)
 #define S_LEVWARN  0x00010000 // killough 8/30/98: Always warn about pending change
-// #define S_      0x00020000
+#define S_NOSELECT 0x00020000
 // #define S_      0x00040000
 #define S_FILE     0x00080000 // killough 10/98: Filenames
 #define S_LEFTJUST 0x00100000 // killough 10/98: items which are left-justified
@@ -1552,6 +1552,8 @@ static void M_UpdateSetupMenu(setup_menu_t *new_setup_menu)
 {
   current_setup_menu = new_setup_menu;
   set_menu_itemon = M_GetSetupMenuItemOn();
+  if (current_setup_menu[set_menu_itemon].m_flags & S_NOSELECT)
+    return;
   while (current_setup_menu[set_menu_itemon++].m_flags & S_SKIP);
   current_setup_menu[--set_menu_itemon].m_flags |= S_HILITE;
 }
@@ -1709,7 +1711,7 @@ static void M_DrawItem(const setup_menu_t* s, int y)
       w = M_GetPixelWidth(menu_buffer) + 4;
     M_DrawMenuString(x - w, y ,color);
     // print a blinking "arrow" next to the currently highlighted menu item
-    if (s == current_setup_menu + set_menu_itemon && whichSkull)
+    if (s == current_setup_menu + set_menu_itemon && whichSkull && !(flags & S_NOSELECT))
       M_DrawString(x - w - 8, y, color, ">");
   }
   Z_Free(t);
@@ -4473,6 +4475,9 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
 
   if (action == MENU_DOWN)
   {
+    if (ptr1->m_flags & S_NOSELECT)
+      return true;
+
     ptr1->m_flags &= ~S_HILITE;     // phares 4/17/98
     do
       if (ptr1->m_flags & S_END)
@@ -4492,6 +4497,9 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
 
   if (action == MENU_UP)
   {
+    if (ptr1->m_flags & S_NOSELECT)
+      return true;
+
     ptr1->m_flags &= ~S_HILITE;     // phares 4/17/98
     do
     {

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2104,7 +2104,7 @@ static void M_DrawInstructions(void)
 #define PREV_PAGE(page) { "<-", S_SKIP | S_PREV | S_LEFTJUST, m_null, 2, .menu = page }
 #define FINAL_ENTRY { 0, S_SKIP | S_END, m_null }
 #define EMPTY_LINE { 0, S_SKIP, m_null }
-#define NEW_COLUMN { 0, S_RESET_Y, m_null }
+#define NEW_COLUMN { 0, S_SKIP | S_RESET_Y, m_null }
 
 #define DEFAULT_LIST_Y (INSTRUCTION_Y + 1.5 * menu_font->line_height)
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3824,15 +3824,15 @@ dboolean M_ConsoleOpen(void)
 
 dboolean M_KeyBndResponder(int ch, int action, event_t* ev)
 {
-  int i;
-  setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
-  setup_menu_t *ptr2 = NULL;
-
-  int s_input = (ptr1->m_flags & S_INPUT) ? ptr1->input : 0;
-
-  // incoming key or button gets bound
+  // changing an entry
   if (setup_select)
   {
+    int i;
+    setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
+    setup_menu_t *ptr2 = NULL;
+
+    int s_input = (ptr1->m_flags & S_INPUT) ? ptr1->input : 0;
+
     if (ev->type == ev_joystick)
     {
       setup_group group;
@@ -3949,12 +3949,12 @@ dboolean M_KeyBndResponder(int ch, int action, event_t* ev)
 
 dboolean M_WeaponResponder(int ch, int action, event_t* ev)
 {
-  setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
-  setup_menu_t *ptr2 = NULL;
-
   // changing an entry
   if (setup_select)
   {
+    setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
+    setup_menu_t *ptr2 = NULL;
+
     if (action != MENU_ENTER)
     {
       int old_value;
@@ -4038,11 +4038,11 @@ dboolean M_AutoResponder(int ch, int action, event_t* ev)
 
 dboolean M_StringResponder(int ch, int action, event_t* ev)
 {
-  setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
-
   // changing an entry
   if (setup_select)
   {
+    setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
+
     if (ptr1->m_flags & S_STRING) // creating/editing a string?
     {
       if (action == MENU_BACKSPACE) // backspace and DEL

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -122,7 +122,7 @@
 #define S_END      0x00008000 // Last item in list (dummy)
 #define S_LEVWARN  0x00010000 // killough 8/30/98: Always warn about pending change
 #define S_NOSELECT 0x00020000
-// #define S_      0x00040000
+#define S_CENTER   0x00040000
 #define S_FILE     0x00080000 // killough 10/98: Filenames
 #define S_LEFTJUST 0x00100000 // killough 10/98: items which are left-justified
 #define S_CREDIT   0x00200000 // killough 10/98: credit
@@ -1707,7 +1707,9 @@ static void M_DrawItem(const setup_menu_t* s, int y)
   for (p = t = Z_Strdup(s->m_text); (p = strtok(p,"\n")); y += 8, p = NULL)
   {      /* killough 10/98: support left-justification: */
     strcpy(menu_buffer,p);
-    if (!(flags & S_LEFTJUST))
+    if (flags & S_CENTER)
+      w = M_GetPixelWidth(menu_buffer) / 2;
+    else if (!(flags & S_LEFTJUST))
       w = M_GetPixelWidth(menu_buffer) + 4;
     M_DrawMenuString(x - w, y ,color);
     // print a blinking "arrow" next to the currently highlighted menu item

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2049,7 +2049,7 @@ void M_DrawDelVerify(void)
 
 static void M_DrawInstructionString(int cr, const char *str)
 {
-  M_DrawStringCentered(160, INSTRUCTION_Y, cr, "Press key or button for this action");
+  M_DrawStringCentered(160, INSTRUCTION_Y, cr, str);
 }
 
 static void M_DrawInstructions(void)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1506,6 +1506,7 @@ dboolean setup_select      = false; // changing an item
 dboolean setup_gather      = false; // gathering keys for value
 dboolean colorbox_active   = false; // color palette being shown
 dboolean set_general_active = false;
+dboolean level_table_active = false;
 
 /////////////////////////////
 //
@@ -2133,6 +2134,19 @@ static void M_DrawInstructions(void)
 
 #define DEFAULT_LIST_Y (INSTRUCTION_Y + 1.5 * menu_font->line_height)
 
+static void M_EnterSetup(menu_t *menu, dboolean *setup_flag, setup_menu_t *setup_menu)
+{
+  M_SetupNextMenu(menu);
+
+  setup_active = true;
+  *setup_flag = true;
+  setup_select = false;
+  colorbox_active = false;
+  setup_gather = false;
+
+  M_UpdateSetupMenu(setup_menu);
+}
+
 /////////////////////////////
 //
 // The Key Binding Screen tables.
@@ -2176,8 +2190,6 @@ setup_menu_t* keys_settings[] =
   build_keys_settings2,
   NULL
 };
-
-int mult_screens_index; // the index of the current screen in a set
 
 // The first Key Binding screen table.
 // Note that the Y values are ascending. If you need to add something to
@@ -2534,14 +2546,7 @@ setup_menu_t build_keys_settings2[] = {
 
 void M_KeyBindings(int choice)
 {
-  M_SetupNextMenu(&KeybndDef);
-
-  setup_active = true;
-  set_keybnd_active = true;
-  setup_select = false;
-  setup_gather = false;
-  mult_screens_index = 0;
-  M_UpdateSetupMenu(keys_settings[0]);
+  M_EnterSetup(&KeybndDef, &set_keybnd_active, keys_settings[0]);
 }
 
 // The drawing part of the Key Bindings Setup initialization. Draw the
@@ -2608,14 +2613,7 @@ setup_menu_t weap_settings1[] =  // Weapons Settings screen
 
 void M_Weapons(int choice)
 {
-  M_SetupNextMenu(&WeaponDef);
-
-  setup_active = true;
-  set_weapon_active = true;
-  setup_select = false;
-  setup_gather = false;
-  mult_screens_index = 0;
-  M_UpdateSetupMenu(weap_settings[0]);
+  M_EnterSetup(&WeaponDef, &set_weapon_active, weap_settings[0]);
 }
 
 
@@ -2702,16 +2700,8 @@ setup_menu_t stat_settings2[] =
 
 void M_StatusBar(int choice)
 {
-  M_SetupNextMenu(&StatusHUDDef);
-
-  setup_active = true;
-  set_status_active = true;
-  setup_select = false;
-  setup_gather = false;
-  mult_screens_index = 0;
-  M_UpdateSetupMenu(stat_settings[0]);
+  M_EnterSetup(&StatusHUDDef, &set_status_active, stat_settings[0]);
 }
-
 
 // The drawing part of the Status Bar / HUD Setup initialization. Draw the
 // background, title, instruction line, and items.
@@ -2832,15 +2822,7 @@ setup_menu_t auto_settings3[] =  // 3nd AutoMap Settings screen
 
 void M_Automap(int choice)
 {
-  M_SetupNextMenu(&AutoMapDef);
-
-  setup_active = true;
-  set_auto_active = true;
-  setup_select = false;
-  colorbox_active = false;
-  setup_gather = false;
-  mult_screens_index = 0;
-  M_UpdateSetupMenu(auto_settings[0]);
+  M_EnterSetup(&AutoMapDef, &set_auto_active, auto_settings[0]);
 }
 
 // Data used by the color palette that is displayed for the player to
@@ -3185,14 +3167,7 @@ void M_ChangeTextureParams(void)
 
 void M_General(int choice)
 {
-  M_SetupNextMenu(&GeneralDef);
-
-  setup_active = true;
-  set_general_active = true;
-  setup_select = false;
-  setup_gather = false;
-  mult_screens_index = 0;
-  M_UpdateSetupMenu(gen_settings[0]);
+  M_EnterSetup(&GeneralDef, &set_general_active, gen_settings[0]);
 }
 
 // The drawing part of the General Setup initialization. Draw the
@@ -3293,15 +3268,8 @@ static void M_BuildLevelTable(void)
 
 void M_LevelTable(int choice)
 {
-  M_SetupNextMenu(&LevelTableDef);
-
   M_BuildLevelTable();
-
-  setup_active = true;
-  setup_select = false;
-  setup_gather = false;
-  mult_screens_index = 0;
-  M_UpdateSetupMenu(level_table_page[0]);
+  M_EnterSetup(&LevelTableDef, &level_table_active, level_table_page[0]);
 }
 
 void M_DrawLevelTable(void)
@@ -4878,7 +4846,6 @@ dboolean M_Responder (event_t* ev) {
         if (ptr2->m_flags & S_PREV)
         {
           ptr1->m_flags &= ~S_HILITE;
-          mult_screens_index--;
           M_SetSetupMenuItemOn(set_menu_itemon);
           M_UpdateSetupMenu(ptr2->menu);
           S_StartVoidSound(g_sfx_menu);  // killough 10/98
@@ -4897,7 +4864,6 @@ dboolean M_Responder (event_t* ev) {
         if (ptr2->m_flags & S_NEXT)
         {
           ptr1->m_flags &= ~S_HILITE;
-          mult_screens_index++;
           M_SetSetupMenuItemOn(set_menu_itemon);
           M_UpdateSetupMenu(ptr2->menu);
           S_StartVoidSound(g_sfx_menu);  // killough 10/98

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3313,6 +3313,8 @@ static void M_BuildLevelTable(void)
     if (map->best_skill) {
       dsda_StringPrintF(&m_text, "%d", map->best_skill);
       entry->m_text = m_text.string;
+      if (map->best_skill == 5)
+        entry->m_flags |= S_TC_SEL;
     }
     else {
       entry->m_text = Z_Strdup("-");

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3985,6 +3985,57 @@ dboolean M_WeaponResponder(int ch, int action, event_t* ev)
   return false;
 }
 
+dboolean M_AutoResponder(int ch, int action, event_t* ev)
+{
+  // changing an entry
+  if (setup_select)
+  {
+    if (action == MENU_DOWN)
+    {
+      if (++color_palette_y == 16)
+        color_palette_y = 0;
+      S_StartVoidSound(g_sfx_itemup);
+      return true;
+    }
+
+    if (action == MENU_UP)
+    {
+      if (--color_palette_y < 0)
+        color_palette_y = 15;
+      S_StartVoidSound(g_sfx_itemup);
+      return true;
+    }
+
+    if (action == MENU_LEFT)
+    {
+      if (--color_palette_x < 0)
+        color_palette_x = 15;
+      S_StartVoidSound(g_sfx_itemup);
+      return true;
+    }
+
+    if (action == MENU_RIGHT)
+    {
+      if (++color_palette_x == 16)
+        color_palette_x = 0;
+      S_StartVoidSound(g_sfx_itemup);
+      return true;
+    }
+
+    if (action == MENU_ENTER)
+    {
+      setup_menu_t *ptr1 = current_setup_menu + set_menu_itemon;
+
+      dsda_UpdateIntConfig(ptr1->config_id, color_palette_x + 16 * color_palette_y, true);
+      M_SelectDone(ptr1);                         // phares 4/17/98
+      colorbox_active = false;
+      return true;
+    }
+  }
+
+  return false;
+}
+
 dboolean M_Responder (event_t* ev) {
   int    ch, action;
   int    i;
@@ -4616,51 +4667,9 @@ dboolean M_Responder (event_t* ev) {
       if (M_WeaponResponder(ch, action, ev))
         return true;
 
-    // Automap
-
     if (set_auto_active) // on the automap setup screen
-      if (setup_select) // incoming key
-      {
-        if (action == MENU_DOWN)
-        {
-          if (++color_palette_y == 16)
-            color_palette_y = 0;
-          S_StartVoidSound(g_sfx_itemup);
-          return true;
-        }
-
-        if (action == MENU_UP)
-        {
-          if (--color_palette_y < 0)
-            color_palette_y = 15;
-          S_StartVoidSound(g_sfx_itemup);
-          return true;
-        }
-
-        if (action == MENU_LEFT)
-        {
-          if (--color_palette_x < 0)
-            color_palette_x = 15;
-          S_StartVoidSound(g_sfx_itemup);
-          return true;
-        }
-
-        if (action == MENU_RIGHT)
-        {
-          if (++color_palette_x == 16)
-            color_palette_x = 0;
-          S_StartVoidSound(g_sfx_itemup);
-          return true;
-        }
-
-        if (action == MENU_ENTER)
-        {
-          dsda_UpdateIntConfig(ptr1->config_id, color_palette_x + 16 * color_palette_y, true);
-          M_SelectDone(ptr1);                         // phares 4/17/98
-          colorbox_active = false;
-          return true;
-        }
-      }
+      if (M_AutoResponder(ch, action, ev))
+        return true;
 
     // killough 10/98: consolidate handling into one place:
     if (setup_select && set_general_active | set_status_active)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3814,6 +3814,19 @@ dboolean M_ConsoleOpen(void)
   return menuactive && currentMenu == &dsda_ConsoleDef;
 }
 
+static void M_LeaveSetupMenu(void)
+{
+  M_SetSetupMenuItemOn(set_menu_itemon);
+  setup_active = false;
+  set_keybnd_active = false;
+  set_weapon_active = false;
+  set_status_active = false;
+  set_auto_active = false;
+  colorbox_active = false;
+  set_general_active = false;
+  level_table_active = false;
+}
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // M_Responder
@@ -4358,7 +4371,7 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
 
   if ((action == MENU_ESCAPE) || (action == MENU_BACKSPACE))
   {
-    M_SetSetupMenuItemOn(set_menu_itemon);
+    M_LeaveSetupMenu();
     if (action == MENU_ESCAPE) // Clear all menus
       M_ClearMenus();
     else // MENU_BACKSPACE = return to Setup Menu
@@ -4369,13 +4382,6 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
         S_StartVoidSound(g_sfx_swtchn);
       }
     ptr1->m_flags &= ~(S_HILITE|S_SELECT);// phares 4/19/98
-    setup_active = false;
-    set_keybnd_active = false;
-    set_weapon_active = false;
-    set_status_active = false;
-    set_auto_active = false;
-    colorbox_active = false;
-    set_general_active = false;    // killough 10/98
     HU_Start();    // catch any message changes // phares 4/19/98
     S_StartVoidSound(g_sfx_swtchx);
     return true;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3284,6 +3284,20 @@ static void M_ResetLevelTable(void)
   }
 }
 
+static void M_CatTime(dsda_string_t* m_text, int tics)
+{
+  dsda_StringCatF(m_text, "%d:%05.2f",
+                  tics / 35 / 60,
+                  (float) (tics % (60 * 35)) / 35);
+}
+
+static void M_PrintTime(dsda_string_t* m_text, int tics)
+{
+  dsda_StringPrintF(m_text, "%d:%05.2f",
+                    tics / 35 / 60,
+                    (float) (tics % (60 * 35)) / 35);
+}
+
 static void M_BuildLevelTable(void)
 {
   int i;
@@ -3399,9 +3413,7 @@ static void M_BuildLevelTable(void)
     entry->m_x = column_x;
 
     if (map->best_time >= 0) {
-      dsda_StringPrintF(&m_text, "%d:%05.2f",
-                        map->best_time / 35 / 60,
-                        (float) (map->best_time % (60 * 35)) / 35);
+      M_PrintTime(&m_text, map->best_time);
       entry->m_text = m_text.string;
       entry->m_flags |= S_TC_SEL;
     }
@@ -3418,9 +3430,7 @@ static void M_BuildLevelTable(void)
     entry->m_x = column_x;
 
     if (map->best_max_time >= 0) {
-      dsda_StringPrintF(&m_text, "%d:%05.2f",
-                        map->best_max_time / 35 / 60,
-                        (float) (map->best_max_time % (60 * 35)) / 35);
+      M_PrintTime(&m_text, map->best_max_time);
       entry->m_text = m_text.string;
       entry->m_flags |= S_TC_SEL;
     }
@@ -3437,9 +3447,7 @@ static void M_BuildLevelTable(void)
     entry->m_x = column_x;
 
     if (map->best_sk5_time >= 0) {
-      dsda_StringPrintF(&m_text, "%d:%05.2f",
-                        map->best_sk5_time / 35 / 60,
-                        (float) (map->best_sk5_time % (60 * 35)) / 35);
+      M_PrintTime(&m_text, map->best_sk5_time);
       entry->m_text = m_text.string;
       entry->m_flags |= S_TC_SEL;
     }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3329,7 +3329,7 @@ static void M_ResetLevelTable(void)
   const int page_count[LEVEL_TABLE_PAGES] = {
     wad_stats.map_count * 5 + 16,
     wad_stats.map_count * 4 + 16,
-    24,
+    40,
   };
 
   for (page = 0; page < LEVEL_TABLE_PAGES; ++page)
@@ -3536,99 +3536,165 @@ static void M_BuildLevelTable(void)
   base_i = 0;
   wad_stats_summary_page = page;
 
-  level_table_page[page][base_i].m_text = Z_Strdup("Wad Stats Summary");
+  level_table_page[page][base_i].m_text = Z_Strdup("Summary");
   level_table_page[page][base_i].m_flags = S_TITLE | S_NOSELECT;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Maps: %d / %d",
-                    wad_stats_summary.completed_count, wad_stats.map_count);
+  dsda_StringPrintF(&m_text, "Maps");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
-  if (wad_stats_summary.completed_count == wad_stats.map_count)
-    dsda_StringPrintF(&m_text, "Skill: %d", wad_stats_summary.best_skill);
-  else
-    dsda_StringPrintF(&m_text, "Skill: -");
+  dsda_StringPrintF(&m_text, "Skill");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Kill Completion: %d/", wad_stats_summary.best_kills);
+  dsda_StringPrintF(&m_text, "Kill Completion");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Item Completion");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Secret Completion");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Time");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Max Time");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "Sk 5 Time");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  level_table_page[page][base_i] = new_column_template;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "%d / %d",
+                    wad_stats_summary.completed_count, wad_stats.map_count);
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  if (wad_stats_summary.completed_count == wad_stats.map_count)
+    dsda_StringPrintF(&m_text, "%d", wad_stats_summary.best_skill);
+  else
+    dsda_StringPrintF(&m_text, "-");
+  level_table_page[page][base_i].m_text = m_text.string;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
+  level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  INSERT_LEVEL_TABLE_EMPTY_LINE
+
+  dsda_StringPrintF(&m_text, "%d / ", wad_stats_summary.best_kills);
   if (wad_stats_summary.completed_count == wad_stats.map_count)
     dsda_StringCatF(&m_text, "%d", wad_stats_summary.max_kills);
   else
     dsda_StringCat(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Item Completion: %d/", wad_stats_summary.best_items);
+  dsda_StringPrintF(&m_text, "%d / ", wad_stats_summary.best_items);
   if (wad_stats_summary.completed_count == wad_stats.map_count)
     dsda_StringCatF(&m_text, "%d", wad_stats_summary.max_items);
   else
     dsda_StringCat(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Secret Completion: %d/", wad_stats_summary.best_secrets);
+  dsda_StringPrintF(&m_text, "%d / ", wad_stats_summary.best_secrets);
   if (wad_stats_summary.completed_count == wad_stats.map_count)
     dsda_StringCatF(&m_text, "%d", wad_stats_summary.max_secrets);
   else
     dsda_StringCat(&m_text, "-");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Time: ");
   if (wad_stats_summary.timed_count == wad_stats.map_count)
-    M_CatTime(&m_text, wad_stats_summary.best_time);
+    M_PrintTime(&m_text, wad_stats_summary.best_time);
   else
-    dsda_StringCat(&m_text, "- : --");
+    dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Max Time: ");
   if (wad_stats_summary.max_timed_count == wad_stats.map_count)
-    M_CatTime(&m_text, wad_stats_summary.best_max_time);
+    M_PrintTime(&m_text, wad_stats_summary.best_max_time);
   else
-    dsda_StringCat(&m_text, "- : --");
+    dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
   level_table_page[page][base_i].m_x = 160;
   ++base_i;
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Sk 5 Time: ");
   if (wad_stats_summary.sk5_timed_count == wad_stats.map_count)
-    M_CatTime(&m_text, wad_stats_summary.best_sk5_time);
+    M_PrintTime(&m_text, wad_stats_summary.best_sk5_time);
   else
-    dsda_StringCat(&m_text, "- : --");
+    dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;
-  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP;
+  level_table_page[page][base_i].m_flags = S_LABEL | S_SKIP | S_LEFTJUST;
   level_table_page[page][base_i].m_x = 160;
+  ++base_i;
+
+  level_table_page[page][base_i] = new_column_template;
   ++base_i;
 
   INSERT_LEVEL_TABLE_PREV_PAGE


### PR DESCRIPTION
This PR adds a new level table to the menu. Currently it's tucked into the options menus because that's the easiest place to put it. There are also a variety of refactorings here in the menu to make it slightly more digestible: different responders have been extracted and a few common operations were deduplicated.

The menu is not really set up for dynamic page building (which is required since we don't know until loading a wad file how many maps there are). The implementation is quite verbose and involves some hacks, but it's fine for now. Eventually I will completely rewrite the whole menu system.