### PR TITLE
GL: Add dithered fade mode

### DIFF
--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TABLES
     lumps/glshadow.lmp
     lumps/gls_main.lmp
     lumps/gls_fuzz.lmp
+    lumps/gls_sb.lmp
     lumps/glh_idx.lmp
     lumps/glh_dith.lmp
     lumps/m_ammo.lmp

--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -53,6 +53,7 @@ set(TABLES
     lumps/gls_main.lmp
     lumps/gls_fuzz.lmp
     lumps/glh_idx.lmp
+    lumps/glh_dith.lmp
     lumps/m_ammo.lmp
     lumps/m_armour.lmp
     lumps/m_arrow.lmp

--- a/prboom2/data/lumps/glh_dith.lmp
+++ b/prboom2/data/lumps/glh_dith.lmp
@@ -1,0 +1,35 @@
+float bayer2(vec2 p)
+{
+  // Equivalent to indexing by (x mod 2, y mod 2) into the Bayer matrix:
+  // [ 0.0   0.5
+  //   0.75  0.25 ]
+  // This avoids dynamic array indexing, which can be expensive on old GPUs
+  return fract(0.5 * p.x + 0.75 * p.y * p.y);
+}
+
+// Larger Bayer sizes can be defined by recurrence
+
+float bayer4(vec2 p)
+{
+  return bayer2(floor(0.5 * p)) * 0.25 + bayer2(p);
+}
+
+float bayer8(vec2 p)
+{
+  return bayer4(floor(0.5 * p)) * 0.25 + bayer2(p);
+}
+
+float bayer16(vec2 p)
+{
+  return bayer8(floor(0.5 * p)) * 0.25 + bayer2(p);
+}
+
+float dither8(vec2 p)
+{
+  return bayer8(floor(p)) - 0.5;
+}
+
+float dither16(vec2 p)
+{
+  return bayer16(floor(p)) - 0.5;
+}

--- a/prboom2/data/lumps/gls_main.lmp
+++ b/prboom2/data/lumps/gls_main.lmp
@@ -12,9 +12,11 @@ void main()
 
 #ifdef FRAGMENT
 #include "glh_idx.lmp"
+#include "glh_dith.lmp"
 
 uniform sampler2D tex;
 uniform int fade_mode;
+uniform float dscale;
 
 void main()
 {
@@ -24,10 +26,25 @@ void main()
   float li = indexLight(gl_FragCoord.z);
   vec3 color;
 
-  if (fade_mode == 1)
+  if (fade_mode == 2)
+  {
+    // Dithered fade mode.
+    // Compute which dither macro-pixel we're in
+    vec2 dp = gl_FragCoord.xy / dscale;
+    // Compute adjustments to light index based on gradient across
+    // macro-pixel, so light level within a macro-pixel is consistent.
+    // (This essentially "pixelates" light levels to match dither scale)
+    float didx = dFdx(li) * fract(dp.x) * dscale;
+    float didy = dFdy(li) * fract(dp.y) * dscale;
+    color = indexRGB(ci, li - didx - didy + dither8(dp));
+  }
+  else if (fade_mode == 1)
   {
     // Smooth fade mode.
-    color = mix(indexRGB(ci, floor(li)), indexRGB(ci, floor(li + 1.0)), fract(li));
+    // Apply fine dither to alleviate quantization artifacts when floating point
+    // color value is converted to a normalized integer
+    float d = dither16(gl_FragCoord.xy);
+    color = mix(indexRGB(ci, floor(li)), indexRGB(ci, floor(li + 1.0)), fract(li)) + d / 127.5;
   }
   else
   {

--- a/prboom2/data/lumps/gls_sb.lmp
+++ b/prboom2/data/lumps/gls_sb.lmp
@@ -1,0 +1,43 @@
+#version 110
+
+#ifdef VERTEX
+void main()
+{
+  gl_FrontColor = gl_Color;
+  gl_TexCoord[0] = gl_TextureMatrix[0] * gl_MultiTexCoord0;
+  gl_Position = ftransform();
+}
+#endif
+
+#ifdef FRAGMENT
+// Texture
+uniform sampler2D tex;
+// Texture dimensions
+uniform vec2 tex_d;
+// Scale factor
+uniform vec2 scale;
+
+void main()
+{
+  // FIXME: it's possible leverage fixed function bilinear filtering
+  // to do this more efficiently, but this requires refactoring
+  // the renderer to handle switching magnification functions for
+  // different shaders and textures units.
+
+  // Compute texture coordinates for gather
+  // See https://www.reedbeta.com/blog/texture-gathers-and-coordinate-precision/
+  vec2 c1 = gl_TexCoord[0].xy * tex_d - 0.5 + 1.0/512.0;
+  vec2 c2 = vec2(c1.x + 1.0, c1.y);
+  vec2 c3 = vec2(c1.x, c1.y + 1.0);
+  vec2 c4 = vec2(c1.x + 1.0, c1.y + 1.0);
+  // Gather texels
+  vec4 t1 = texture2D(tex, c1 / tex_d);
+  vec4 t2 = texture2D(tex, c2 / tex_d);
+  vec4 t3 = texture2D(tex, c3 / tex_d);
+  vec4 t4 = texture2D(tex, c4 / tex_d);
+  // Compute mix factors
+  vec2 m = clamp(scale * (fract(c1) - 0.5) + 0.5, 0.0, 1.0);
+  // Mix texels
+  gl_FragColor = mix(mix(t1, t2, m.x), mix(t3, t4, m.x), m.y);
+}
+#endif

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1147,7 +1147,11 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_gl_fade_mode] = {
     "gl_fade_mode", dsda_config_gl_fade_mode,
-    dsda_config_int, 0, 1, { 0 }
+    dsda_config_int, 0, 2, { 0 }
+  },
+  [dsda_config_gl_dither_scale] = {
+    "gl_dither_scale", dsda_config_gl_dither_scale,
+    dsda_config_int, 1, 30, { 1 }
   },
   [dsda_config_boom_translucent_sprites] = {
     "boom_translucent_sprites", dsda_config_boom_translucent_sprites,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -121,6 +121,7 @@ typedef enum {
   dsda_config_gl_health_bar,
   dsda_config_gl_usevbo,
   dsda_config_gl_fade_mode,
+  dsda_config_gl_dither_scale,
   dsda_config_use_mouse,
   dsda_config_mouse_sensitivity_horiz,
   dsda_config_mouse_sensitivity_vert,

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -501,6 +501,8 @@ void glsl_PushMainShader(void);
 void glsl_PopMainShader(void);
 void glsl_PushFuzzShader(int tic, int sprite, float ratio);
 void glsl_PopFuzzShader(void);
+void glsl_PushSharpBilinearShader(void);
+void glsl_PopSharpBilinearShader(void);
 void glsl_SetLightLevel(float lightlevel);
 
 #endif // _GL_INTERN_H

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1064,6 +1064,7 @@ void gld_EndDrawScene(void)
     GLEXT_glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
 
     glBindTexture(GL_TEXTURE_2D, glSceneImageTextureFBOTexID);
+    glsl_SetTextureDims(0, SCREENWIDTH, SCREENHEIGHT);
 
     // Setup blender
     glColor3f(1.0f, 1.0f, 1.0f);
@@ -1073,6 +1074,7 @@ void gld_EndDrawScene(void)
     dsda_GLSetRenderViewport();
     // elim - Prevent undrawn parts of game scene texture being rendered into the viewport
     dsda_GLSetRenderSceneScissor();
+    glsl_PushSharpBilinearShader();
     glBegin(GL_TRIANGLE_STRIP);
     {
       glTexCoord2f(0.0f, 1.0f); glVertex2f(0.0f, 0.0f);
@@ -1084,6 +1086,8 @@ void gld_EndDrawScene(void)
 
     // elim - Set the scissor back to the full viewport so post-scene draws can happen (ie StatusBar)
     dsda_GLSetRenderViewportScissor();
+
+    glsl_PopSharpBilinearShader();
 
     gld_Set2DMode();
 

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -573,7 +573,8 @@ enum
   MAIN_UNIF_TEX,
   MAIN_UNIF_COLORMAP,
   MAIN_UNIF_LIGHTLEVEL,
-  MAIN_UNIF_FADE_MODE
+  MAIN_UNIF_FADE_MODE,
+  MAIN_UNIF_DSCALE
 };
 
 enum
@@ -598,6 +599,7 @@ static const shader_info_t main_info =
     UNIF(MAIN_UNIF_COLORMAP, "colormap", UNIF_TEX2),
     UNIF(MAIN_UNIF_LIGHTLEVEL, "lightlevel", UNIF_1F),
     UNIF(MAIN_UNIF_FADE_MODE, "fade_mode", UNIF_1I),
+    UNIF(MAIN_UNIF_DSCALE, "dscale", UNIF_1F),
     UNIF_END
   }
 };
@@ -636,9 +638,11 @@ void glsl_PopNullShader(void)
 void glsl_PushMainShader(void)
 {
   int mode = dsda_IntConfig(dsda_config_gl_fade_mode);
+  float dscale = MAX(1, dsda_IntConfig(dsda_config_gl_dither_scale));
 
   glsl_ShaderPush(sh_main,
                   MAIN_UNIF_FADE_MODE, mode,
+                  MAIN_UNIF_DSCALE, dscale,
                   UNIF_VAL_END);
 }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2958,7 +2958,7 @@ static const char* fake_contrast_list[] =
   NULL
 };
 
-static const char *gl_fade_mode_list[] = { "Normal", "Smooth", NULL };
+static const char *gl_fade_mode_list[] = { "Normal", "Smooth", "Dithered", NULL };
 
 setup_menu_t audiovideo_settings[] = {
   { "Video", S_SKIP | S_TITLE, m_null, G_X},
@@ -2972,6 +2972,7 @@ setup_menu_t audiovideo_settings[] = {
   { "FPS Limit", S_NUM, m_conf, G_X, dsda_config_fps_limit },
   { "Fake Contrast", S_CHOICE, m_conf, G_X, dsda_config_fake_contrast_mode, 0, fake_contrast_list },
   { "GL Light Fade", S_CHOICE, m_conf, G_X, dsda_config_gl_fade_mode, 0, gl_fade_mode_list },
+  { "Dither Scale", S_NUM, m_conf, G_X, dsda_config_gl_dither_scale },
   EMPTY_LINE,
   { "Sound & Music", S_SKIP | S_TITLE, m_null, G_X},
   { "Number of Sound Channels", S_NUM, m_conf, G_X, dsda_config_snd_channels },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -171,6 +171,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_gl_health_bar),
   MIGRATED_SETTING(dsda_config_gl_usevbo),
   MIGRATED_SETTING(dsda_config_gl_fade_mode),
+  MIGRATED_SETTING(dsda_config_gl_dither_scale),
 
   SETTING_HEADING("Mouse settings"),
   MIGRATED_SETTING(dsda_config_use_mouse),


### PR DESCRIPTION
This can wait until 0.27 since 0.26 is in RC.

# Modes

- Smooth mode performs linear interpolation between colormap entries based on light level, removing light banding
- Dithered mode applies Bayer 8x8 dithering to selecting colormap entries, which gives a more retro look

## Normal

![doom00](https://github.com/kraflab/dsda-doom/assets/2101303/18a92716-0db9-43b9-a669-ffe2e7bc6610)

## Smooth

![doom01](https://github.com/kraflab/dsda-doom/assets/2101303/4836410d-c0b7-42f3-8c4f-ff1bc923f974)


## Dithered

![doom02](https://github.com/kraflab/dsda-doom/assets/2101303/e7e3c4c6-7725-4c7f-bed7-1bc750341f25)

# Filtering

The second commit adds a "sharp bilinear" shader for render scaling.  This reduces aliasing from non-integer scales (particularly noticeable on dither patterns) while retaining sharp pixels.  It's equivalent to nearest-neighbor scaling by the greatest integer less than the scale factor, followed by bilinear interpolation for the remaining fractional scale.

## Nearest neighbor

This dither pattern is uneven due to nearest-neighbor aliasing.

![doom02](https://github.com/kraflab/dsda-doom/assets/2101303/9a80bb69-3b49-46aa-88c0-4dba3196ae89)

## Sharp bilinear

This makes the pattern even while retaining as much sharpness as possible by only blending at the transition between source texels.

![doom04](https://github.com/kraflab/dsda-doom/assets/2101303/5abf178f-e3f9-4fd1-8784-606080d4da0e)

## Bilinear

For reference, this is what normal bilinear filtering does to the pattern.

![foo](https://github.com/kraflab/dsda-doom/assets/2101303/c1e1bde4-5717-40c1-b243-03ba19bfcff9)
