### PR TITLE
GL: tweak weapon pos rounding

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -793,12 +793,9 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // Shotgun from DSV3_War looks correctly now. Especially during movement.
   // There is no more line of graphics under certain weapons.
   x1 = vis->x1;
-  x2 = x1 + gltexture->realtexwidth * pspritexscale_f;
-  y1 = centery - vis->texturemid * pspriteyscale_f / FRACUNIT;
-  y2 = y1 + gltexture->realtexheight * pspriteyscale_f;
-  x2 = roundf(x2);
-  y1 = roundf(y1);
-  y2 = roundf(y2);
+  x2 = roundf(x1 + gltexture->realtexwidth * pspritexscale_f);
+  y1 = roundf(viewheight / 2.0 - vis->texturemid * pspriteyscale_f / FRACUNIT);
+  y2 = roundf(y1 + gltexture->realtexheight * pspriteyscale_f);
   // e6y: don't do the gamma table correction on the lighting
   light = (float)lightlevel / 255.0f;
 


### PR DESCRIPTION
Tweaks to my previous patch based on testing more sprites/resolutions

----

- Round before adding sprite width/height, so dimensions are stable during weapon sway (prevents subtle shimmering effect)
- Use floating point expression for center of screen so it rounds appropriately on odd resolutions