### PR TITLE
zip: Cleanup at exit and use unique names

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -82,6 +82,7 @@
 #include "dsda/text_file.h"
 #include "dsda/time.h"
 #include "dsda/wad_stats.h"
+#include "dsda/zipfile.h"
 
 /* Most of the following has been rewritten by Lee Killough
  *
@@ -206,6 +207,7 @@ static void I_EssentialQuit (void)
   dsda_WriteAnalysis();
   dsda_WriteSplits();
   dsda_SaveWadStats();
+  dsda_CleanZipTempDirs();
 }
 
 static void I_Quit (void)

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1525,24 +1525,16 @@ static void EvaluateDoomVerStr(void)
 
 static void D_AddZip(const char* zipped_file_name, wad_source_t source)
 {
-  dsda_string_t temporary_directory;
   char* full_zip_path;
-  static unsigned int file_counter = 0;
+  const char* temporary_directory;
 
   full_zip_path = I_RequireZip(zipped_file_name);
-  dsda_StringPrintF(&temporary_directory, "%s/%u-%s", I_GetTempDir(), file_counter, dsda_BaseName(zipped_file_name));
-  if (M_IsDir(temporary_directory.string))
-    if (!M_RemoveFilesAtPath(temporary_directory.string))
-      I_Error("D_AddZip: unable to clear tempdir %s\n", temporary_directory.string);
-  M_MakeDir(temporary_directory.string, true);
+  temporary_directory = dsda_UnzipFile(full_zip_path);
 
-  dsda_UnzipFile(full_zip_path, temporary_directory.string);
+  LoadWADsAtPath(temporary_directory, source);
+  LoadDehackedFilesAtPath(temporary_directory, true);
 
-  LoadWADsAtPath(temporary_directory.string, source);
-  LoadDehackedFilesAtPath(temporary_directory.string, true);
-
-  dsda_FreeString(&temporary_directory);
-  file_counter++;
+  Z_Free(full_zip_path);
 }
 
 //

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1527,9 +1527,10 @@ static void D_AddZip(const char* zipped_file_name, wad_source_t source)
 {
   dsda_string_t temporary_directory;
   char* full_zip_path;
+  static unsigned int file_counter = 0;
 
   full_zip_path = I_RequireZip(zipped_file_name);
-  dsda_StringPrintF(&temporary_directory, "%s/%s", I_GetTempDir(), dsda_BaseName(zipped_file_name));
+  dsda_StringPrintF(&temporary_directory, "%s/%u-%s", I_GetTempDir(), file_counter, dsda_BaseName(zipped_file_name));
   if (M_IsDir(temporary_directory.string))
     if (!M_RemoveFilesAtPath(temporary_directory.string))
       I_Error("D_AddZip: unable to clear tempdir %s\n", temporary_directory.string);
@@ -1541,6 +1542,7 @@ static void D_AddZip(const char* zipped_file_name, wad_source_t source)
   LoadDehackedFilesAtPath(temporary_directory.string, true);
 
   dsda_FreeString(&temporary_directory);
+  file_counter++;
 }
 
 //

--- a/prboom2/src/dsda/zipfile.c
+++ b/prboom2/src/dsda/zipfile.c
@@ -18,11 +18,14 @@
 #include <stdio.h>
 #include <zip.h>
 
+#include "i_system.h"
 #include "lprintf.h"
 #include "m_file.h"
 #include "z_zone.h"
 
 #include "dsda/utility.h"
+
+static char **temp_dirs;
 
 /* Allow a maximum of 1GB to be uncompressed to prevent zip-bombs */
 #define UNZIPPED_BYTES_LIMIT 1000000000ULL
@@ -90,7 +93,7 @@ static void dsda_WriteZippedFilesToDest(zip_t *archive, const char *destination_
   }
 }
 
-void dsda_UnzipFile(const char *zipped_file_name, const char *destination_directory) {
+static void dsda_UnzipFileToDestination(const char *zipped_file_name, const char *destination_directory) {
   int error_code;
   zip_t *archive_handle;
 
@@ -99,10 +102,44 @@ void dsda_UnzipFile(const char *zipped_file_name, const char *destination_direct
   if (archive_handle == NULL) {
     zip_error_t error;
     zip_error_init_with_code(&error, error_code);
-    I_Error("dsda_UnzipFile: Unable to open %s: %s.\n", zipped_file_name, zip_error_strerror(&error));
+    I_Error("dsda_UnzipFileToDestination: Unable to open %s: %s.\n", zipped_file_name, zip_error_strerror(&error));
   }
 
   dsda_WriteZippedFilesToDest(archive_handle, destination_directory);
 
   zip_close(archive_handle);
+}
+
+const char* dsda_UnzipFile(const char *zipped_file_name) {
+  dsda_string_t temporary_directory;
+  static unsigned int file_counter = 0;
+
+  dsda_StringPrintF(&temporary_directory, "%s/%u-%s", I_GetTempDir(), file_counter, dsda_BaseName(zipped_file_name));
+  if (M_IsDir(temporary_directory.string))
+    if (!M_RemoveFilesAtPath(temporary_directory.string))
+      I_Error("dsda_UnzipFile: unable to clear tempdir %s\n", temporary_directory.string);
+  M_MakeDir(temporary_directory.string, true);
+
+  dsda_UnzipFileToDestination(zipped_file_name, temporary_directory.string);
+
+  temp_dirs = Z_Realloc(temp_dirs, (file_counter + 2) * sizeof(*temp_dirs));
+  temp_dirs[file_counter] = temporary_directory.string;
+  temp_dirs[file_counter + 1] = NULL;
+  file_counter++;
+
+  return temporary_directory.string;
+}
+
+void dsda_CleanZipTempDirs(void) {
+  int i;
+
+  if(temp_dirs == NULL)
+    return;
+
+  for (i = 0; temp_dirs[i] != NULL; i++) {
+    M_RemoveFilesAtPath(temp_dirs[i]);
+    M_remove(temp_dirs[i]);
+    Z_Free(temp_dirs[i]);
+  }
+  Z_Free(temp_dirs);
 }

--- a/prboom2/src/dsda/zipfile.h
+++ b/prboom2/src/dsda/zipfile.h
@@ -18,6 +18,8 @@
 #ifndef __DSDA_ZIPFILE__
 #define __DSDA_ZIPFILE__
 
-void dsda_UnzipFile(const char *zipped_file_name, const char *destination_directory);
+const char* dsda_UnzipFile(const char *zipped_file_name);
+
+void dsda_CleanZipTempDirs(void);
 
 #endif /* __DSDA_ZIPFILE__ */


### PR DESCRIPTION
- [X] Ensure unique names
- [x] Clean up temporary directories when shutting down

---

This PR changes the extraction directory to be prefixed by a file count. This avoids an issue where passing two zips with the same filename would "ignore" the first one.

Some systems, most notably Windows, do not clean their temp directory automatically by default. How should we go about cleaning it up ?
- Make it a concern of the `zipfile` module. Every time a zip file is decompressed, its destination directory is added to a list, and a cleanup function is ran AtExit, so even if an error is encountered, directories will be cleaned up.
- Run cleanup in `I_Quit` like [Woof does](https://github.com/fabiangreffrath/woof/blob/11c652b67e6144ac66f7b45e9942b4d963fa0542/src/d_quit.c#L52). The idea would be to have `D_AddZip` to add the path to a list and clean it up when shutting down. The issue with that approach is that it is not run when an error is encountered.

What do you think @kraflab ?