### PR TITLE
build: accept mad.dll for libmad

### DIFF
--- a/prboom2/cmake/FindLibMad.cmake
+++ b/prboom2/cmake/FindLibMad.cmake
@@ -45,7 +45,7 @@ find_path(
 
 find_file(
   LibMad_DLL
-  NAMES libmad.dll libmad-0.dll
+  NAMES libmad.dll libmad-0.dll mad.dll
 )
 
 find_library(


### PR DESCRIPTION
Something changed in vcpkg and libmad is now `mad.dll` instead of `libmad.dll`

This won't fix github CI, only local builds.