### PR TITLE
GL: make gl_skymode 2 more consistent

### DIFF
--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -111,7 +111,6 @@ float skyUpAngle;
 float skyUpShift;
 float skyXShift;
 float skyYShift;
-dboolean mlook_or_fov;
 
 #ifdef _WIN32
 const char* WINError(void)

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -88,7 +88,6 @@ extern float skyUpAngle;
 extern float skyUpShift;
 extern float skyXShift;
 extern float skyYShift;
-extern dboolean mlook_or_fov;
 
 void ParamsMatchingCheck();
 void e6y_HandleSkip(void);

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -129,8 +129,9 @@ typedef struct
   float light;
   float fogdensity;
   float alpha;
-  float skyymid;
+  float skypitch;
   float skyyaw;
+  float skyoffset;
   float xscale;
   float yscale;
   dboolean anchor_vb;
@@ -448,7 +449,6 @@ typedef struct SkyBoxParams_s
   int index;
   unsigned int type;
   GLWall wall;
-  float x_scale, y_scale;
   float x_offset, y_offset;
   // 0 - no colormap; 1 - INVUL inverse colormap
   PalEntry_t FloorSkyColor[2];

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -997,40 +997,17 @@ void gld_StartDrawScene(void)
   //e6y: fog in frame
   gl_use_fog = gl_fog && !frame_fixedcolormap && !boom_cm;
 
-//e6y
-  mlook_or_fov = dsda_MouseLook() || (gl_render_fov != FOV90);
-  if (raven || !mlook_or_fov)
-  {
-    if (raven)
-    {
-      pitch = ANGLE_T_TO_PITCH_F(viewpitch);
-      paperitems_pitch = ((pitch > 87.0f && pitch <= 90.0f) ? 87.0f : pitch);
+  pitch = ANGLE_T_TO_PITCH_F(viewpitch);
+  viewPitch = (pitch > 180 ? pitch - 360 : pitch);
+  paperitems_pitch = ((pitch > 87.0f && pitch <= 90.0f) ? 87.0f : pitch);
 
-      viewPitch = (pitch > 180 ? pitch - 360 : pitch);
+  skyXShift = (double) viewangle / (double) ANGLE_MAX;
 
-      skyXShift = -2.0f * ((yaw + 90.0f) / 90.0f);
-      skyYShift = 0.875 * (200.0f / 320.0f) * viewPitch / (360.0f - RAVEN_PITCH_UP_LIMIT);
-    }
-    else
-    {
-      pitch = 0.0f;
-      paperitems_pitch = 0.0f;
-
-      skyXShift = -2.0f * ((yaw + 90.0f) / 90.0f);
-      skyYShift = 200.0f / 319.5f;
-    }
-  }
+  if (skystretch)
+    skyYShift = BETWEEN(-25 / skyscale, 180, viewPitch) / 360.0;
   else
-  {
-    float f = viewPitch * 2 + 50 / skyscale;
-    f = BETWEEN(0, 127, f);
-    skyXShift = -2.0f * ((yaw + 90.0f) / 90.0f / skyscale);
-    skyYShift = f / 128.0f + 200.0f / 320.0f / skyscale;
+    skyYShift = viewPitch / 360.0;
 
-    pitch = ANGLE_T_TO_PITCH_F(viewpitch);
-    paperitems_pitch = ((pitch > 87.0f && pitch <= 90.0f) ? 87.0f : pitch);
-    viewPitch = (pitch > 180 ? pitch - 360 : pitch);
-  }
   cos_paperitems_pitch = (float)cos(paperitems_pitch * M_PI / 180.f);
   sin_paperitems_pitch = (float)sin(paperitems_pitch * M_PI / 180.f);
 


### PR DESCRIPTION
- Respect render_stretchsky setting
- Consistently correct scale for FOV
- Tweak behavior to be closer to software
- Simplify code and remove magic constants where possible
- Move the fussy math into a single function
-----

## Software

![doom00](https://github.com/kraflab/dsda-doom/assets/2101303/ea029db5-3413-4c13-b61c-856c3a3fecd3)

## GL, FOV 90, mouselook off

![doom01](https://github.com/kraflab/dsda-doom/assets/2101303/38d89911-5011-4eaa-93c4-bb1c640cc281)

## GL, FOV 90, mouselook on

![doom02](https://github.com/kraflab/dsda-doom/assets/2101303/4a8c1c19-a39e-4265-a94d-3ca3769054e0)

## GL, FOV 110, mouselook off

![doom03](https://github.com/kraflab/dsda-doom/assets/2101303/c7b30b02-7dc0-4782-a482-686629e5896c)

## GL, FOV110, mouselook on

![doom04](https://github.com/kraflab/dsda-doom/assets/2101303/9b8f1ffa-3069-428d-ac39-c912709470df)

## gl_skymode 3, mouselook off

![doom00](https://github.com/kraflab/dsda-doom/assets/2101303/f93ee962-75c4-4a85-9815-898a090686ec)

## gl_skymode 3, mouselook on

![doom01](https://github.com/kraflab/dsda-doom/assets/2101303/dbca12b8-14e3-4978-8546-2ca6461c6f1c)


Closes #373 