### PR TITLE
PortMidi: Optimize reset messages

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -768,11 +768,11 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_mus_portmidi_reverb_level] = {
     "mus_portmidi_reverb_level", dsda_config_mus_portmidi_reverb_level,
-    dsda_config_int, 0, 127, { 40 }
+    dsda_config_int, -1, 127, { -1 }
   },
   [dsda_config_mus_portmidi_chorus_level] = {
     "mus_portmidi_chorus_level", dsda_config_mus_portmidi_chorus_level,
-    dsda_config_int, 0, 127, { 0 }
+    dsda_config_int, -1, 127, { -1 }
   },
   [dsda_config_cap_soundcommand] = {
     "cap_soundcommand", dsda_config_cap_soundcommand,


### PR DESCRIPTION
This reduces the amount of messages sent during a reset, similar to Chocolate, Woof, etc. This also fixes a regression where wads with mid-level music changes were causing the game to pause briefly (https://github.com/coelckers/prboom-plus/files/7654830/MusChange.zip). Ideally, music should be handled on a separate thread, but this is a simple solution for now. 