### PR TITLE
GL: draw weapon sprite at full resolution

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1048,10 +1048,6 @@ void gld_EndDrawScene(void)
   glViewport(0, 0, SCREENWIDTH, SCREENHEIGHT);
   gld_Set2DMode();
 
-  glsl_PushMainShader();
-  R_DrawPlayerSprites();
-  glsl_PopMainShader();
-
   // e6y
   // Effect of invulnerability uses a colormap instead of hard-coding now
   // See nuts.wad
@@ -1089,6 +1085,10 @@ void gld_EndDrawScene(void)
 
     glTexEnvi(GL_TEXTURE_ENV,GL_TEXTURE_ENV_MODE,GL_MODULATE);
   }
+
+  glsl_PushMainShader();
+  R_DrawPlayerSprites();
+  glsl_PopMainShader();
 
   glColor3f(1.0f,1.0f,1.0f);
   glDisable(GL_SCISSOR_TEST);


### PR DESCRIPTION
Avoids bad aliasing in some resolutions

-----

## Before

![doom01](https://github.com/kraflab/dsda-doom/assets/2101303/5b481aae-1b3b-40a4-9bb5-6a4669c128e6)

## After

![doom00](https://github.com/kraflab/dsda-doom/assets/2101303/17a3c0a9-cb24-4028-9c96-5bd0beea96a2)