### PR TITLE
Close wad file handles before cleaning temp files

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -207,6 +207,10 @@ static void I_EssentialQuit (void)
   dsda_WriteAnalysis();
   dsda_WriteSplits();
   dsda_SaveWadStats();
+  // We need to close out all wad handles/memory mappings before we can remove
+  // temporary wads on Windows
+  W_Shutdown();
+  W_DoneCache();
   dsda_CleanZipTempDirs();
 }
 

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -617,3 +617,17 @@ int W_LumpNameExists2(const char *name, int ns)
 {
   return W_CheckNumForName2(name, ns) != LUMP_NOT_FOUND;
 }
+
+void W_Shutdown(void)
+{
+  int i;
+
+  for (i = 0; i < numwadfiles; ++i)
+  {
+    if (wadfiles[i].handle > 0)
+    {
+      close(wadfiles[i].handle);
+      wadfiles[i].handle = -1;
+    }
+  }
+}

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -95,6 +95,7 @@ extern size_t numwadfiles; // CPhipps - size of the wadfiles array
 void W_Init(void); // CPhipps - uses the above array
 void W_InitCache(void);
 void W_DoneCache(void);
+void W_Shutdown(void);
 
 typedef enum
 {


### PR DESCRIPTION
You can't ordinarily delete a file on Windows when you still have it open.

------------

This prevents share access conflicts on Windows