### PR TITLE
detect patches in PNG format, substitute dummy patch

### DIFF
--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -112,6 +112,29 @@ const byte *R_GetTextureColumn(const rpatch_t *texpatch, int col) {
   return texpatch->columns[col].pixels;
 }
 
+// [FG] detect invalid patches, substitute dummy patch
+
+static void R_SubstInvalidPatches (int texnum)
+{
+  texture_t *texture = textures[texnum];
+  texpatch_t *patch = texture->patches;
+  int i = texture->patchcount;
+
+  while (--i >= 0)
+  {
+    int pat = patch[i].patch;
+
+    if (!CheckIfPatch(pat))
+    {
+      fprintf(stderr, "R_SubstInvalidPatches: Texture '%.8s'"
+              " patch num %d ('%.8s') is not valid\n",
+              texture->name, i, W_LumpName(pat));
+
+      patch[i].patch = W_CheckNumForName2("TNT1A0", ns_sprites);
+    }
+  }
+}
+
 //
 // R_InitTextures
 // Initializes the texture list
@@ -291,6 +314,9 @@ static void R_InitTextures (void)
 
   if (errors)
     I_Error("R_InitTextures: %d errors", errors);
+
+  for (i = 0; i < numtextures; i++)
+    R_SubstInvalidPatches(i);
 
   // Create translation table for global animation.
   // killough 4/9/98: make column offsets 32-bit;

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -630,6 +630,19 @@ static void createTextureCompositePatch(int id) {
     patchNum = texpatch->patch;
     oldPatch = (const patch_t*)W_LumpByNum(patchNum);
 
+    // [FG] detect patches in PNG format, substitute dummy patch
+    {
+      const unsigned char *magic = (const unsigned char *) oldPatch;
+
+      if (magic[0] == 0x89 &&
+          magic[1] == 'P' && magic[2] == 'N' && magic[3] == 'G')
+      {
+        fprintf(stderr, "createTextureCompositePatch: patch '%.8s' in PNG format detected\n", W_LumpName(patchNum));
+        texpatch->patch = W_CheckNumForName2("TNT1A0", ns_sprites);
+        oldPatch = (const patch_t*)W_LumpByNum(texpatch->patch);
+      }
+    }
+
     for (x=0; x<LittleShort(oldPatch->width); x++) {
       int tx = texpatch->originx + x;
 

--- a/prboom2/src/r_patch.h
+++ b/prboom2/src/r_patch.h
@@ -32,6 +32,8 @@
 #ifndef R_PATCH_H
 #define R_PATCH_H
 
+#include "doomtype.h"
+
 // Used to specify the sloping of the top and bottom of a column post
 typedef enum {
   RDRAW_EDGESLOPE_TOP_UP   = (1<<0),
@@ -102,6 +104,7 @@ const rcolumn_t *R_GetPatchColumnClamped(const rpatch_t *patch, int columnIndex)
 // and R_GetPatchColumnClamped otherwise
 const rcolumn_t *R_GetPatchColumn(const rpatch_t *patch, int columnIndex);
 
+dboolean CheckIfPatch(int lump);
 
 void R_InitPatches();
 void R_UpdatePlayPal();


### PR DESCRIPTION
Fixes crashes with WADs that use a PNG patch as sky, e.g. egregor.wad