### PR TITLE
GL: fix mysterious single-frame missing walls

### DIFF
--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -535,7 +535,8 @@ typedef struct vbo_xy_uv_rgba_s
 
 // preprocessing
 extern byte *segrendered; // true if sector rendered (only here for malloc)
-extern byte *linerendered[2]; // true if linedef rendered (only here for malloc)
+extern int *linerendered[2]; // true if linedef rendered (only here for malloc)
+extern int rendermarker;
 extern GLuint flats_vbo_id;
 
 typedef struct GLShader_s

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1137,9 +1137,9 @@ vbo_xyz_uv_t *flats_vbo = NULL;
 GLSeg *gl_segs=NULL;
 GLSeg *gl_lines=NULL;
 
-byte rendermarker=0;
+int rendermarker=0;
 byte *segrendered; // true if sector rendered (only here for malloc)
-byte *linerendered[2]; // true if linedef rendered (only here for malloc)
+int *linerendered[2]; // true if linedef rendered (only here for malloc)
 
 float roll     = 0.0f;
 float yaw      = 0.0f;

--- a/prboom2/src/gl_preprocess.c
+++ b/prboom2/src/gl_preprocess.c
@@ -886,8 +886,8 @@ static void gld_PreprocessSectors(void)
 
   if (numlines)
   {
-    linerendered[0]=Z_Calloc(numlines, sizeof(byte));
-    linerendered[1]=Z_Calloc(numlines, sizeof(byte));
+    linerendered[0]=Z_Calloc(numlines, sizeof(*linerendered[0]));
+    linerendered[1]=Z_Calloc(numlines, sizeof(*linerendered[1]));
     if (!linerendered[0] || !linerendered[1])
       I_Error("gld_PreprocessSectors: Not enough memory for array linerendered");
   }
@@ -1070,6 +1070,8 @@ void gld_PreprocessLevel(void)
     memset(linerendered[0], 0, numlines*sizeof(linerendered[0][0]));
     memset(linerendered[1], 0, numlines*sizeof(linerendered[1][0]));
   }
+
+  rendermarker = 0;
 
   gld_ResetLastTexture();
   gld_ResetTexturedAutomap();

--- a/prboom2/src/gl_vertex.c
+++ b/prboom2/src/gl_vertex.c
@@ -231,8 +231,6 @@ void gld_SplitRightEdge(const GLWall *wall, dboolean detail)
 //==========================================================================
 void gld_RecalcVertexHeights(const vertex_t *v)
 {
-  extern byte rendermarker;
-
   int i,j,k;
   float height;
   vertexsplit_info_t *vi;


### PR DESCRIPTION
I was trying to track town a problem in my experimental branch where walls would occasionally not be rendered for a frame when rounding a corner (very noticeable with `flashing_hom`), and started to suspect that it might be an existing bug.  The GL renderer uses a `validcount`-like counter to make sure it renders a wall only once per frame, but it only uses a byte for the counter.  This wraps very rapidly even at modest framerates, so there's a roughly 1-in-256 chance that a wall that just became visible in a frame will not be rendered because its count happens to match the wrapped global count.

A related problem is probably responsible for the random rendering glitch during the wipe effect: the counter values for all walls are reset on map start, but not the global counter.  This means you have a 1-in-256 chance of *all* walls not being rendered during the wipe.

-----------------

- Reset rendermarker when resetting linerendered array
- Use int for rendermarker so it doesn't wrap so quickly