### PR TITLE
Remove gl_lightmode_glboom

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -278,7 +278,7 @@ int main(int argc, char **argv)
   // e6y: Check for conflicts.
   // Conflicting command-line parameters could cause the engine to be confused
   // in some cases. Added checks to prevent this.
-  // Example: glboom.exe -record mydemo -playdemo demoname
+  // Example: dsda-doom.exe -record mydemo -playdemo demoname
   ParamsMatchingCheck();
 
   // e6y: was moved from D_DoomMainSetup

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -607,7 +607,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_gl_lightmode] = {
     "gl_lightmode", dsda_config_gl_lightmode,
-    dsda_config_int, gl_lightmode_glboom, gl_lightmode_last - 1, { gl_lightmode_indexed },
+    dsda_config_int, 0, gl_lightmode_last - 1, { gl_lightmode_indexed },
     NULL, NOT_STRICT, M_ChangeLightMode
   },
   [dsda_config_gl_health_bar] = {

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -605,10 +605,9 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "gl_render_fov", dsda_config_gl_render_fov,
     dsda_config_int, 20, 160, { 90 }, &gl_render_fov, NOT_STRICT, M_ChangeFOV
   },
-  [dsda_config_gl_lightmode] = {
-    "gl_lightmode", dsda_config_gl_lightmode,
-    dsda_config_int, 0, gl_lightmode_last - 1, { gl_lightmode_indexed },
-    NULL, NOT_STRICT, M_ChangeLightMode
+  [dsda_config_gl_lightmode_indexed] = {
+    "gl_lightmode_indexed", dsda_config_gl_lightmode_indexed,
+    CONF_BOOL(1), NULL, NOT_STRICT, M_ChangeLightMode
   },
   [dsda_config_gl_health_bar] = {
     "gl_health_bar", dsda_config_gl_health_bar,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -122,7 +122,7 @@ typedef enum {
   dsda_config_gl_tex_format_string,
   dsda_config_gl_render_multisampling,
   dsda_config_gl_render_fov,
-  dsda_config_gl_lightmode,
+  dsda_config_gl_lightmode_indexed,
   dsda_config_gl_health_bar,
   dsda_config_gl_usevbo,
   dsda_config_use_mouse,

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -146,7 +146,7 @@ const char* WINError(void)
 /* ParamsMatchingCheck
  * Conflicting command-line parameters could cause the engine to be confused
  * in some cases. Added checks to prevent this.
- * Example: glboom.exe -record mydemo -playdemo demoname
+ * Example: dsda-doom.exe -record mydemo -playdemo demoname
  */
 void ParamsMatchingCheck()
 {

--- a/prboom2/src/gl_gamma.c
+++ b/prboom2/src/gl_gamma.c
@@ -156,7 +156,7 @@ int gld_SetGammaRamp(int gamma)
     if (!succeeded)
     {
       lprintf(LO_WARN, "gld_SetGammaRamp: hardware gamma adjustment is not supported\n");
-      gl_lightmode = gl_lightmode_glboom;
+      gl_lightmode = gl_lightmode_indexed;
     }
   }
 

--- a/prboom2/src/gl_gamma.c
+++ b/prboom2/src/gl_gamma.c
@@ -156,7 +156,8 @@ int gld_SetGammaRamp(int gamma)
     if (!succeeded)
     {
       lprintf(LO_WARN, "gld_SetGammaRamp: hardware gamma adjustment is not supported\n");
-      gl_lightmode = gl_lightmode_indexed;
+      gl_lightmode_indexed = true;
+      gl_hardware_gamma = false;
     }
   }
 

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -460,11 +460,11 @@ void gld_SetupFloodedPlaneLight(GLWall *wall);
 void gld_StaticLightAlpha(float light, float alpha);
 #define gld_StaticLight(light) gld_StaticLightAlpha(light, 1.0f)
 void gld_InitLightTable(void);
-typedef float (*gld_CalcLightLevel_f)(int lightlevel);
 typedef float (*gld_Calc2DLightLevel_f)(int lightlevel);
-extern gld_CalcLightLevel_f gld_CalcLightLevel;
 extern gld_Calc2DLightLevel_f gld_Calc2DLightLevel;
 int gld_GetGunFlashLight(void);
+
+float gld_CalcLightLevel(int lightlevel);
 
 //fog
 extern int gl_fog;

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -470,8 +470,8 @@ extern int gl_fog;
 extern int gl_use_fog;
 void gl_EnableFog(int on);
 void gld_SetFog(float fogdensity);
-typedef float (*gld_CalcFogDensity_f)(sector_t *sector, int lightlevel, GLDrawItemType type);
-extern gld_CalcFogDensity_f gld_CalcFogDensity;
+
+float gld_CalcFogDensity(sector_t *sector, int lightlevel, GLDrawItemType type);
 
 // SkyBox
 #define SKY_NONE    0

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -557,7 +557,6 @@ void glsl_SetLightLevel(float lightlevel);
 void glsl_SetFuzzTime(int time);
 void glsl_SetFuzzScreenResolution(float screenwidth, float screenheight);
 void glsl_SetFuzzTextureDimensions(float texwidth, float texheight);
-int glsl_IsActive(void);
 dboolean glsl_UseFuzzShader(void);
 
 #endif // _GL_INTERN_H

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -460,11 +460,10 @@ void gld_SetupFloodedPlaneLight(GLWall *wall);
 void gld_StaticLightAlpha(float light, float alpha);
 #define gld_StaticLight(light) gld_StaticLightAlpha(light, 1.0f)
 void gld_InitLightTable(void);
-typedef float (*gld_Calc2DLightLevel_f)(int lightlevel);
-extern gld_Calc2DLightLevel_f gld_Calc2DLightLevel;
 int gld_GetGunFlashLight(void);
 
 float gld_CalcLightLevel(int lightlevel);
+float gld_Calc2DLightLevel(int lightlevel);
 
 //fog
 extern int gl_fog;

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -546,7 +546,7 @@ typedef struct GLShader_s
   GLhandleARB hFragProg;
 } GLShader;
 
-int glsl_Init(void);
+void glsl_Init(void);
 void glsl_SetActiveShader(GLShader *shader);
 void glsl_SuspendActiveShader(void);
 void glsl_ResumeActiveShader(void);

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -98,11 +98,6 @@ void M_ChangeLightMode(void)
   M_ChangeSkyMode();
 }
 
-void gld_InitLightTable(void)
-{
-  gld_InitLightTable_glboom();
-}
-
 /*
  * lookuptable for lightvalues
  * calculated as follow:
@@ -110,7 +105,7 @@ void gld_InitLightTable(void)
  * gamma=-0,2;-2,0;-4,0;-6,0;-8,0
  * light=0,0 .. 1,0
  */
-static void gld_InitLightTable_glboom(void)
+void gld_InitLightTable(void)
 {
   int i, g;
   float gamma[5] = {-0.2f, -2.0f, -4.0f, -6.0f, -8.0f};

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -68,10 +68,7 @@ static float lighttable_glboom[5][256];
 
 static void gld_InitLightTable_glboom(void);
 
-static float gld_CalcFogDensity_glboom(sector_t *sector, int lightlevel, GLDrawItemType type);
-
 int gl_hardware_gamma = false;
-gld_CalcFogDensity_f gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
 void M_ChangeLightMode(void)
 {
@@ -85,7 +82,6 @@ void M_ChangeLightMode(void)
   gl_lightmode = gl_lightmode_default;
 
   gl_hardware_gamma = (gl_lightmode == gl_lightmode_shaders);
-  gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
   if (gl_hardware_gamma)
   {
@@ -245,7 +241,7 @@ void M_ChangeAllowFog(void)
   }
 }
 
-static float gld_CalcFogDensity_glboom(sector_t *sector, int lightlevel, GLDrawItemType type)
+float gld_CalcFogDensity(sector_t *sector, int lightlevel, GLDrawItemType type)
 {
   return 0;
 }

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -74,10 +74,7 @@ void M_ChangeLightMode(void)
 {
   gl_lightmode_t gl_lightmode_default = dsda_IntConfig(dsda_config_gl_lightmode);
 
-  if (!glsl_Init())
-  {
-    I_Error("glsl_Init failed!");
-  }
+  glsl_Init();
 
   gl_lightmode = gl_lightmode_default;
 

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -61,11 +61,7 @@ int gl_distfog = 70;
 float gl_CurrentFogDensity = -1.0f;
 float distfogtable[3][256];
 
-typedef void (*gld_InitLightTable_f)(void);
-
-static float lighttable_glboom[5][256];
-
-static void gld_InitLightTable_glboom(void);
+static float lighttable[5][256];
 
 int gl_hardware_gamma = false;
 
@@ -110,14 +106,14 @@ void gld_InitLightTable(void)
   {
     for (i = 0; i < 256; i++)
     {
-      lighttable_glboom[g][i] = (float)((1.0f - exp(pow(i / 255.0f, 3) * gamma[g])) / (1.0f - exp(1.0f * gamma[g])));
+      lighttable[g][i] = (float)((1.0f - exp(pow(i / 255.0f, 3) * gamma[g])) / (1.0f - exp(1.0f * gamma[g])));
     }
   }
 }
 
 float gld_Calc2DLightLevel(int lightlevel)
 {
-  return lighttable_glboom[usegamma][BETWEEN(0, 255, lightlevel)];
+  return lighttable[usegamma][BETWEEN(0, 255, lightlevel)];
 }
 
 float gld_CalcLightLevel(int lightlevel)

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -50,7 +50,6 @@
 #include "dsda/configuration.h"
 
 gl_lightmode_t gl_lightmode;
-const char *gl_lightmodes[] = {"glboom", "shaders", "indexed", NULL};
 dboolean gl_ui_lightmode_indexed = false;
 dboolean gl_automap_lightmode_indexed = false;
 

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -68,12 +68,9 @@ static float lighttable_glboom[5][256];
 
 static void gld_InitLightTable_glboom(void);
 
-static float gld_CalcLightLevel_glboom(int lightlevel);
-
 static float gld_CalcFogDensity_glboom(sector_t *sector, int lightlevel, GLDrawItemType type);
 
 int gl_hardware_gamma = false;
-gld_Calc2DLightLevel_f gld_Calc2DLightLevel = gld_CalcLightLevel_glboom;
 gld_CalcFogDensity_f gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
 void M_ChangeLightMode(void)
@@ -88,7 +85,6 @@ void M_ChangeLightMode(void)
   gl_lightmode = gl_lightmode_default;
 
   gl_hardware_gamma = (gl_lightmode == gl_lightmode_shaders);
-  gld_Calc2DLightLevel = gld_CalcLightLevel_glboom;
   gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
   if (gl_hardware_gamma)
@@ -132,7 +128,7 @@ static void gld_InitLightTable_glboom(void)
   }
 }
 
-static float gld_CalcLightLevel_glboom(int lightlevel)
+float gld_Calc2DLightLevel(int lightlevel)
 {
   return lighttable_glboom[usegamma][BETWEEN(0, 255, lightlevel)];
 }

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -67,7 +67,10 @@ int gl_hardware_gamma = false;
 
 void M_ChangeLightMode(void)
 {
-  glsl_Init();
+  if (!V_IsOpenGLMode())
+  {
+    return;
+  }
 
   gl_lightmode_indexed = dsda_IntConfig(dsda_config_gl_lightmode_indexed);
   gl_hardware_gamma = !gl_lightmode_indexed;

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -69,12 +69,10 @@ static float lighttable_glboom[5][256];
 static void gld_InitLightTable_glboom(void);
 
 static float gld_CalcLightLevel_glboom(int lightlevel);
-static float gld_CalcLightLevel_shaders(int lightlevel);
 
 static float gld_CalcFogDensity_glboom(sector_t *sector, int lightlevel, GLDrawItemType type);
 
 int gl_hardware_gamma = false;
-gld_CalcLightLevel_f gld_CalcLightLevel = gld_CalcLightLevel_glboom;
 gld_Calc2DLightLevel_f gld_Calc2DLightLevel = gld_CalcLightLevel_glboom;
 gld_CalcFogDensity_f gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
@@ -90,7 +88,6 @@ void M_ChangeLightMode(void)
   gl_lightmode = gl_lightmode_default;
 
   gl_hardware_gamma = (gl_lightmode == gl_lightmode_shaders);
-  gld_CalcLightLevel = gld_CalcLightLevel_shaders;
   gld_Calc2DLightLevel = gld_CalcLightLevel_glboom;
   gld_CalcFogDensity = gld_CalcFogDensity_glboom;
 
@@ -140,7 +137,7 @@ static float gld_CalcLightLevel_glboom(int lightlevel)
   return lighttable_glboom[usegamma][BETWEEN(0, 255, lightlevel)];
 }
 
-static float gld_CalcLightLevel_shaders(int lightlevel)
+float gld_CalcLightLevel(int lightlevel)
 {
   int light;
 

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -49,7 +49,7 @@
 
 #include "dsda/configuration.h"
 
-gl_lightmode_t gl_lightmode;
+dboolean gl_lightmode_indexed = true;
 dboolean gl_ui_lightmode_indexed = false;
 dboolean gl_automap_lightmode_indexed = false;
 
@@ -67,19 +67,18 @@ int gl_hardware_gamma = false;
 
 void M_ChangeLightMode(void)
 {
-  gl_lightmode_t gl_lightmode_default = dsda_IntConfig(dsda_config_gl_lightmode);
-
   glsl_Init();
 
-  gl_lightmode = gl_lightmode_default;
-
-  gl_hardware_gamma = (gl_lightmode == gl_lightmode_shaders);
+  gl_lightmode_indexed = dsda_IntConfig(dsda_config_gl_lightmode_indexed);
+  gl_hardware_gamma = !gl_lightmode_indexed;
 
   if (gl_hardware_gamma)
   {
     gld_SetGammaRamp(gl_usegamma);
   }
-  else
+
+  // Not "else" because the above call can fail and revert gl_hardware_gamma
+  if (!gl_hardware_gamma)
   {
     gld_SetGammaRamp(-1);
     gld_FlushTextures();

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -309,6 +309,7 @@ void gld_Init(int width, int height)
 
   gld_InitLightTable();
   gld_InitSky();
+  glsl_Init();
   M_ChangeLightMode();
   M_ChangeAllowFog();
 
@@ -331,8 +332,6 @@ void gld_Init(int width, int height)
   gld_ResetLastTexture();
 
   I_AtExit(gld_CleanMemory, true, "gld_CleanMemory", exit_priority_normal); //e6y
-
-  glsl_Init(); // elim - Required for fuzz shader, even if lighting mode not set to "shaders"
 }
 
 void gld_InitCommandLine(void)

--- a/prboom2/src/gl_opengl.c
+++ b/prboom2/src/gl_opengl.c
@@ -327,13 +327,16 @@ void gld_InitOpenGL(void)
         !GLEXT_glGetUniformfvARB)
       gl_arb_shader_objects = false;
   }
-  if (gl_arb_shader_objects)
+
+  if (!gl_arb_shader_objects)
   {
-    lprintf(LO_DEBUG, "using GL_ARB_shader_objects\n");
-    lprintf(LO_DEBUG, "using GL_ARB_vertex_shader\n");
-    lprintf(LO_DEBUG, "using GL_ARB_fragment_shader\n");
-    lprintf(LO_DEBUG, "using GL_ARB_shading_language_100\n");
+    I_Error("gld_InitOpenGL: Insufficient support for shader objects");
   }
+
+  lprintf(LO_DEBUG, "using GL_ARB_shader_objects\n");
+  lprintf(LO_DEBUG, "using GL_ARB_vertex_shader\n");
+  lprintf(LO_DEBUG, "using GL_ARB_fragment_shader\n");
+  lprintf(LO_DEBUG, "using GL_ARB_shading_language_100\n");
 
   glGetIntegerv(GL_MAX_TEXTURE_SIZE, &gl_max_texture_size);
   lprintf(LO_DEBUG, "GL_MAX_TEXTURE_SIZE=%i\n", gl_max_texture_size);

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -139,26 +139,22 @@ void get_fuzz_shader_bindings()
   }
 }
 
-int glsl_Init(void)
+void glsl_Init(void)
 {
-  if (!gl_arb_shader_objects)
+  sh_main = gld_LoadShader("glvp", "glfp");
+  get_light_shader_bindings();
+
+  sh_indexed = gld_LoadShader("glvp", "glfp_idx");
+  get_indexed_shader_bindings();
+
+  sh_fuzz = gld_LoadShader("glvp", "glfp_fuzz");
+  get_fuzz_shader_bindings();
+  glsl_SetFuzzScreenResolution((float)SCREENWIDTH, (float)SCREENHEIGHT);
+
+  if (!sh_main || !sh_indexed || !sh_fuzz)
   {
-    lprintf(LO_WARN, "glsl_Init: shaders expects OpenGL 2.0\n");
+    I_Error("glsl_Init: Failed to load shaders");
   }
-  else
-  {
-    sh_main = gld_LoadShader("glvp", "glfp");
-    get_light_shader_bindings();
-
-    sh_indexed = gld_LoadShader("glvp", "glfp_idx");
-    get_indexed_shader_bindings();
-
-    sh_fuzz = gld_LoadShader("glvp", "glfp_fuzz");
-    get_fuzz_shader_bindings();
-    glsl_SetFuzzScreenResolution((float)SCREENWIDTH, (float)SCREENHEIGHT);
-  }
-
-  return (sh_main != NULL) && (sh_indexed != NULL) && (sh_fuzz != NULL);
 }
 
 static int ReadLump(const char *filename, const char *lumpname, char **buffer)

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -419,11 +419,6 @@ void glsl_SetFuzzTextureDimensions(float texwidth, float texheight)
   }
 }
 
-int glsl_IsActive(void)
-{
-  return ((gl_lightmode == gl_lightmode_shaders && sh_main) || (V_IsWorldLightmodeIndexed() && sh_indexed));
-}
-
 dboolean glsl_UseFuzzShader(void)
 {
   // stub in case we ever want to make this an option.

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -272,13 +272,10 @@ static GLShader* gld_LoadShader(const char *vpname, const char *fpname)
 
 void glsl_SetActiveShader(GLShader *shader)
 {
-  if (gl_lightmode == gl_lightmode_shaders || V_IsWorldLightmodeIndexed())
+  if (shader != active_shader)
   {
-    if (shader != active_shader)
-    {
-      GLEXT_glUseProgramObjectARB((shader ? shader->hShader : 0));
-      active_shader = shader;
-    }
+    GLEXT_glUseProgramObjectARB((shader ? shader->hShader : 0));
+    active_shader = shader;
   }
 }
 

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -48,13 +48,6 @@ typedef enum {
 } skytype_t;
 
 #define MAX_GLGAMMA 32
-typedef enum
-{
-  gl_lightmode_shaders,
-  gl_lightmode_indexed,
-
-  gl_lightmode_last
-} gl_lightmode_t;
 
 enum bleedtype {
   BLEED_NONE = 0x0,
@@ -64,7 +57,7 @@ enum bleedtype {
 
 extern int gl_drawskys;
 extern int gl_hardware_gamma;
-extern gl_lightmode_t gl_lightmode;
+extern dboolean gl_lightmode_indexed;
 extern dboolean gl_ui_lightmode_indexed;
 extern dboolean gl_automap_lightmode_indexed;
 extern int gl_usegamma;

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -50,7 +50,6 @@ typedef enum {
 #define MAX_GLGAMMA 32
 typedef enum
 {
-  gl_lightmode_glboom,
   gl_lightmode_shaders,
   gl_lightmode_indexed,
 

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -65,7 +65,6 @@ enum bleedtype {
 extern int gl_drawskys;
 extern int gl_hardware_gamma;
 extern gl_lightmode_t gl_lightmode;
-extern const char *gl_lightmodes[];
 extern dboolean gl_ui_lightmode_indexed;
 extern dboolean gl_automap_lightmode_indexed;
 extern int gl_usegamma;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2950,8 +2950,6 @@ static const char* render_stretch_list[] = {
   "Not Adjusted", "Doom Format", "Fit to Width", NULL
 };
 
-static const char *gl_lightmodes[] = { "shaders", "indexed", NULL };
-
 setup_menu_t audiovideo_settings[] = {
   { "Video", S_SKIP | S_TITLE, m_null, G_X},
   { "Video mode", S_CHOICE | S_STR, m_conf, G_X, dsda_config_videomode, 0, videomodes },
@@ -2963,7 +2961,7 @@ setup_menu_t audiovideo_settings[] = {
   { "Uncapped Framerate", S_YESNO, m_conf, G_X, dsda_config_uncapped_framerate },
   { "FPS Limit", S_NUM, m_conf, G_X, dsda_config_fps_limit },
   EMPTY_LINE,
-  { "OpenGL Light Mode", S_CHOICE, m_conf, G_X, dsda_config_gl_lightmode, 0, gl_lightmodes },
+  { "OpenGL Indexed Light Mode", S_YESNO, m_conf, G_X, dsda_config_gl_lightmode_indexed },
   EMPTY_LINE,
   { "Sound & Music", S_SKIP | S_TITLE, m_null, G_X},
   { "Number of Sound Channels", S_NUM, m_conf, G_X, dsda_config_snd_channels },

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2950,6 +2950,8 @@ static const char* render_stretch_list[] = {
   "Not Adjusted", "Doom Format", "Fit to Width", NULL
 };
 
+static const char *gl_lightmodes[] = { "shaders", "indexed", NULL };
+
 setup_menu_t audiovideo_settings[] = {
   { "Video", S_SKIP | S_TITLE, m_null, G_X},
   { "Video mode", S_CHOICE | S_STR, m_conf, G_X, dsda_config_videomode, 0, videomodes },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -163,7 +163,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_gl_tex_format_string),
   MIGRATED_SETTING(dsda_config_gl_render_multisampling),
   MIGRATED_SETTING(dsda_config_gl_render_fov),
-  MIGRATED_SETTING(dsda_config_gl_lightmode),
+  MIGRATED_SETTING(dsda_config_gl_lightmode_indexed),
   MIGRATED_SETTING(dsda_config_gl_skymode),
   MIGRATED_SETTING(dsda_config_gl_usegamma),
   MIGRATED_SETTING(dsda_config_gl_health_bar),

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1258,8 +1258,6 @@ static void R_DrawPSprite (pspdef_t *psp)
       R_FakeFlat( viewplayer->mo->subsector->sector, &tmpsec,
                   &floorlightlevel, &ceilinglightlevel, false);
       lightlevel = ((floorlightlevel+ceilinglightlevel) >> 1) + (extralight << LIGHTSEGSHIFT);
-      if (!gl_hardware_gamma && !V_IsWorldLightmodeIndexed())
-        lightlevel += usegamma * 16;
 
       if (lightlevel < 0)
         lightlevel = 0;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -846,7 +846,7 @@ dboolean V_IsOpenGLMode(void) {
 }
 
 dboolean V_IsWorldLightmodeIndexed(void) {
-  return gl_lightmode == gl_lightmode_indexed;
+  return gl_lightmode_indexed;
 }
 
 dboolean V_IsUILightmodeIndexed(void) {


### PR DESCRIPTION
- gl_lightmode has been replaced by a flag gl_lightmode_indexed
- resolve all the lightmode-related function proxies
- fix inconsistent hardware gamma / lightmode handling
- shift various errors closer to the cause
- simplify checks for shader support / existence
- replaced some lingering references to glboom.exe