### PR TITLE
Scale fuzz in the software renderer

### DIFF
--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -44,6 +44,7 @@
 #include "g_game.h"
 #include "am_map.h"
 #include "lprintf.h"
+#include "i_system.h"
 
 #include "dsda/stretch.h"
 
@@ -112,12 +113,18 @@ static int fuzzpos = 0;
 // Fuzz cell size for scaled software fuzz
 static int fuzzcellsize;
 
-// Fuzz intensity table. Contains a pattern of fuzz intensities, where a
+// A pattern of fuzz intensities, where a
 // fuzz intensity is how much a fuzz cell darkens its contents
 static const byte fuzzintensity[FUZZTABLE] = {
   0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 3, 4, 0, 1, 2,
   0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 2, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 1, 0, 0, 1, 0
 };
+
+// Fuzz intensity table for every colormap
+// A fuzz intensity table contains 5 tables of 256 colors, where each table
+// contains darkened colors corresponding to the intensity
+// (table 0 is intensity 0, table 1 is intensity 1, etc.)
+static byte *fuzzintensitytables;
 
 // render pipelines
 #define RDC_STANDARD      1
@@ -463,6 +470,38 @@ void R_InitBuffersRes(void)
   temp_x = 0;
 }
 
+static void R_InitFuzzIntensityTables(void)
+{
+  int i, j, k, l;
+  byte *table;
+
+  fuzzintensitytables = Z_Malloc(sizeof(*fuzzintensitytables) * 5 * 256 * numcolormaps);
+
+  for (i = 0; i < numcolormaps; i++)
+  {
+    table = fuzzintensitytables + 5 * 256 * i;
+
+    for (j = 0; j < 5; j++)
+    {
+      for (k = 0; k < 256; k++)
+      {
+        // Get accurate shade for fuzz intensity
+        table[j * 256 + k] = colormaps[i][6 * 256 + k];
+
+        for (l = 0; l < j; l++)
+        {
+          table[j * 256 + k] = colormaps[i][6 * 256 + table[j * 256 + k]];
+        }
+      }
+    }
+  }
+}
+
+static void R_FreeFuzzIntensityTables(void)
+{
+  Z_Free(fuzzintensitytables);
+}
+
 //
 // R_InitBuffer
 // Creats lookup tables that avoid
@@ -480,6 +519,12 @@ void R_InitBuffer(int width, int height)
     fuzzcellsize = (SCREENHEIGHT + 100) / 200;
   else
     fuzzcellsize = (SCREENWIDTH + 160) / 320;
+
+  if (!fuzzintensitytables)
+  {
+    R_InitFuzzIntensityTables();
+    I_AtExit(R_FreeFuzzIntensityTables, true, "R_FreeFuzzIntensityTables", exit_priority_normal);
+  }
 }
 
 //

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -107,18 +107,6 @@ static const byte   *tempfuzzmap;
 //#define FUZZOFF (SCREENWIDTH)
 #define FUZZOFF 1
 
-static const int fuzzoffset_org[FUZZTABLE] = {
-  FUZZOFF,-FUZZOFF,FUZZOFF,-FUZZOFF,FUZZOFF,FUZZOFF,-FUZZOFF,
-  FUZZOFF,FUZZOFF,-FUZZOFF,FUZZOFF,FUZZOFF,FUZZOFF,-FUZZOFF,
-  FUZZOFF,FUZZOFF,FUZZOFF,-FUZZOFF,-FUZZOFF,-FUZZOFF,-FUZZOFF,
-  FUZZOFF,-FUZZOFF,-FUZZOFF,FUZZOFF,FUZZOFF,FUZZOFF,FUZZOFF,-FUZZOFF,
-  FUZZOFF,-FUZZOFF,FUZZOFF,FUZZOFF,-FUZZOFF,-FUZZOFF,FUZZOFF,
-  FUZZOFF,-FUZZOFF,-FUZZOFF,-FUZZOFF,-FUZZOFF,FUZZOFF,FUZZOFF,
-  FUZZOFF,FUZZOFF,-FUZZOFF,FUZZOFF,FUZZOFF,-FUZZOFF,FUZZOFF
-};
-
-static int fuzzoffset[FUZZTABLE];
-
 static int fuzzpos = 0;
 
 // Lovey01 04/29/2023: Scaled software fuzz
@@ -491,18 +479,13 @@ void R_InitBuffersRes(void)
 
 void R_InitBuffer(int width, int height)
 {
-  int i;
-
   drawvars.topleft = screens[0].data;
   drawvars.pitch = screens[0].pitch;
 
-  for (i=0; i<FUZZTABLE; i++)
-    fuzzoffset[i] = fuzzoffset_org[i]*screens[0].pitch;
-
   if (!tallscreen)
-    fuzzcellsize = (WIDE_SCREENHEIGHT + 100) / 200;
+    fuzzcellsize = (SCREENHEIGHT + 100) / 200;
   else
-    fuzzcellsize = (WIDE_SCREENWIDTH + 160) / 320;
+    fuzzcellsize = (SCREENWIDTH + 160) / 320;
 }
 
 //

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -112,19 +112,11 @@ static int fuzzpos = 0;
 // Fuzz cell size for scaled software fuzz
 static int fuzzcellsize;
 
-// Fuzz colormap table. Contains colormaps for fuzz intensities, where a
-// fuzz intensity is how strong a fuzz cell is, or how much it darkens its
-// contents
-// NOTE: Formula to find a colormap for an intensity is
-// (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz intensity
-static const byte fuzzcmaps[FUZZTABLE] = {
-  6, 11, 6, 11, 6, 6, 11,
-  6, 6, 11, 6, 6, 6, 11,
-  6, 6, 6, 11, 15, 18, 21,
-  6, 11, 15, 6, 6, 6, 6, 11,
-  6, 11, 6, 6, 11, 15, 6,
-  6, 11, 15, 18, 21, 6, 6,
-  6, 6, 11, 6, 6, 11, 6
+// Fuzz intensity table. Contains a pattern of fuzz intensities, where a
+// fuzz intensity is how much a fuzz cell darkens its contents
+static const byte fuzzintensity[FUZZTABLE] = {
+  0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 3, 4, 0, 1, 2,
+  0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 2, 0, 0, 1, 2, 3, 4, 0, 0, 0, 0, 1, 0, 0, 1, 0
 };
 
 // render pipelines

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -124,7 +124,7 @@ static const byte fuzzintensity[FUZZTABLE] = {
 // A fuzz intensity table contains 5 tables of 256 colors, where each table
 // contains darkened colors corresponding to the intensity
 // (table 0 is intensity 0, table 1 is intensity 1, etc.)
-static byte *fuzzintensitytables;
+static byte *fuzzintensitytables = NULL;
 
 // render pipelines
 #define RDC_STANDARD      1

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -599,5 +599,6 @@ void R_ResetFuzzCol(int rows)
 
 void R_NewFuzzCol(int x, int rows)
 {
-  if (!(x % fuzzcellsize)) R_ResetFuzzCol(rows);
+  if (!(x % fuzzcellsize))
+    R_ResetFuzzCol(rows);
 }

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -593,7 +593,9 @@ int R_GetFuzzPos()
 
 void R_ResetFuzzCol(int rows)
 {
-  R_ResetColumnBuffer(); // Flush current columns before changing fuzzpos
+  // Make sure previous columns are drawn before changing fuzzpos
+  R_ResetColumnBuffer();
+
   fuzzpos = (fuzzpos + (rows / fuzzcellsize)) % FUZZTABLE;
 }
 

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -596,7 +596,6 @@ int R_GetFuzzPos()
 
 void R_ResetFuzzCol(int height)
 {
-  // Make sure previous columns are drawn before changing fuzzpos
   R_ResetColumnBuffer();
 
   fuzzpos = (fuzzpos + (height / fuzzcellsize)) % FUZZTABLE;

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -109,7 +109,7 @@ static const byte   *tempfuzzmap;
 
 static int fuzzpos = 0;
 
-// Lovey01 04/29/2023: Scaled software fuzz
+// Fuzz cell size for scaled software fuzz
 static int fuzzcellsize;
 
 // NOTE: Formula is (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -122,8 +122,7 @@ static int fuzzoffset[FUZZTABLE];
 static int fuzzpos = 0;
 
 // Lovey01 04/29/2023: Scaled software fuzz
-#define FUZZCELLSHIFT 2
-#define FUZZCELLSIZE (1 << FUZZCELLSHIFT)
+#define FUZZCELLSIZE 5
 
 // NOTE: Formula is (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz
 // intensity
@@ -608,10 +607,10 @@ int R_GetFuzzPos()
 void R_ResetFuzzCol(int rows)
 {
   R_ResetColumnBuffer(); // Flush current columns before changing fuzzpos
-  fuzzpos = (fuzzpos + (rows >> FUZZCELLSHIFT)) % FUZZTABLE;
+  fuzzpos = (fuzzpos + (rows / FUZZCELLSIZE)) % FUZZTABLE;
 }
 
 void R_NewFuzzCol(int x, int rows)
 {
-  if (!(x & (FUZZCELLSIZE - 1))) R_ResetFuzzCol(rows);
+  if (!(x % FUZZCELLSIZE)) R_ResetFuzzCol(rows);
 }

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -594,16 +594,16 @@ int R_GetFuzzPos()
   return fuzzpos;
 }
 
-void R_ResetFuzzCol(int rows)
+void R_ResetFuzzCol(int height)
 {
   // Make sure previous columns are drawn before changing fuzzpos
   R_ResetColumnBuffer();
 
-  fuzzpos = (fuzzpos + (rows / fuzzcellsize)) % FUZZTABLE;
+  fuzzpos = (fuzzpos + (height / fuzzcellsize)) % FUZZTABLE;
 }
 
-void R_NewFuzzCol(int x, int rows)
+void R_CheckFuzzCol(int x, int height)
 {
   if (!(x % fuzzcellsize))
-    R_ResetFuzzCol(rows);
+    R_ResetFuzzCol(height);
 }

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -114,8 +114,7 @@ static int fuzzcellsize;
 
 // NOTE: Formula is (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz
 // intensity
-// NOTE2: Not const because it's stored closer to fuzzpos this way
-static byte fuzzcmaps[FUZZTABLE] = {
+static const byte fuzzcmaps[FUZZTABLE] = {
   6, 11, 6, 11, 6, 6, 11,
   6, 6, 11, 6, 6, 6, 11,
   6, 6, 6, 11, 15, 18, 21,

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -122,7 +122,7 @@ static int fuzzoffset[FUZZTABLE];
 static int fuzzpos = 0;
 
 // Lovey01 04/29/2023: Scaled software fuzz
-#define FUZZCELLSIZE 5
+static int fuzzcellsize;
 
 // NOTE: Formula is (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz
 // intensity
@@ -498,6 +498,11 @@ void R_InitBuffer(int width, int height)
 
   for (i=0; i<FUZZTABLE; i++)
     fuzzoffset[i] = fuzzoffset_org[i]*screens[0].pitch;
+
+  if (!tallscreen)
+    fuzzcellsize = (WIDE_SCREENHEIGHT + 100) / 200;
+  else
+    fuzzcellsize = (WIDE_SCREENWIDTH + 160) / 320;
 }
 
 //
@@ -607,10 +612,10 @@ int R_GetFuzzPos()
 void R_ResetFuzzCol(int rows)
 {
   R_ResetColumnBuffer(); // Flush current columns before changing fuzzpos
-  fuzzpos = (fuzzpos + (rows / FUZZCELLSIZE)) % FUZZTABLE;
+  fuzzpos = (fuzzpos + (rows / fuzzcellsize)) % FUZZTABLE;
 }
 
 void R_NewFuzzCol(int x, int rows)
 {
-  if (!(x % FUZZCELLSIZE)) R_ResetFuzzCol(rows);
+  if (!(x % fuzzcellsize)) R_ResetFuzzCol(rows);
 }

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -112,8 +112,11 @@ static int fuzzpos = 0;
 // Fuzz cell size for scaled software fuzz
 static int fuzzcellsize;
 
-// NOTE: Formula is (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz
-// intensity
+// Fuzz colormap table. Contains colormaps for fuzz intensities, where a
+// fuzz intensity is how strong a fuzz cell is, or how much it darkens its
+// contents
+// NOTE: Formula to find a colormap for an intensity is
+// (6 + 21 - (9 - i) * (9 - i) * 5 / 19), where i is the fuzz intensity
 static const byte fuzzcmaps[FUZZTABLE] = {
   6, 11, 6, 11, 6, 6, 11,
   6, 6, 11, 6, 6, 6, 11,

--- a/prboom2/src/r_draw.h
+++ b/prboom2/src/r_draw.h
@@ -143,4 +143,13 @@ void R_ResetColumnBuffer(void);
 void R_SetFuzzPos(int fuzzpos);
 int R_GetFuzzPos();
 
+// Lovey01 04/30/2023: Scaled software fuzz
+
+// Reset scaled fuzz column
+// rows is the number of rows, in pixels, of the last column
+void R_ResetFuzzCol(int rows);
+
+// Calls R_ResetFuzzCol if x is aligned to the fuzz cell grid
+void R_NewFuzzCol(int x, int rows);
+
 #endif

--- a/prboom2/src/r_draw.h
+++ b/prboom2/src/r_draw.h
@@ -143,8 +143,6 @@ void R_ResetColumnBuffer(void);
 void R_SetFuzzPos(int fuzzpos);
 int R_GetFuzzPos();
 
-// Lovey01 04/30/2023: Scaled software fuzz
-
 // Reset scaled fuzz column
 // rows is the number of rows, in pixels, of the last column
 void R_ResetFuzzCol(int rows);

--- a/prboom2/src/r_draw.h
+++ b/prboom2/src/r_draw.h
@@ -144,10 +144,10 @@ void R_SetFuzzPos(int fuzzpos);
 int R_GetFuzzPos();
 
 // Reset scaled fuzz column
-// rows is the number of rows, in pixels, of the last column
-void R_ResetFuzzCol(int rows);
+// height is the height of the last column, in pixels
+void R_ResetFuzzCol(int height);
 
 // Calls R_ResetFuzzCol if x is aligned to the fuzz cell grid
-void R_NewFuzzCol(int x, int rows);
+void R_CheckFuzzCol(int x, int height);
 
 #endif

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -56,19 +56,18 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
 
    x = temp_x;
    topleft = drawvars.topleft + startx;
-   fp = fuzzpos;
 
    while (--x >= 0)
    {
       yl = tempyl[x];
       dest = topleft + yl * drawvars.pitch + x;
       count = tempyh[x] - yl + 1;
+      fp = fuzzpos + (yl / FUZZCELLSIZE);
 
-      count2 = FUZZCELLSIZE - (yl & (FUZZCELLSIZE - 1));
+      count2 = FUZZCELLSIZE - (yl % FUZZCELLSIZE);
       do
       {
-         intensitycmap =
-            fuzzcmaps[(fp + (yl >> FUZZCELLSHIFT)) % FUZZTABLE] << 8;
+         intensitycmap = fuzzcmaps[fp % FUZZTABLE] << 8;
 
          count -= count2;
          cmask = count >> 31;
@@ -81,7 +80,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
             dest += drawvars.pitch;
          } while (--count2);
 
-         yl += FUZZCELLSIZE;
+         ++fp;
          count2 = FUZZCELLSIZE;
       } while (count);
    }

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -46,15 +46,16 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
    // Scaled software fuzz algorithm
 #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
    int x;
-   byte *dest, *topleft;
+   byte *dest, *topleft, *fuzztable;
    int yl;
    int count, count2, cmask;
-   int intensity, i;
+   int tableoffset;
    int fp, cs;
 
    x = temp_x;
    topleft = drawvars.topleft + startx;
    cs = fuzzcellsize;
+   fuzztable = fuzzintensitytables + 5 * 256 * boom_cm;
 
    while (--x >= 0)
    {
@@ -69,7 +70,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
       count2 = cs - (yl % cs);
       do
       {
-         intensity = fuzzintensity[fp % FUZZTABLE];
+         tableoffset = fuzzintensity[fp % FUZZTABLE] * 256;
 
          count -= count2;
 
@@ -84,12 +85,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
          // Draw cell stripe, pixel by pixel
          do
          {
-            i = intensity;
-
-            do {
-               *dest = tempfuzzmap[6 * 256 + *dest];
-            } while (--i >= 0);
-
+            *dest = fuzztable[tableoffset + *dest];
             dest += drawvars.pitch;
          } while (--count2);
 

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -101,13 +101,6 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
       {
 #if (R_DRAWCOLUMN_PIPELINE & RDC_TRANSLUCENT)
          *dest = GETDESTCOLOR(*dest, *source);
-#elif (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
-         // SoM 7-28-04: Fix the fuzz problem.
-         *dest = GETDESTCOLOR(dest[fuzzoffset[fuzzpos]]);
-
-         // Clamp table lookup index.
-         if(++fuzzpos == FUZZTABLE)
-            fuzzpos = 0;
 #else
          *dest = *source;
 #endif
@@ -156,13 +149,6 @@ static void R_FLUSHHEADTAIL_FUNCNAME(void)
 #if (R_DRAWCOLUMN_PIPELINE & RDC_TRANSLUCENT)
             // haleyjd 09/11/04: use temptranmap here
             *dest = GETDESTCOLOR(*dest, *source);
-#elif (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
-            // SoM 7-28-04: Fix the fuzz problem.
-            *dest = GETDESTCOLOR(dest[fuzzoffset[fuzzpos]]);
-
-            // Clamp table lookup index.
-            if(++fuzzpos == FUZZTABLE)
-               fuzzpos = 0;
 #else
             *dest = *source;
 #endif
@@ -184,13 +170,6 @@ static void R_FLUSHHEADTAIL_FUNCNAME(void)
 #if (R_DRAWCOLUMN_PIPELINE & RDC_TRANSLUCENT)
             // haleyjd 09/11/04: use temptranmap here
             *dest = GETDESTCOLOR(*dest, *source);
-#elif (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
-            // SoM 7-28-04: Fix the fuzz problem.
-            *dest = GETDESTCOLOR(dest[fuzzoffset[fuzzpos]]);
-
-            // Clamp table lookup index.
-            if(++fuzzpos == FUZZTABLE)
-               fuzzpos = 0;
 #else
             *dest = *source;
 #endif

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -52,19 +52,20 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
    int intensitycmap;
    int yl;
    int count, count2, cmask;
-   int fp;
+   int fp, cs;
 
    x = temp_x;
    topleft = drawvars.topleft + startx;
+   cs = fuzzcellsize;
 
    while (--x >= 0)
    {
       yl = tempyl[x];
       dest = topleft + yl * drawvars.pitch + x;
       count = tempyh[x] - yl + 1;
-      fp = fuzzpos + (yl / FUZZCELLSIZE);
+      fp = fuzzpos + (yl / cs);
 
-      count2 = FUZZCELLSIZE - (yl % FUZZCELLSIZE);
+      count2 = cs - (yl % cs);
       do
       {
          intensitycmap = fuzzcmaps[fp % FUZZTABLE] << 8;
@@ -81,7 +82,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
          } while (--count2);
 
          ++fp;
-         count2 = FUZZCELLSIZE;
+         count2 = cs;
       } while (count);
    }
 #else  /* if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ) */

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -47,9 +47,9 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
 #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
    int x;
    byte *dest, *topleft;
-   int intensitycmap;
    int yl;
    int count, count2, cmask;
+   int intensity, i;
    int fp, cs;
 
    x = temp_x;
@@ -69,7 +69,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
       count2 = cs - (yl % cs);
       do
       {
-         intensitycmap = fuzzcmaps[fp % FUZZTABLE] << 8;
+         intensity = fuzzintensity[fp % FUZZTABLE];
 
          count -= count2;
 
@@ -84,7 +84,12 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
          // Draw cell stripe, pixel by pixel
          do
          {
-            *dest = tempfuzzmap[intensitycmap + *dest];
+            i = intensity;
+
+            do {
+               *dest = tempfuzzmap[6 * 256 + *dest];
+            } while (--i >= 0);
+
             dest += drawvars.pitch;
          } while (--count2);
 

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -30,8 +30,6 @@
 
 #if (R_DRAWCOLUMN_PIPELINE & RDC_TRANSLUCENT)
 #define GETDESTCOLOR(col1, col2) (temptranmap[((col1)<<8)+(col2)])
-#elif (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
-#define GETDESTCOLOR(col) (tempfuzzmap[6*256+(col)])
 #else
 #define GETDESTCOLOR(col) (col)
 #endif

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -61,18 +61,27 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
       yl = tempyl[x];
       dest = topleft + yl * drawvars.pitch + x;
       count = tempyh[x] - yl + 1;
+
+      // Draw fuzz stripe independently from vertical screen position
       fp = fuzzpos + (yl / cs);
 
+      // Draw column, cell stripe by cell stripe
       count2 = cs - (yl % cs);
       do
       {
          intensitycmap = fuzzcmaps[fp % FUZZTABLE] << 8;
 
          count -= count2;
+
+         // if (count < 0) {
+         //    count2 += count;
+         //    count = 0;
+         // }
          cmask = count >> 31;
          count2 += count & cmask;
          count &= ~cmask;
 
+         // Draw cell stripe, pixel by pixel
          do
          {
             *dest = tempfuzzmap[intensitycmap + *dest];

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -77,7 +77,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
          //    count2 += count;
          //    count = 0;
          // }
-         cmask = count >> 31;
+         cmask = count >> (sizeof(int) * 8 - 1);
          count2 += count & cmask;
          count &= ~cmask;
 

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -43,7 +43,7 @@
 //
 static void R_FLUSHWHOLE_FUNCNAME(void)
 {
-   // Lovey01 04/29/2023: Scaled software fuzz algorithm
+   // Scaled software fuzz algorithm
 #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
    int x;
    byte *dest, *topleft;
@@ -134,7 +134,7 @@ static void R_FLUSHHEADTAIL_FUNCNAME(void)
    int yl, yh;
 
 #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
-   // Lovey01 04/29/2023: Only whole flushes are supported for fuzz
+   // Only whole flushes are supported for fuzz
    R_FLUSHWHOLE_FUNCNAME();
    return;
 #endif
@@ -195,7 +195,7 @@ static void R_FLUSHQUAD_FUNCNAME(void)
    byte *dest = drawvars.topleft + commontop*drawvars.pitch + startx;
    int count;
 #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
-   // Lovey01 04/29/2023: Only whole flushes are supported for fuzz
+   // Only whole flushes are supported for fuzz
    return;
 #endif
 

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -448,6 +448,7 @@ int   *mfloorclip;   // dropoff overflow
 int   *mceilingclip; // dropoff overflow
 fixed_t spryscale;
 int64_t sprtopscreen; // R_WiggleFix
+int colheight; // Scaled software fuzz
 
 void R_DrawMaskedColumn(
   const rpatch_t *patch,
@@ -462,6 +463,8 @@ void R_DrawMaskedColumn(
   int64_t     topscreen; // R_WiggleFix
   int64_t     bottomscreen; // R_WiggleFix
   fixed_t basetexturemid = dcvars->texturemid;
+
+  colheight = 0;
 
   dcvars->texheight = patch->height; // killough 11/98
   for (i=0; i<column->numPosts; i++) {
@@ -498,6 +501,8 @@ void R_DrawMaskedColumn(
           dcvars->drawingmasked = 1; // POPE
           colfunc (dcvars);
           dcvars->drawingmasked = 0; // POPE
+
+          colheight += dcvars->yh - dcvars->yl + 1;
         }
     }
   dcvars->texturemid = basetexturemid;
@@ -560,6 +565,7 @@ static void R_DrawVisSprite(vissprite_t *vis)
 
   if (!dcvars.colormap)   // NULL colormap = shadow draw
   {
+    R_ResetFuzzCol(colheight); // Reset fuzz column for new sprite
     colfunc = R_GetDrawColumnFunc(RDC_PIPELINE_FUZZ, RDRAW_FILTER_POINT);    // killough 3/14/98
   }
   else if (vis->color)
@@ -608,6 +614,9 @@ static void R_DrawVisSprite(vissprite_t *vis)
   for (dcvars.x=vis->x1 ; dcvars.x<=vis->x2 ; dcvars.x++, frac += vis->xiscale)
     {
       texturecolumn = frac>>FRACBITS;
+
+      // Fuzz column handling
+      if (!dcvars.colormap) R_NewFuzzCol(dcvars.x, colheight);
 
       R_DrawMaskedColumn(
         patch,

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -616,7 +616,7 @@ static void R_DrawVisSprite(vissprite_t *vis)
       texturecolumn = frac>>FRACBITS;
 
       // Fuzz column handling
-      if (!dcvars.colormap) R_NewFuzzCol(dcvars.x, colheight);
+      if (!dcvars.colormap) R_CheckFuzzCol(dcvars.x, colheight);
 
       R_DrawMaskedColumn(
         patch,


### PR DESCRIPTION
For a long time now, software renderer fuzz has been drawn using an algorithm that doesn't adapt to screen size, making fuzz harder to see at higher resolutions. This PR overwrites the old algorithm with a new one that scales the fuzz to match the window size.

From my tests at 1080p, it performs better than the original algorithm, but it could be optimized further.

Comparisons:
![fuzzComparison1](https://user-images.githubusercontent.com/87508305/235378386-e30e1d61-ec7a-4ee8-80f5-25299a262772.png)
![fuzzComparison2](https://user-images.githubusercontent.com/87508305/235378392-b4e3bc2a-3b3f-4823-b83d-576a9b64a864.png)
![fuzzComparison3](https://user-images.githubusercontent.com/87508305/235378393-28525602-d18a-4b92-ab47-ba67d92cbbbb.png)
