### PR TITLE
GL: don't stencil bleed from closed sectors

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1430,7 +1430,8 @@ void gld_AddWall(seg_t *seg)
         if (!temptex && gl_use_stencil && backsector &&
           !(seg->linedef->r_flags & RF_ISOLATED) &&
           /*frontsector->ceilingpic != skyflatnum && */backsector->ceilingpic != skyflatnum &&
-          !(backsector->flags & NULL_SECTOR))
+          !(backsector->flags & NULL_SECTOR) &&
+          backsector->floorheight < backsector->ceilingheight)
         {
           wall.ytop=((float)(ceiling_height)/(float)MAP_SCALE)+SMALLDELTA;
           wall.ybottom=((float)(floor_height)/(float)MAP_SCALE)-SMALLDELTA;
@@ -1635,7 +1636,8 @@ bottomtexture:
       if (!temptex && gl_use_stencil && backsector &&
         !(seg->linedef->r_flags & RF_ISOLATED) &&
         /*frontsector->floorpic != skyflatnum && */backsector->floorpic != skyflatnum &&
-        !(backsector->flags & NULL_SECTOR))
+        !(backsector->flags & NULL_SECTOR) &&
+        backsector->floorheight < backsector->ceilingheight)
       {
         wall.ytop=((float)(ceiling_height)/(float)MAP_SCALE)+SMALLDELTA;
         wall.ybottom=((float)(floor_height)/(float)MAP_SCALE)-SMALLDELTA;


### PR DESCRIPTION
Fixes rendering glitch on cchest2 MAP05

------------

The flats of closed sectors aren't visible, so they shouldn't flood into adjacent missing wall textures.

## Before
![doom00](https://github.com/kraflab/dsda-doom/assets/2101303/1a1293b6-73c3-45d2-bf97-cc2312656fc5)

## After
![doom02](https://github.com/kraflab/dsda-doom/assets/2101303/7f54463b-5d80-43d6-afcb-eef0146e8d42)

