### PR TITLE
Add fake_contrast 2 setting

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -25,6 +25,7 @@
 #include "gl_struct.h"
 #include "lprintf.h"
 #include "r_main.h"
+#include "r_segs.h"
 #include "s_sound.h"
 #include "smooth.h"
 #include "v_video.h"
@@ -86,7 +87,6 @@ extern int sts_always_red;
 extern int sts_pct_always_gray;
 extern int sts_traditional_keys;
 extern int full_sounds;
-extern int fake_contrast;
 
 void I_Init2(void);
 void M_ChangeDemoSmoothTurns(void);
@@ -1099,9 +1099,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "render_doom_lightmaps", dsda_config_render_doom_lightmaps,
     CONF_BOOL(0)
   },
-  [dsda_config_fake_contrast] = {
-    "fake_contrast", dsda_config_fake_contrast,
-    CONF_BOOL(1), &fake_contrast
+  [dsda_config_fake_contrast_mode] = {
+    "fake_contrast_mode", dsda_config_fake_contrast_mode,
+    dsda_config_int, FAKE_CONTRAST_MODE_OFF, FAKE_CONTRAST_MODE_SMOOTH,
+    { FAKE_CONTRAST_MODE_ON }, (int*) &fake_contrast_mode
   },
   [dsda_config_render_stretch_hud] = {
     "render_stretch_hud", dsda_config_render_stretch_hud,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -246,7 +246,7 @@ typedef enum {
   dsda_config_integer_scaling,
   dsda_config_render_aspect,
   dsda_config_render_doom_lightmaps,
-  dsda_config_fake_contrast,
+  dsda_config_fake_contrast_mode,
   dsda_config_render_stretch_hud,
   dsda_config_render_patches_scalex,
   dsda_config_render_patches_scaley,

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -74,6 +74,7 @@
 #include "smooth.h"
 #include "r_fps.h"
 #include "r_main.h"
+#include "r_segs.h"
 #include "f_finale.h"
 #include "e6y.h"//e6y
 
@@ -2949,6 +2950,14 @@ static const char* render_stretch_list[] = {
   "Not Adjusted", "Doom Format", "Fit to Width", NULL
 };
 
+static const char* fake_contrast_list[] =
+{
+  [FAKE_CONTRAST_MODE_OFF] = "Off",
+  [FAKE_CONTRAST_MODE_ON] = "Normal",
+  [FAKE_CONTRAST_MODE_SMOOTH] = "Smooth",
+  NULL
+};
+
 setup_menu_t audiovideo_settings[] = {
   { "Video", S_SKIP | S_TITLE, m_null, G_X},
   { "Video mode", S_CHOICE | S_STR, m_conf, G_X, dsda_config_videomode, 0, videomodes },
@@ -2959,6 +2968,7 @@ setup_menu_t audiovideo_settings[] = {
   { "Vertical Sync", S_YESNO, m_conf, G_X, dsda_config_render_vsync },
   { "Uncapped Framerate", S_YESNO, m_conf, G_X, dsda_config_uncapped_framerate },
   { "FPS Limit", S_NUM, m_conf, G_X, dsda_config_fps_limit },
+  { "Fake Contrast", S_CHOICE, m_conf, G_X, dsda_config_fake_contrast_mode, 0, fake_contrast_list },
   EMPTY_LINE,
   { "Sound & Music", S_SKIP | S_TITLE, m_null, G_X},
   { "Number of Sound Channels", S_NUM, m_conf, G_X, dsda_config_snd_channels },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -151,7 +151,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_integer_scaling),
   MIGRATED_SETTING(dsda_config_render_aspect),
   MIGRATED_SETTING(dsda_config_render_doom_lightmaps),
-  MIGRATED_SETTING(dsda_config_fake_contrast),
+  MIGRATED_SETTING(dsda_config_fake_contrast_mode),
   MIGRATED_SETTING(dsda_config_render_stretch_hud),
   MIGRATED_SETTING(dsda_config_render_patches_scalex),
   MIGRATED_SETTING(dsda_config_render_patches_scaley),

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -108,7 +108,7 @@ static int	HEIGHTUNIT = (1 << 12);
 static int	invhgtbits = 4;
 
 /* cph - allow crappy fake contrast to be disabled */
-int fake_contrast;
+fake_contrast_mode_t fake_contrast_mode;
 
 //
 // R_FixWiggle()
@@ -232,7 +232,7 @@ const int fake_contrast_value = 16;
 
 static dboolean R_FakeContrast(seg_t *seg)
 {
-  return fake_contrast && seg && !(seg->sidedef->flags & SF_NOFAKECONTRAST) && !hexen;
+  return fake_contrast_mode != FAKE_CONTRAST_MODE_OFF && seg && !(seg->sidedef->flags & SF_NOFAKECONTRAST) && !hexen;
 }
 
 void R_AddContrast(seg_t *seg, int *base_lightlevel)
@@ -249,7 +249,7 @@ void R_AddContrast(seg_t *seg, int *base_lightlevel)
     {
       *base_lightlevel += fake_contrast_value;
     }
-    else if (seg->sidedef->flags & SF_SMOOTHLIGHTING)
+    else if (fake_contrast_mode == FAKE_CONTRAST_MODE_SMOOTH || seg->sidedef->flags & SF_SMOOTHLIGHTING)
     {
       double dx, dy;
 

--- a/prboom2/src/r_segs.h
+++ b/prboom2/src/r_segs.h
@@ -42,4 +42,13 @@ int R_MidLightLevel(side_t *side, int base_lightlevel);
 int R_BottomLightLevel(side_t *side, int base_lightlevel);
 void R_AddContrast(seg_t *seg, int *base_lightlevel);
 
+typedef enum
+{
+  FAKE_CONTRAST_MODE_OFF,
+  FAKE_CONTRAST_MODE_ON,
+  FAKE_CONTRAST_MODE_SMOOTH
+} fake_contrast_mode_t;
+
+extern fake_contrast_mode_t fake_contrast_mode;
+
 #endif


### PR DESCRIPTION
This forces smooth fake contrast except for walls that explicitly have it turned off.

----

Fake contrast can look a bit odd in some places because it only applies to exactly axis-aligned walls and not walls that are slightly off-axis.  This adds an extra configuration value to use the smooth fake contrast calculation even for older maps that don't explicitly enable it on some walls.