### PR TITLE
Extract new messenger

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -159,6 +159,8 @@ set(COMMON_SRC
     dsda/mapinfo/u.h
     dsda/memory.c
     dsda/memory.h
+    dsda/messenger.c
+    dsda/messenger.h
     dsda/mobjinfo.c
     dsda/mobjinfo.h
     dsda/mouse.c

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -59,6 +59,7 @@
 
 #include "dsda/input.h"
 #include "dsda/map_format.h"
+#include "dsda/messenger.h"
 #include "dsda/settings.h"
 #include "dsda/stretch.h"
 
@@ -1034,16 +1035,14 @@ dboolean AM_Responder
   else if (dsda_InputActivated(dsda_input_map_follow))
   {
     dsda_ToggleConfig(dsda_config_automap_follow, true);
-    // Ty 03/27/98 - externalized
-    plr->message = automap_follow ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF;
+    dsda_AddMessage(automap_follow ? s_AMSTR_FOLLOWON : s_AMSTR_FOLLOWOFF);
 
     return true;
   }
   else if (dsda_InputActivated(dsda_input_map_grid))
   {
     dsda_ToggleConfig(dsda_config_automap_grid, true);
-    // Ty 03/27/98 - *not* externalized
-    plr->message = automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF;
+    dsda_AddMessage(automap_grid ? s_AMSTR_GRIDON : s_AMSTR_GRIDOFF);
 
     return true;
   }
@@ -1059,14 +1058,14 @@ dboolean AM_Responder
   else if (dsda_InputActivated(dsda_input_map_clear))
   {
     AM_clearMarks();  // Ty 03/27/98 - *not* externalized
-    plr->message = s_AMSTR_MARKSCLEARED;
+    dsda_AddMessage(s_AMSTR_MARKSCLEARED);
 
     return true;
   }
   else if (dsda_InputActivated(dsda_input_map_rotate))
   {
     dsda_ToggleConfig(dsda_config_automap_rotate, true);
-    plr->message = automap_rotate ? s_AMSTR_ROTATEON : s_AMSTR_ROTATEOFF;
+    dsda_AddMessage(automap_rotate ? s_AMSTR_ROTATEON : s_AMSTR_ROTATEOFF);
 
     return true;
   }
@@ -1081,7 +1080,7 @@ dboolean AM_Responder
   else if (dsda_InputActivated(dsda_input_map_textured))
   {
     dsda_ToggleConfig(dsda_config_map_textured, true);
-    plr->message = (map_textured ? s_AMSTR_TEXTUREDON : s_AMSTR_TEXTUREDOFF);
+    dsda_AddMessage(map_textured ? s_AMSTR_TEXTUREDON : s_AMSTR_TEXTUREDOFF);
 
     return true;
   }

--- a/prboom2/src/d_player.h
+++ b/prboom2/src/d_player.h
@@ -195,9 +195,6 @@ typedef struct player_s
   int                 itemcount;
   int                 secretcount;
 
-  // Hint messages. // CPhipps - const
-  const char*         message;
-
   // For screen flashing (red or bright).
   int                 damagecount;
   int                 bonuscount;

--- a/prboom2/src/dsda/hud_components/message.c
+++ b/prboom2/src/dsda/hud_components/message.c
@@ -27,11 +27,11 @@ typedef struct {
 static local_component_t* local;
 
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
-  char* HU_PlayerMessage(void);
+  char* dsda_PlayerMessage(void);
 
   char* message;
 
-  message = HU_PlayerMessage();
+  message = dsda_PlayerMessage();
 
   if (message)
     snprintf(

--- a/prboom2/src/dsda/messenger.c
+++ b/prboom2/src/dsda/messenger.c
@@ -142,6 +142,10 @@ void dsda_UpdateMessenger(void) {
   }
 }
 
+void dsda_InitMessenger(void) {
+  dsda_ClearMessages();
+}
+
 char* dsda_PlayerMessage(void) {
   if (!current_message)
     return NULL;

--- a/prboom2/src/dsda/messenger.c
+++ b/prboom2/src/dsda/messenger.c
@@ -1,0 +1,150 @@
+//
+// Copyright(C) 2023 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Message
+//
+
+#include "d_player.h"
+#include "doomstat.h"
+#include "z_zone.h"
+
+#include "dsda/settings.h"
+
+#include "messenger.h"
+
+// hexen_note: use FONTAY_S for yellow messages (new font, y_message, etc)
+
+#define MESSAGE_LIFETIME 140
+
+typedef enum {
+  message_alert,
+  message_normal,
+} message_priority_t;
+
+typedef struct message_s {
+  char* str;
+  message_priority_t priority;
+  int tics;
+  struct message_s* next_message;
+} message_t;
+
+static message_t* current_message;
+static message_t* last_message;
+
+static void dsda_FreeMessage(message_t* message) {
+  Z_Free(message->str);
+  Z_Free(message);
+}
+
+static void dsda_ClearMessages(void) {
+  message_t* message_p;
+
+  while (current_message) {
+    message_p = current_message->next_message;
+    dsda_FreeMessage(current_message);
+    current_message = message_p;
+  }
+}
+
+static void dsda_AppendMessage(message_t* message) {
+  if (!current_message)
+    current_message = message;
+  else {
+    message_t* message_p;
+
+    message_p = current_message;
+    while (message_p->next_message)
+      message_p = message_p->next_message;
+
+    message_p->next_message = message;
+  }
+}
+
+static void dsda_QueueMessage(const char* str, message_priority_t priority) {
+  message_t* new_message;
+
+  if (current_message) {
+    if (current_message->priority < priority)
+      return;
+    else if (current_message->priority > priority)
+      dsda_ClearMessages();
+    else if (priority == message_normal) {
+      Z_Free(current_message->str);
+
+      current_message->str = Z_Strdup(str);
+      current_message->tics = MESSAGE_LIFETIME;
+
+      return;
+    }
+  }
+
+  new_message = Z_Calloc(1, sizeof(*new_message));
+  new_message->str = Z_Strdup(str);
+  new_message->priority = priority;
+  new_message->tics = MESSAGE_LIFETIME;
+
+  dsda_AppendMessage(new_message);
+}
+
+void dsda_AddPlayerAlert(const char* str, player_t* player) {
+  if (player == &players[displayplayer])
+    dsda_QueueMessage(str, message_alert);
+}
+
+void dsda_AddAlert(const char* str) {
+  dsda_QueueMessage(str, message_alert);
+}
+
+void dsda_AddPlayerMessage(const char* str, player_t* player) {
+  if (dsda_ShowMessages() && player == &players[displayplayer])
+    dsda_QueueMessage(str, message_normal);
+}
+
+void dsda_AddMessage(const char* str) {
+  if (dsda_ShowMessages())
+    dsda_QueueMessage(str, message_normal);
+}
+
+void dsda_AddUnblockableMessage(const char* str) {
+  dsda_QueueMessage(str, message_normal);
+}
+
+void dsda_UpdateMessenger(void) {
+  if (!current_message)
+    return;
+
+  --current_message->tics;
+  if (!current_message->tics) {
+    if (current_message->next_message) {
+      message_t* old_message;
+
+      old_message = current_message;
+      current_message = current_message->next_message;
+      dsda_FreeMessage(old_message);
+    }
+    else {
+      if (last_message)
+        dsda_FreeMessage(last_message);
+      last_message = current_message;
+      current_message = NULL;
+    }
+  }
+}
+
+char* dsda_PlayerMessage(void) {
+  if (!current_message)
+    return NULL;
+
+  return current_message->str;
+}

--- a/prboom2/src/dsda/messenger.c
+++ b/prboom2/src/dsda/messenger.c
@@ -126,24 +126,20 @@ void dsda_UpdateMessenger(void) {
 
   --current_message->tics;
   if (!current_message->tics) {
-    if (current_message->next_message) {
-      message_t* old_message;
-
-      old_message = current_message;
-      current_message = current_message->next_message;
-      dsda_FreeMessage(old_message);
-    }
-    else {
-      if (last_message)
-        dsda_FreeMessage(last_message);
-      last_message = current_message;
-      current_message = NULL;
-    }
+    if (last_message)
+      dsda_FreeMessage(last_message);
+    last_message = current_message;
+    current_message = current_message->next_message;
   }
 }
 
 void dsda_InitMessenger(void) {
   dsda_ClearMessages();
+  if (last_message)
+    dsda_FreeMessage(last_message);
+  last_message = NULL;
+}
+
 }
 
 char* dsda_PlayerMessage(void) {

--- a/prboom2/src/dsda/messenger.c
+++ b/prboom2/src/dsda/messenger.c
@@ -140,6 +140,11 @@ void dsda_InitMessenger(void) {
   last_message = NULL;
 }
 
+void dsda_ReplayMessage(void) {
+  if (last_message) {
+    dsda_ClearMessages();
+    dsda_QueueMessage(last_message->str, last_message->priority);
+  }
 }
 
 char* dsda_PlayerMessage(void) {

--- a/prboom2/src/dsda/messenger.h
+++ b/prboom2/src/dsda/messenger.h
@@ -25,5 +25,6 @@ void dsda_AddMessage(const char* str);
 void dsda_AddUnblockableMessage(const char* str);
 void dsda_UpdateMessenger(void);
 void dsda_InitMessenger(void);
+void dsda_ReplayMessage(void);
 
 #endif

--- a/prboom2/src/dsda/messenger.h
+++ b/prboom2/src/dsda/messenger.h
@@ -1,0 +1,28 @@
+//
+// Copyright(C) 2023 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Message
+//
+
+#ifndef __DSDA_MESSAGE__
+#define __DSDA_MESSAGE__
+
+void dsda_AddPlayerAlert(const char* str, player_t* player);
+void dsda_AddAlert(const char* str);
+void dsda_AddPlayerMessage(const char* str, player_t* player);
+void dsda_AddMessage(const char* str);
+void dsda_AddUnblockableMessage(const char* str);
+void dsda_UpdateMessenger(void);
+
+#endif

--- a/prboom2/src/dsda/messenger.h
+++ b/prboom2/src/dsda/messenger.h
@@ -24,5 +24,6 @@ void dsda_AddPlayerMessage(const char* str, player_t* player);
 void dsda_AddMessage(const char* str);
 void dsda_AddUnblockableMessage(const char* str);
 void dsda_UpdateMessenger(void);
+void dsda_InitMessenger(void);
 
 #endif

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -96,6 +96,7 @@
 #include "dsda/exdemo.h"
 #include "dsda/features.h"
 #include "dsda/key_frame.h"
+#include "dsda/messenger.h"
 #include "dsda/save.h"
 #include "dsda/settings.h"
 #include "dsda/input.h"
@@ -3951,7 +3952,8 @@ void doom_printf(const char *s, ...)
   va_start(v,s);
   vsnprintf(msg,sizeof(msg),s,v);   /* print message in buffer */
   va_end(v);
-  players[consoleplayer].message = msg;  // set new message
+
+  dsda_AddMessage(msg);
 }
 
 //e6y

--- a/prboom2/src/hexen/sv_save.c
+++ b/prboom2/src/hexen/sv_save.c
@@ -2014,7 +2014,6 @@ void SV_MapTeleport(int map, int position)
             continue;
         }
         players[i] = playerBackup[i];
-        ClearMessage();
         players[i].attacker = NULL;
         players[i].poisoner = NULL;
 

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -344,6 +344,7 @@ void HU_Start(void)
   HU_FetchTitle();
   HU_InitCrosshair();
 
+  dsda_InitMessenger();
   dsda_InitExHud();
 }
 

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -83,7 +83,6 @@ typedef struct message_thinker_s
 {
   thinker_t thinker;
   int plr;
-  int delay;
   custom_message_t msg;
 } message_thinker_t;
 
@@ -502,7 +501,7 @@ void T_ShowMessage (message_thinker_t* message)
   P_RemoveThinker(&message->thinker); // unlink and free
 }
 
-int SetCustomMessage(int plr, const char *msg, int delay, int ticks, int cm, int sfx)
+int SetCustomMessage(int plr, const char *msg, int ticks, int cm, int sfx)
 {
   custom_message_t item;
 
@@ -517,21 +516,7 @@ int SetCustomMessage(int plr, const char *msg, int delay, int ticks, int cm, int
   item.cm = cm;
   item.sfx = sfx;
 
-  if (delay <= 0)
-  {
-    custom_message[plr] = item;
-  }
-  else
-  {
-    message_thinker_t *message = Z_CallocLevel(1, sizeof(*message));
-    message->thinker.function = T_ShowMessage;
-    message->delay = delay;
-    message->plr = plr;
-
-    message->msg = item;
-
-    P_AddThinker(&message->thinker);
-  }
+  custom_message[plr] = item;
 
   return true;
 }

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -430,8 +430,7 @@ dboolean HU_Responder(event_t *ev)
 {
   if (dsda_InputActivated(dsda_input_repeat_message)) // phares
   {
-    message_on = true;
-    message_counter = HU_MSGTIMEOUT;
+    dsda_ReplayMessage();
 
     return true;
   }

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -66,12 +66,6 @@
 
 static player_t*  plr;
 
-static dboolean    message_on;
-dboolean           message_dontfuckwithme;
-static dboolean    message_nottobefuckedwith;
-static int         message_counter;
-static int         yellow_message;
-
 typedef struct custom_message_s
 {
   int ticks;
@@ -112,10 +106,6 @@ static void HU_FetchTitle(void)
 static void HU_InitMessages(void)
 {
   custom_message_p = &custom_message[displayplayer];
-  message_on = false;
-  message_dontfuckwithme = false;
-  message_nottobefuckedwith = false;
-  yellow_message = false;
 }
 
 static void HU_InitPlayer(void)
@@ -456,10 +446,4 @@ int SetCustomMessage(int plr, const char *msg, int ticks, int cm, int sfx)
   custom_message[plr] = item;
 
   return true;
-}
-
-void ClearMessage(void)
-{
-  message_counter = 0;
-  yellow_message = false;
 }

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -59,6 +59,7 @@
 #include "dsda/exhud.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
+#include "dsda/messenger.h"
 #include "dsda/pause.h"
 #include "dsda/settings.h"
 #include "dsda/stretch.h"
@@ -368,20 +369,7 @@ void HU_Drawer(void)
   V_EndUIDraw();
 }
 
-char* player_message;
 char* secret_message;
-
-static void HU_UpdateMessage(const char* message)
-{
-  if (player_message)
-    Z_Free(player_message);
-
-  player_message = Z_Strdup(message);
-}
-
-char* HU_PlayerMessage(void) {
-  return message_on ? player_message : NULL;
-}
 
 static void HU_UpdateSecretMessage(const char* message)
 {
@@ -406,40 +394,7 @@ void HU_Ticker(void)
 {
   int i;
 
-  // tick down message counter if message is up
-  if (message_counter && !--message_counter)
-  {
-    message_on = false;
-    message_nottobefuckedwith = false;
-    yellow_message = false;
-  }
-
-  // if messages on, or "Messages Off" is being displayed
-  // this allows the notification of turning messages off to be seen
-  if (dsda_ShowMessages() || message_dontfuckwithme)
-  {
-    // display message if necessary
-    if ((plr->message && !message_nottobefuckedwith)
-        || (plr->message && message_dontfuckwithme))
-    {
-      // update the active message
-      HU_UpdateMessage(plr->message);
-
-      // clear the message to avoid posting multiple times
-      plr->message = 0;
-      // note a message is displayed
-      message_on = true;
-      // start the message persistence counter
-      message_counter = HU_MSGTIMEOUT;
-      // transfer "Messages Off" exception to the "being displayed" variable
-      message_nottobefuckedwith = message_dontfuckwithme;
-      // clear the flag that "Messages Off" is being posted
-      message_dontfuckwithme = 0;
-
-      yellow_message = plr->yellowMessage;
-      // hexen_note: use FONTAY_S for yellow messages (new font, y_message, etc)
-    }
-  }
+  dsda_UpdateMessenger();
 
   // centered messages
   for (i = 0; i < g_maxplayers; i++)

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -79,13 +79,6 @@ typedef struct custom_message_s
   const char *msg;
 } custom_message_t;
 
-typedef struct message_thinker_s
-{
-  thinker_t thinker;
-  int plr;
-  custom_message_t msg;
-} message_thinker_t;
-
 static custom_message_t custom_message[MAX_MAXPLAYERS];
 static custom_message_t *custom_message_p;
 

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -490,17 +490,6 @@ dboolean HU_Responder(event_t *ev)
   return false;
 }
 
-void T_ShowMessage (message_thinker_t* message)
-{
-  if (--message->delay > 0)
-    return;
-
-  SetCustomMessage(message->plr, message->msg.msg, 0,
-    message->msg.ticks, message->msg.cm, message->msg.sfx);
-
-  P_RemoveThinker(&message->thinker); // unlink and free
-}
-
 int SetCustomMessage(int plr, const char *msg, int ticks, int cm, int sfx)
 {
   custom_message_t item;

--- a/prboom2/src/hu_stuff.h
+++ b/prboom2/src/hu_stuff.h
@@ -51,7 +51,7 @@ void HU_Drawer(void);
 
 mobj_t *HU_Target(void);
 
-int SetCustomMessage(int plr, const char *msg, int delay, int ticks, int cm, int sfx);
+int SetCustomMessage(int plr, const char *msg, int ticks, int cm, int sfx);
 void ClearMessage(void);
 
 extern int hud_health_red;    // health amount less than which status is red

--- a/prboom2/src/hu_stuff.h
+++ b/prboom2/src/hu_stuff.h
@@ -52,7 +52,6 @@ void HU_Drawer(void);
 mobj_t *HU_Target(void);
 
 int SetCustomMessage(int plr, const char *msg, int ticks, int cm, int sfx);
-void ClearMessage(void);
 
 extern int hud_health_red;    // health amount less than which status is red
 extern int hud_health_yellow; // health amount less than which status is yellow

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -62,6 +62,7 @@
 #include "dsda/input.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
+#include "dsda/messenger.h"
 #include "dsda/settings.h"
 
 #define plyr (players+consoleplayer)     /* the console player */
@@ -260,7 +261,7 @@ char buf[3];
   if (!isdigit(buf[0]) || !isdigit(buf[1]))
     return;
 
-  plyr->message = s_STSTR_MUS; // Ty 03/27/98 - externalized
+  dsda_AddMessage(s_STSTR_MUS);
 
   if (gamemode == commercial)
     {
@@ -268,7 +269,7 @@ char buf[3];
 
       //jff 4/11/98 prevent IDMUS00 in DOOMII and IDMUS36 or greater
       if (musnum < mus_runnin ||  ((buf[0]-'0')*10 + buf[1]-'0') > 35)
-        plyr->message = s_STSTR_NOMUS; // Ty 03/27/98 - externalized
+        dsda_AddMessage(s_STSTR_NOMUS);
       else
         {
           S_ChangeMusic(musnum, 1);
@@ -281,7 +282,7 @@ char buf[3];
 
       //jff 4/11/98 prevent IDMUS0x IDMUSx0 in DOOMI and greater than introa
       if (buf[0] < '1' || buf[1] < '1' || ((buf[0]-'1')*9 + buf[1]-'1') > 31)
-        plyr->message = s_STSTR_NOMUS; // Ty 03/27/98 - externalized
+        dsda_AddMessage(s_STSTR_NOMUS);
       else
         {
           S_ChangeMusic(musnum, 1);
@@ -295,7 +296,7 @@ static void cheat_choppers()
 {
   plyr->weaponowned[wp_chainsaw] = true;
   plyr->powers[pw_invulnerability] = true;
-  plyr->message = s_STSTR_CHOPPERS; // Ty 03/27/98 - externalized
+  dsda_AddMessage(s_STSTR_CHOPPERS);
 }
 
 void M_CheatGod(void)
@@ -331,10 +332,10 @@ void M_CheatGod(void)
       plyr->mo->health = god_health;  // Ty 03/09/98 - deh
 
     plyr->health = god_health;
-    plyr->message = s_STSTR_DQDON; // Ty 03/27/98 - externalized
+    dsda_AddMessage(s_STSTR_DQDON);
   }
   else
-    plyr->message = s_STSTR_DQDOFF; // Ty 03/27/98 - externalized
+    dsda_AddMessage(s_STSTR_DQDOFF);
 
   if (raven) SB_Start();
 }
@@ -357,7 +358,7 @@ static void cheat_health()
     if (plyr->mo)
       plyr->mo->health = mega_health;
     plyr->health = mega_health;
-    plyr->message = s_STSTR_BEHOLDX; // Ty 03/27/98 - externalized
+    dsda_AddMessage(s_STSTR_BEHOLDX);
   }
 }
 
@@ -365,7 +366,7 @@ static void cheat_megaarmour()
 {
   plyr->armorpoints[ARMOR_ARMOR] = idfa_armor;      // Ty 03/09/98 - deh
   plyr->armortype = idfa_armor_class;  // Ty 03/09/98 - deh
-  plyr->message = s_STSTR_BEHOLDX; // Ty 03/27/98 - externalized
+  dsda_AddMessage(s_STSTR_BEHOLDX);
 }
 
 static void cheat_fa()
@@ -409,7 +410,7 @@ static void cheat_fa()
       if (i!=am_cell || gamemode!=shareware)
         plyr->ammo[i] = plyr->maxammo[i];
 
-    plyr->message = s_STSTR_FAADDED;
+    dsda_AddMessage(s_STSTR_FAADDED);
   }
 }
 
@@ -420,7 +421,7 @@ static void cheat_k()
     if (!plyr->cards[i])     // only print message if at least one key added
       {                      // however, caller may overwrite message anyway
         plyr->cards[i] = true;
-        plyr->message = "Keys Added";
+        dsda_AddMessage("Keys Added");
       }
 
   // heretic - reset status bar
@@ -431,13 +432,12 @@ static void cheat_kfa()
 {
   cheat_k();
   cheat_fa();
-  plyr->message = s_STSTR_KFAADDED;
+  dsda_AddMessage(s_STSTR_KFAADDED);
 }
 
 void M_CheatNoClip(void)
 {
-  plyr->message = (plyr->cheats ^= CF_NOCLIP) & CF_NOCLIP ?
-    s_STSTR_NCON : s_STSTR_NCOFF; // Ty 03/27/98 - externalized
+  dsda_AddMessage((plyr->cheats ^= CF_NOCLIP) & CF_NOCLIP ? s_STSTR_NCON : s_STSTR_NCOFF);
 }
 
 static void cheat_noclip()
@@ -468,13 +468,13 @@ static void cheat_pw(int pw)
       if (pw != pw_strength)
         plyr->powers[pw] = -1;      // infinite duration -- killough
     }
-  plyr->message = s_STSTR_BEHOLDX; // Ty 03/27/98 - externalized
+  dsda_AddMessage(s_STSTR_BEHOLDX);
 }
 
 // 'behold' power-up menu
 static void cheat_behold()
 {
-  plyr->message = s_STSTR_BEHOLD; // Ty 03/27/98 - externalized
+  dsda_AddMessage(s_STSTR_BEHOLD);
 }
 
 extern int EpiCustom;
@@ -497,7 +497,7 @@ static void cheat_clev(char buf[3])
 
   if (dsda_ResolveCLEV(&epsd, &map))
   {
-    plyr->message = s_STSTR_CLEV; // Ty 03/27/98 - externalized
+    dsda_AddMessage(s_STSTR_CLEV);
 
     G_DeferedInitNew(gameskill, epsd, map);
   }
@@ -537,9 +537,8 @@ static void cheat_comp(char buf[3])
 // variable friction cheat
 static void cheat_friction()
 {
-  plyr->message =                       // Ty 03/27/98 - *not* externalized
-    (variable_friction = !variable_friction) ? "Variable Friction enabled" :
-                                               "Variable Friction disabled";
+  dsda_AddMessage((variable_friction = !variable_friction) ? "Variable Friction enabled" :
+                                                             "Variable Friction disabled");
 }
 
 
@@ -547,8 +546,7 @@ static void cheat_friction()
 // phares 3/10/98
 static void cheat_pushers()
 {
-  plyr->message =                      // Ty 03/27/98 - *not* externalized
-    (allow_pushers = !allow_pushers) ? "Pushers enabled" : "Pushers disabled";
+  dsda_AddMessage((allow_pushers = !allow_pushers) ? "Pushers enabled" : "Pushers disabled");
 }
 
 static void cheat_massacre()    // jff 2/01/98 kill all monsters
@@ -715,41 +713,38 @@ static void cheat_reveal_item()
 // killough 2/7/98: HOM autodetection
 static void cheat_hom()
 {
-  plyr->message = dsda_ToggleConfig(dsda_config_flashing_hom, true) ? "HOM Detection On"
-                                                                    : "HOM Detection Off";
+  dsda_AddMessage(dsda_ToggleConfig(dsda_config_flashing_hom, true) ? "HOM Detection On"
+                                                                    : "HOM Detection Off");
 }
 
 // killough 3/6/98: -fast parameter toggle
 static void cheat_fast()
 {
-  plyr->message = (fastparm = !fastparm) ? "Fast Monsters On" :
-    "Fast Monsters Off";  // Ty 03/27/98 - *not* externalized
+  dsda_AddMessage((fastparm = !fastparm) ? "Fast Monsters On" : "Fast Monsters Off");
   G_SetFastParms(fastparm); // killough 4/10/98: set -fast parameter correctly
 }
 
 // killough 2/16/98: keycard/skullkey cheat functions
 static void cheat_tntkey()
 {
-  plyr->message = "Red, Yellow, Blue";  // Ty 03/27/98 - *not* externalized
+  dsda_AddMessage("Red, Yellow, Blue");
 }
 
 static void cheat_tntkeyx()
 {
-  plyr->message = "Card, Skull";        // Ty 03/27/98 - *not* externalized
+  dsda_AddMessage("Card, Skull");
 }
 
 static void cheat_tntkeyxx(int key)
 {
-  plyr->message = (plyr->cards[key] = !plyr->cards[key]) ?
-    "Key Added" : "Key Removed";  // Ty 03/27/98 - *not* externalized
+  dsda_AddMessage((plyr->cards[key] = !plyr->cards[key]) ? "Key Added" : "Key Removed");
 }
 
 // killough 2/16/98: generalized weapon cheats
 
 static void cheat_tntweap()
-{                                   // Ty 03/27/98 - *not* externalized
-  plyr->message = gamemode==commercial ?           // killough 2/28/98
-    "Weapon number 1-9" : "Weapon number 1-8";
+{
+  dsda_AddMessage(gamemode == commercial ? "Weapon number 1-9" : "Weapon number 1-8");
 }
 
 static void cheat_tntweapx(buf)
@@ -766,10 +761,10 @@ char buf[3];
   else
     if (w >= 0 && w < NUMWEAPONS) {
       if ((plyr->weaponowned[w] = !plyr->weaponowned[w]))
-        plyr->message = "Weapon Added";  // Ty 03/27/98 - *not* externalized
+        dsda_AddMessage("Weapon Added");
       else
         {
-          plyr->message = "Weapon Removed"; // Ty 03/27/98 - *not* externalized
+          dsda_AddMessage("Weapon Removed");
           if (w==plyr->readyweapon)         // maybe switch if weapon removed
             plyr->pendingweapon = P_SwitchWeapon(plyr);
         }
@@ -779,7 +774,7 @@ char buf[3];
 // killough 2/16/98: generalized ammo cheats
 static void cheat_tntammo()
 {
-  plyr->message = "Ammo 1-4, Backpack";  // Ty 03/27/98 - *not* externalized
+  dsda_AddMessage("Ammo 1-4, Backpack");
 }
 
 static void cheat_tntammox(buf)
@@ -788,48 +783,52 @@ char buf[1];
   int a = *buf - '1';
   if (*buf == 'b')  // Ty 03/27/98 - strings *not* externalized
     if ((plyr->backpack = !plyr->backpack))
-      for (plyr->message = "Backpack Added",   a=0 ; a<NUMAMMO ; a++)
+    {
+      dsda_AddMessage("Backpack Added");
+      for (a = 0; a < NUMAMMO; a++)
         plyr->maxammo[a] <<= 1;
+    }
     else
-      for (plyr->message = "Backpack Removed", a=0 ; a<NUMAMMO ; a++)
-        {
-          if (plyr->ammo[a] > (plyr->maxammo[a] >>= 1))
-            plyr->ammo[a] = plyr->maxammo[a];
-        }
+    {
+      dsda_AddMessage("Backpack Removed");
+      for (a = 0; a < NUMAMMO; a++)
+        if (plyr->ammo[a] > (plyr->maxammo[a] >>= 1))
+          plyr->ammo[a] = plyr->maxammo[a];
+    }
   else
     if (a>=0 && a<NUMAMMO)  // Ty 03/27/98 - *not* externalized
       { // killough 5/5/98: switch plasma and rockets for now -- KLUDGE
         a = a==am_cell ? am_misl : a==am_misl ? am_cell : a;  // HACK
-        plyr->message = (plyr->ammo[a] = !plyr->ammo[a]) ?
-          plyr->ammo[a] = plyr->maxammo[a], "Ammo Added" : "Ammo Removed";
+        dsda_AddMessage((plyr->ammo[a] = !plyr->ammo[a]) ?
+                        plyr->ammo[a] = plyr->maxammo[a], "Ammo Added" : "Ammo Removed");
       }
 }
 
 static void cheat_smart()
 {
-  plyr->message = (monsters_remember = !monsters_remember) ?
-    "Smart Monsters Enabled" : "Smart Monsters Disabled";
+  dsda_AddMessage((monsters_remember = !monsters_remember) ?
+                  "Smart Monsters Enabled" : "Smart Monsters Disabled");
 }
 
 static void cheat_pitch()
 {
-  plyr->message = dsda_ToggleConfig(dsda_config_pitched_sounds, true) ? "Pitch Effects Enabled"
-                                                                      : "Pitch Effects Disabled";
+  dsda_AddMessage(dsda_ToggleConfig(dsda_config_pitched_sounds, true) ? "Pitch Effects Enabled"
+                                                                      : "Pitch Effects Disabled");
 }
 
 static void cheat_notarget()
 {
   plyr->cheats ^= CF_NOTARGET;
   if (plyr->cheats & CF_NOTARGET)
-    plyr->message = "Notarget Mode ON";
+    dsda_AddMessage("Notarget Mode ON");
   else
-    plyr->message = "Notarget Mode OFF";
+    dsda_AddMessage("Notarget Mode OFF");
 }
 
 static void cheat_freeze()
 {
   dsda_ToggleFrozenMode();
-  plyr->message = dsda_FrozenMode() ? "FREEZE ON" : "FREEZE OFF";
+  dsda_AddMessage(dsda_FrozenMode() ? "FREEZE ON" : "FREEZE OFF");
 }
 
 static void cheat_fly()
@@ -842,13 +841,13 @@ static void cheat_fly()
       {
         P_PlayerEndFlight(plyr);
         plyr->powers[pw_flight] = 0;
-        plyr->message = "Fly mode OFF";
+        dsda_AddMessage("Fly mode OFF");
       }
       else
       {
         P_GivePower(plyr, pw_flight);
         plyr->powers[pw_flight] = INT_MAX;
-        plyr->message = "Fly mode ON";
+        dsda_AddMessage("Fly mode ON");
       }
     }
     else
@@ -858,13 +857,13 @@ static void cheat_fly()
       {
         plyr->mo->flags |= MF_NOGRAVITY;
         plyr->mo->flags |= MF_FLY;
-        plyr->message = "Fly mode ON";
+        dsda_AddMessage("Fly mode ON");
       }
       else
       {
         plyr->mo->flags &= ~MF_NOGRAVITY;
         plyr->mo->flags &= ~MF_FLY;
-        plyr->message = "Fly mode OFF";
+        dsda_AddMessage("Fly mode OFF");
       }
     }
   }
@@ -1080,7 +1079,7 @@ static void cheat_reset_health(void)
   {
     plyr->health = plyr->mo->health = MAXHEALTH;
   }
-  plyr->message = "FULL HEALTH";
+  dsda_AddMessage("FULL HEALTH");
 }
 
 static void cheat_artifact(char buf[3])
@@ -1107,24 +1106,24 @@ static void cheat_artifact(char buf[3])
         P_GiveArtifact(plyr, i, NULL);
       }
     }
-    plyr->message = "YOU GOT IT";
+    dsda_AddMessage("YOU GOT IT");
   }
   else if (type > arti_none && type < NUMARTIFACTS && count > 0 && count < 10)
   {
     if (gamemode == shareware && (type == arti_superhealth || type == arti_teleport))
     {
-      plyr->message = "BAD INPUT";
+      dsda_AddMessage("BAD INPUT");
       return;
     }
     for (i = 0; i < count; i++)
     {
       P_GiveArtifact(plyr, type, NULL);
     }
-    plyr->message = "YOU GOT IT";
+    dsda_AddMessage("YOU GOT IT");
   }
   else
-  { // Bad input
-    plyr->message = "BAD INPUT";
+  {
+    dsda_AddMessage("BAD INPUT");
   }
 }
 
@@ -1135,12 +1134,12 @@ static void cheat_tome(void)
   if (plyr->powers[pw_weaponlevel2])
   {
     plyr->powers[pw_weaponlevel2] = 0;
-    plyr->message = "POWER OFF";
+    dsda_AddMessage("POWER OFF");
   }
   else
   {
     P_UseArtifact(plyr, arti_tomeofpower);
-    plyr->message = "POWER ON";
+    dsda_AddMessage("POWER ON");
   }
 }
 
@@ -1155,12 +1154,12 @@ static void cheat_chicken(void)
     {
       if (P_UndoPlayerChicken(plyr))
       {
-          plyr->message = "CHICKEN OFF";
+          dsda_AddMessage("CHICKEN OFF");
       }
     }
     else if (P_ChickenMorphPlayer(plyr))
     {
-      plyr->message = "CHICKEN ON";
+      dsda_AddMessage("CHICKEN ON");
     }
   }
   else
@@ -1173,7 +1172,7 @@ static void cheat_chicken(void)
     {
       P_MorphPlayer(plyr);
     }
-    plyr->message = "SQUEAL!!";
+    dsda_AddMessage("SQUEAL!!");
   }
   P_MapEnd();
 }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -82,6 +82,7 @@
 #include "dsda/font.h"
 #include "dsda/game_controller.h"
 #include "dsda/global.h"
+#include "dsda/messenger.h"
 #include "dsda/settings.h"
 #include "dsda/key_frame.h"
 #include "dsda/input.h"
@@ -1430,11 +1431,9 @@ void M_EndGame(int choice)
 void M_ChangeMessages(void)
 {
   if (!dsda_ShowMessages())
-    players[consoleplayer].message = s_MSGOFF; // Ty 03/27/98 - externalized
+    dsda_AddUnblockableMessage(s_MSGOFF);
   else
-    players[consoleplayer].message = s_MSGON ; // Ty 03/27/98 - externalized
-
-  message_dontfuckwithme = true;
+    dsda_AddMessage(s_MSGON);
 }
 
 /////////////////////////////
@@ -5205,12 +5204,11 @@ dboolean M_Responder (event_t* ev) {
     {
 //e6y
       dsda_CycleConfig(dsda_config_usegamma, true);
-      players[consoleplayer].message =
-        usegamma == 0 ? s_GAMMALVL0 :
-        usegamma == 1 ? s_GAMMALVL1 :
-        usegamma == 2 ? s_GAMMALVL2 :
-        usegamma == 3 ? s_GAMMALVL3 :
-        s_GAMMALVL4;
+      dsda_AddMessage(usegamma == 0 ? s_GAMMALVL0 :
+                      usegamma == 1 ? s_GAMMALVL1 :
+                      usegamma == 2 ? s_GAMMALVL2 :
+                      usegamma == 3 ? s_GAMMALVL3 :
+                      s_GAMMALVL4);
       return true;
     }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4848,7 +4848,6 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
         S_StartVoidSound(g_sfx_swtchn);
       }
     ptr1->m_flags &= ~(S_HILITE|S_SELECT);// phares 4/19/98
-    HU_Start();    // catch any message changes // phares 4/19/98
     S_StartVoidSound(g_sfx_swtchx);
     return true;
   }

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -44,6 +44,7 @@
 
 #include "dsda/id_list.h"
 #include "dsda/map_format.h"
+#include "dsda/messenger.h"
 
 #include "hexen/p_acs.h"
 #include "hexen/sn_sonix.h"
@@ -465,7 +466,7 @@ int EV_DoLockedDoor
     case 133:
       if (!p->cards[it_bluecard] && !p->cards[it_blueskull])
       {
-        p->message = s_PD_BLUEO;             // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(s_PD_BLUEO, p);
         S_StartMobjSound(p->mo,sfx_oof);         // killough 3/20/98
         return 0;
       }
@@ -475,7 +476,7 @@ int EV_DoLockedDoor
     case 135:
       if (!p->cards[it_redcard] && !p->cards[it_redskull])
       {
-        p->message = s_PD_REDO;              // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(s_PD_REDO, p);
         S_StartMobjSound(p->mo,sfx_oof);         // killough 3/20/98
         return 0;
       }
@@ -485,7 +486,7 @@ int EV_DoLockedDoor
     case 137:
       if (!p->cards[it_yellowcard] && !p->cards[it_yellowskull])
       {
-        p->message = s_PD_YELLOWO;           // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(s_PD_YELLOWO, p);
         S_StartMobjSound(p->mo,sfx_oof);         // killough 3/20/98
         return 0;
       }
@@ -631,7 +632,7 @@ int EV_VerticalDoor
         return 0;
       if (!player->cards[it_bluecard] && !player->cards[it_blueskull])
       {
-          player->message = s_PD_BLUEK;         // Ty 03/27/98 - externalized
+          dsda_AddPlayerMessage(s_PD_BLUEK, player);
           S_StartMobjSound(player->mo,sfx_oof);     // killough 3/20/98
           return 0;
       }
@@ -643,7 +644,7 @@ int EV_VerticalDoor
           return 0;
       if (!player->cards[it_yellowcard] && !player->cards[it_yellowskull])
       {
-          player->message = s_PD_YELLOWK;       // Ty 03/27/98 - externalized
+          dsda_AddPlayerMessage(s_PD_YELLOWK, player);
           S_StartMobjSound(player->mo,sfx_oof);     // killough 3/20/98
           return 0;
       }
@@ -655,7 +656,7 @@ int EV_VerticalDoor
           return 0;
       if (!player->cards[it_redcard] && !player->cards[it_redskull])
       {
-          player->message = s_PD_REDK;          // Ty 03/27/98 - externalized
+          dsda_AddPlayerMessage(s_PD_REDK, player);
           S_StartMobjSound(player->mo,sfx_oof);     // killough 3/20/98
           return 0;
       }

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -54,6 +54,7 @@
 
 #include "dsda.h"
 #include "dsda/map_format.h"
+#include "dsda/messenger.h"
 
 #include "heretic/def.h"
 #include "heretic/sb_bar.h"
@@ -464,13 +465,13 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_ARM1:
       if (!P_GiveArmor (player, green_armor_class))
         return;
-      player->message = s_GOTARMOR; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTARMOR, player);
       break;
 
     case SPR_ARM2:
       if (!P_GiveArmor (player, blue_armor_class))
         return;
-      player->message = s_GOTMEGA; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTMEGA, player);
       break;
 
         // bonus items
@@ -479,7 +480,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       if (player->health > (maxhealthbonus))//e6y
         player->health = (maxhealthbonus);//e6y
       player->mo->health = player->health;
-      player->message = s_GOTHTHBONUS; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTHTHBONUS, player);
       break;
 
     case SPR_BON2:
@@ -500,7 +501,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         player->armortype =
          ((!demo_compatibility || prboom_comp[PC_APPLY_GREEN_ARMOR_CLASS_TO_ARMOR_BONUSES].state) ?
           green_armor_class : 1);
-      player->message = s_GOTARMBONUS; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTARMBONUS, player);
       break;
 
     case SPR_SOUL:
@@ -508,7 +509,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       if (player->health > max_soul)
         player->health = max_soul;
       player->mo->health = player->health;
-      player->message = s_GOTSUPER; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSUPER, player);
       sound = sfx_getpow;
       break;
 
@@ -523,7 +524,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
       P_GiveArmor (player,
          ((!demo_compatibility || prboom_comp[PC_APPLY_BLUE_ARMOR_CLASS_TO_MEGASPHERE].state) ?
           blue_armor_class : 2));
-      player->message = s_GOTMSPHERE; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTMSPHERE, player);
       sound = sfx_getpow;
       break;
 
@@ -531,7 +532,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         // leave cards for everyone
     case SPR_BKEY:
       if (!player->cards[it_bluecard])
-        player->message = s_GOTBLUECARD; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTBLUECARD, player);
       P_GiveCard (player, it_bluecard);
       if (!netgame)
         break;
@@ -539,7 +540,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_YKEY:
       if (!player->cards[it_yellowcard])
-        player->message = s_GOTYELWCARD; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTYELWCARD, player);
       P_GiveCard (player, it_yellowcard);
       if (!netgame)
         break;
@@ -547,7 +548,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_RKEY:
       if (!player->cards[it_redcard])
-        player->message = s_GOTREDCARD; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTREDCARD, player);
       P_GiveCard (player, it_redcard);
       if (!netgame)
         break;
@@ -555,7 +556,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_BSKU:
       if (!player->cards[it_blueskull])
-        player->message = s_GOTBLUESKUL; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTBLUESKUL, player);
       P_GiveCard (player, it_blueskull);
       if (!netgame)
         break;
@@ -563,7 +564,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_YSKU:
       if (!player->cards[it_yellowskull])
-        player->message = s_GOTYELWSKUL; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTYELWSKUL, player);
       P_GiveCard (player, it_yellowskull);
       if (!netgame)
         break;
@@ -571,7 +572,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
 
     case SPR_RSKU:
       if (!player->cards[it_redskull])
-        player->message = s_GOTREDSKULL; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTREDSKULL, player);
       P_GiveCard (player, it_redskull);
       if (!netgame)
         break;
@@ -581,7 +582,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_STIM:
       if (!P_GiveBody (player, 10))
         return;
-      player->message = s_GOTSTIM; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSTIM, player);
       break;
 
     case SPR_MEDI:
@@ -589,9 +590,9 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         return;
 
       if (player->health < 50) // cph - 25 + the 25 just added, thanks to Quasar for reporting this bug
-        player->message = s_GOTMEDINEED; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTMEDINEED, player);
       else
-        player->message = s_GOTMEDIKIT; // Ty 03/22/98 - externalized
+        dsda_AddPlayerMessage(s_GOTMEDIKIT, player);
       break;
 
 
@@ -599,14 +600,14 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_PINV:
       if (!P_GivePower (player, pw_invulnerability))
         return;
-      player->message = s_GOTINVUL; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTINVUL, player);
       sound = sfx_getpow;
       break;
 
     case SPR_PSTR:
       if (!P_GivePower (player, pw_strength))
         return;
-      player->message = s_GOTBERSERK; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTBERSERK, player);
       if (player->readyweapon != wp_fist)
         player->pendingweapon = wp_fist;
       sound = sfx_getpow;
@@ -615,28 +616,28 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
     case SPR_PINS:
       if (!P_GivePower (player, pw_invisibility))
         return;
-      player->message = s_GOTINVIS; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTINVIS, player);
       sound = sfx_getpow;
       break;
 
     case SPR_SUIT:
       if (!P_GivePower (player, pw_ironfeet))
         return;
-      player->message = s_GOTSUIT; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSUIT, player);
       sound = sfx_getpow;
       break;
 
     case SPR_PMAP:
       if (!P_GivePower (player, pw_allmap))
         return;
-      player->message = s_GOTMAP; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTMAP, player);
       sound = sfx_getpow;
       break;
 
     case SPR_PVIS:
       if (!P_GivePower (player, pw_infrared))
         return;
-      player->message = s_GOTVISOR; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTVISOR, player);
       sound = sfx_getpow;
       break;
 
@@ -652,49 +653,49 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
           if (!P_GiveAmmo (player,am_clip,1))
             return;
         }
-      player->message = s_GOTCLIP; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTCLIP, player);
       break;
 
     case SPR_AMMO:
       if (!P_GiveAmmo (player, am_clip,5))
         return;
-      player->message = s_GOTCLIPBOX; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTCLIPBOX, player);
       break;
 
     case SPR_ROCK:
       if (!P_GiveAmmo (player, am_misl,1))
         return;
-      player->message = s_GOTROCKET; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTROCKET, player);
       break;
 
     case SPR_BROK:
       if (!P_GiveAmmo (player, am_misl,5))
         return;
-      player->message = s_GOTROCKBOX; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTROCKBOX, player);
       break;
 
     case SPR_CELL:
       if (!P_GiveAmmo (player, am_cell,1))
         return;
-      player->message = s_GOTCELL; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTCELL, player);
       break;
 
     case SPR_CELP:
       if (!P_GiveAmmo (player, am_cell,5))
         return;
-      player->message = s_GOTCELLBOX; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTCELLBOX, player);
       break;
 
     case SPR_SHEL:
       if (!P_GiveAmmo (player, am_shell,1))
         return;
-      player->message = s_GOTSHELLS; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSHELLS, player);
       break;
 
     case SPR_SBOX:
       if (!P_GiveAmmo (player, am_shell,5))
         return;
-      player->message = s_GOTSHELLBOX; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSHELLBOX, player);
       break;
 
     case SPR_BPAK:
@@ -706,56 +707,56 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         }
       for (i=0 ; i<NUMAMMO ; i++)
         P_GiveAmmo (player, i, 1);
-      player->message = s_GOTBACKPACK; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTBACKPACK, player);
       break;
 
         // weapons
     case SPR_BFUG:
       if (!P_GiveWeapon (player, wp_bfg, false) )
         return;
-      player->message = s_GOTBFG9000; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTBFG9000, player);
       sound = sfx_wpnup;
       break;
 
     case SPR_MGUN:
       if (!P_GiveWeapon (player, wp_chaingun, (special->flags&MF_DROPPED)!=0) )
         return;
-      player->message = s_GOTCHAINGUN; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTCHAINGUN, player);
       sound = sfx_wpnup;
       break;
 
     case SPR_CSAW:
       if (!P_GiveWeapon (player, wp_chainsaw, false) )
         return;
-      player->message = s_GOTCHAINSAW; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTCHAINSAW, player);
       sound = sfx_wpnup;
       break;
 
     case SPR_LAUN:
       if (!P_GiveWeapon (player, wp_missile, false) )
         return;
-      player->message = s_GOTLAUNCHER; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTLAUNCHER, player);
       sound = sfx_wpnup;
       break;
 
     case SPR_PLAS:
       if (!P_GiveWeapon (player, wp_plasma, false) )
         return;
-      player->message = s_GOTPLASMA; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTPLASMA, player);
       sound = sfx_wpnup;
       break;
 
     case SPR_SHOT:
       if (!P_GiveWeapon (player, wp_shotgun, (special->flags&MF_DROPPED)!=0 ) )
         return;
-      player->message = s_GOTSHOTGUN; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSHOTGUN, player);
       sound = sfx_wpnup;
       break;
 
     case SPR_SGN2:
       if (!P_GiveWeapon(player, wp_supershotgun, (special->flags&MF_DROPPED)!=0))
         return;
-      player->message = s_GOTSHOTGUN2; // Ty 03/22/98 - externalized
+      dsda_AddPlayerMessage(s_GOTSHOTGUN2, player);
       sound = sfx_wpnup;
       break;
 
@@ -1810,7 +1811,7 @@ void A_RestoreSpecialThing2(mobj_t * thing)
 
 void P_SetMessage(player_t * player, const char *message, dboolean ultmsg)
 {
-    player->message = message;
+    dsda_AddPlayerMessage(message, player);
     player->yellowMessage = false;
 }
 
@@ -2769,7 +2770,7 @@ dboolean Hexen_P_GiveArmor(player_t * player, armortype_t armortype, int amount)
 
 void P_SetYellowMessage(player_t * player, const char *message, dboolean ultmsg)
 {
-    player->message = message;
+    dsda_AddPlayerMessage(message, player);
     player->yellowMessage = true;
 }
 

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2037,7 +2037,6 @@ void P_SpawnPlayer (int n, const mapthing_t* mthing)
   p->mo            = mobj;
   p->playerstate   = PST_LIVE;
   p->refire        = 0;
-  p->message       = NULL;
   p->damagecount   = 0;
   p->bonuscount    = 0;
   p->poisoncount   = 0;

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -139,7 +139,6 @@ void P_UnArchivePlayers (void)
 
         // will be set when unarc thinker
         players[i].mo = NULL;
-        players[i].message = NULL;
         players[i].attacker = NULL;
         // HERETIC_TODO: does the rain need to be remembered?
         players[i].rain1 = NULL;

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -1445,7 +1445,7 @@ void P_PlayerCollectSecret(player_t *player)
   {
     int sfx_id = raven ? g_sfx_secret :
                  I_GetSfxLumpNum(&S_sfx[g_sfx_secret]) < 0 ? sfx_itmbk : g_sfx_secret;
-    SetCustomMessage(player - players, "A secret is revealed!", 0, 2 * TICRATE, CR_GOLD, sfx_id);
+    SetCustomMessage(player - players, "A secret is revealed!", 2 * TICRATE, CR_GOLD, sfx_id);
   }
 }
 

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -70,6 +70,7 @@
 #include "dsda/id_list.h"
 #include "dsda/line_special.h"
 #include "dsda/map_format.h"
+#include "dsda/messenger.h"
 #include "dsda/thing_id.h"
 #include "dsda/utility.h"
 
@@ -942,7 +943,7 @@ dboolean P_CanUnlockGenDoor
         !player->cards[it_yellowskull]
       )
       {
-        player->message = s_PD_ANY; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(s_PD_ANY, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -954,7 +955,7 @@ dboolean P_CanUnlockGenDoor
         (!skulliscard || !player->cards[it_redskull])
       )
       {
-        player->message = skulliscard? s_PD_REDK : s_PD_REDC; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(skulliscard ? s_PD_REDK : s_PD_REDC, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -966,7 +967,7 @@ dboolean P_CanUnlockGenDoor
         (!skulliscard || !player->cards[it_blueskull])
       )
       {
-        player->message = skulliscard? s_PD_BLUEK : s_PD_BLUEC; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(skulliscard ? s_PD_BLUEK : s_PD_BLUEC, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -978,7 +979,7 @@ dboolean P_CanUnlockGenDoor
         (!skulliscard || !player->cards[it_yellowskull])
       )
       {
-        player->message = skulliscard? s_PD_YELLOWK : s_PD_YELLOWC; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(skulliscard ? s_PD_YELLOWK : s_PD_YELLOWC, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -990,7 +991,7 @@ dboolean P_CanUnlockGenDoor
         (!skulliscard || !player->cards[it_redcard])
       )
       {
-        player->message = skulliscard? s_PD_REDK : s_PD_REDS; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(skulliscard ? s_PD_REDK : s_PD_REDS, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -1002,7 +1003,7 @@ dboolean P_CanUnlockGenDoor
         (!skulliscard || !player->cards[it_bluecard])
       )
       {
-        player->message = skulliscard? s_PD_BLUEK : s_PD_BLUES; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(skulliscard ? s_PD_BLUEK : s_PD_BLUES, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -1014,7 +1015,7 @@ dboolean P_CanUnlockGenDoor
         (!skulliscard || !player->cards[it_yellowcard])
       )
       {
-        player->message = skulliscard? s_PD_YELLOWK : s_PD_YELLOWS; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(skulliscard ? s_PD_YELLOWK : s_PD_YELLOWS, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -1033,7 +1034,7 @@ dboolean P_CanUnlockGenDoor
         )
       )
       {
-        player->message = s_PD_ALL6; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(s_PD_ALL6, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -1057,7 +1058,7 @@ dboolean P_CanUnlockGenDoor
         )
       )
       {
-        player->message = s_PD_ALL3; // Ty 03/27/98 - externalized
+        dsda_AddPlayerMessage(s_PD_ALL3, player);
         S_StartMobjSound(player->mo,sfx_oof);             // killough 3/20/98
         return false;
       }
@@ -1203,7 +1204,7 @@ dboolean P_CheckKeys(mobj_t *mo, zdoom_lock_t lock, dboolean legacy)
 
   if (message)
   {
-    player->message = message;
+    dsda_AddPlayerMessage(message, player);
   }
 
   if (sfx != sfx_None)


### PR DESCRIPTION
- Differentiate between player-messages (picking up a key) and system messages (toggling controls)
- Support message priorities for alerts and special messages (i.e., the "messages off" message)
- Clean up various obsolete stuff related to messages

This does not extract the secret message, only the top left message bar. More things are to come, this is a preliminary step to get the framework in place.