### PR TITLE
Fix bad FD usage on Linux

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -210,7 +210,6 @@ static void I_EssentialQuit (void)
   // We need to close out all wad handles/memory mappings before we can remove
   // temporary wads on Windows
   W_Shutdown();
-  W_DoneCache();
   dsda_CleanZipTempDirs();
 }
 

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -212,7 +212,7 @@ void W_DoneCache(void)
     for (i=0; i<numlumps; i++)
       if (lumpinfo[i].wadfile) {
         int fd = lumpinfo[i].wadfile->handle;
-        if (mapped_wad[fd]) {
+        if (fd > 0 && mapped_wad[fd]) {
           if (munmap(mapped_wad[fd],I_Filelength(fd)))
             I_Error("W_DoneCache: failed to munmap");
           mapped_wad[fd] = NULL;

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -622,6 +622,8 @@ void W_Shutdown(void)
 {
   int i;
 
+  W_DoneCache();
+
   for (i = 0; i < numwadfiles; ++i)
   {
     if (wadfiles[i].handle > 0)


### PR DESCRIPTION
Made an oopsie on my previous PR

-----

- Always do W_DoneCache before closing wad FDs
- Make W_DoneCache ignore wads with closed handles