### PR TITLE
Shaders: handle texture dimension uniforms generically

### DIFF
--- a/prboom2/data/lumps/gls_fuzz.lmp
+++ b/prboom2/data/lumps/gls_fuzz.lmp
@@ -16,13 +16,13 @@ uniform sampler2D tex;
 uniform sampler2D fuzz;
 // Texture dimensions
 uniform vec2 tex_d;
+// Fuzz texture dimensions
+uniform vec2 fuzz_d;
 // Fuzz macro-pixel ratio in terms of window coordinates
 // If 0, use texture coordinates instead
 uniform float ratio;
 // Random seed
 uniform float seed;
-
-const float fuzzsize = 50.0;
 
 float random(vec2 n)
 {
@@ -34,7 +34,7 @@ float darkness(vec2 c)
   // Compute random offset based on seed and x coordinate
   float r = random(vec2(seed, c.x));
   // Sample fuzz lookup texture at y coordinate plus random offset modulo size
-  return texture2D(fuzz, vec2(fract(c.y / fuzzsize + r), 0)).r;
+  return texture2D(fuzz, vec2(fract(c.y / fuzz_d.x + r), 0)).r;
 }
 
 void main()

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -494,6 +494,7 @@ extern int rendermarker;
 extern GLuint flats_vbo_id;
 
 void glsl_Init(void);
+void glsl_SetTextureDims(int unit, unsigned int width, unsigned int height);
 void glsl_PushNullShader(void);
 void glsl_PopNullShader(void);
 void glsl_PushMainShader(void);

--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -499,7 +499,7 @@ void glsl_PushNullShader(void);
 void glsl_PopNullShader(void);
 void glsl_PushMainShader(void);
 void glsl_PopMainShader(void);
-void glsl_PushFuzzShader(int tic, int sprite, int width, int height, float ratio);
+void glsl_PushFuzzShader(int tic, int sprite, float ratio);
 void glsl_PopFuzzShader(void);
 void glsl_SetLightLevel(float lightlevel);
 

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -747,12 +747,12 @@ void gld_DrawLine(int x0, int y0, int x1, int y1, int BaseColor)
 }
 
 
-void gld_StartFuzz(int sprite, int width, int height, float ratio)
+void gld_StartFuzz(int sprite, float ratio)
 {
   color_rgb_t color;
 
   // shader init
-  glsl_PushFuzzShader(gametic, sprite, width, height, ratio);
+  glsl_PushFuzzShader(gametic, sprite, ratio);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   // for indexed lightmode, the fuzz color needs to take
@@ -800,7 +800,7 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // when invisibility is about to go
   if (/*(viewplayer->mo->flags & MF_SHADOW) && */!vis->colormap)
   {
-    gld_StartFuzz(-1, gltexture->realtexwidth, gltexture->realtexheight, 0);
+    gld_StartFuzz(-1, 0);
   }
   else
   {
@@ -1958,7 +1958,7 @@ static void gld_DrawSprite(GLSprite *sprite)
       glGetIntegerv(GL_BLEND_SRC, &blend_src);
       glGetIntegerv(GL_BLEND_DST, &blend_dst);
       restore = 1;
-      gld_StartFuzz(sprite->id, sprite->gltexture->width, sprite->gltexture->height, ratio);
+      gld_StartFuzz(sprite->id, ratio);
     }
     else
     {

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -579,6 +579,7 @@ enum
   FUZZ_UNIF_TEX,
   FUZZ_UNIF_FUZZ,
   FUZZ_UNIF_TEX_D,
+  FUZZ_UNIF_FUZZ_D,
   FUZZ_UNIF_RATIO,
   FUZZ_UNIF_SEED
 };
@@ -604,8 +605,9 @@ static const shader_info_t fuzz_info =
   .unifs =
   {
     UNIF(FUZZ_UNIF_TEX, "tex", UNIF_TEX0),
+    UNIF(FUZZ_UNIF_TEX_D, "tex_d", UNIF_TEX0D),
     UNIF(FUZZ_UNIF_FUZZ, "fuzz", UNIF_TEX1),
-    UNIF(FUZZ_UNIF_TEX_D, "tex_d", UNIF_2F),
+    UNIF(FUZZ_UNIF_FUZZ_D, "fuzz_d", UNIF_TEX1D),
     UNIF(FUZZ_UNIF_RATIO, "ratio", UNIF_1F),
     UNIF(FUZZ_UNIF_SEED, "seed", UNIF_1F),
     UNIF_END
@@ -643,7 +645,7 @@ void glsl_SetLightLevel(float lightlevel)
   glsl_ShaderUniform(sh_main, MAIN_UNIF_LIGHTLEVEL, lightlevel);
 }
 
-void glsl_PushFuzzShader(int tic, int sprite, int width, int height, float ratio)
+void glsl_PushFuzzShader(int tic, int sprite, float ratio)
 {
   // Large integers converted to float can lose precision, causing
   // problems in the shader.  Since the tic and sprite count are just
@@ -657,7 +659,6 @@ void glsl_PushFuzzShader(int tic, int sprite, int width, int height, float ratio
   seed *= factor;
 
   glsl_ShaderPush(sh_fuzz,
-             FUZZ_UNIF_TEX_D, (double) width, (double) height,
              FUZZ_UNIF_RATIO, ratio,
              FUZZ_UNIF_SEED, (double) seed / INT_MAX,
              UNIF_VAL_END);

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -943,6 +943,7 @@ void gld_BindTexture(GLTexture *gltexture, unsigned int flags, dboolean sky)
   {
     glBindTexture(GL_TEXTURE_2D, *gltexture->texid_p);
     gld_SetTexClamp(gltexture, flags);
+    glsl_SetTextureDims(0, gltexture->realtexwidth, gltexture->realtexheight);
     return;
   }
 
@@ -974,6 +975,7 @@ void gld_BindTexture(GLTexture *gltexture, unsigned int flags, dboolean sky)
   gld_BuildTexture(gltexture, buffer, false, gltexture->buffer_width, gltexture->buffer_height);
 
   gld_SetTexClamp(gltexture, flags);
+  glsl_SetTextureDims(0, gltexture->realtexwidth, gltexture->realtexheight);
 }
 
 GLTexture *gld_RegisterPatch(int lump, int cm, dboolean is_sprite, dboolean indexed)
@@ -1057,6 +1059,7 @@ void gld_BindPatch(GLTexture *gltexture, int cm)
   {
     glBindTexture(GL_TEXTURE_2D, *gltexture->texid_p);
     gld_SetTexClamp(gltexture, GLTEXTURE_CLAMPXY);
+    glsl_SetTextureDims(0, gltexture->realtexwidth, gltexture->realtexheight);
     return;
   }
 
@@ -1072,6 +1075,7 @@ void gld_BindPatch(GLTexture *gltexture, int cm)
   gld_BuildTexture(gltexture, buffer, false, gltexture->buffer_width, gltexture->buffer_height);
 
   gld_SetTexClamp(gltexture, GLTEXTURE_CLAMPXY);
+  glsl_SetTextureDims(0, gltexture->realtexwidth, gltexture->realtexheight);
 }
 
 GLTexture *gld_RegisterRaw(int lump, int width, int height, dboolean mipmap, dboolean indexed)
@@ -1148,6 +1152,7 @@ void gld_BindRaw(GLTexture *gltexture, unsigned int flags)
   {
     glBindTexture(GL_TEXTURE_2D, *gltexture->texid_p);
     gld_SetTexClamp(gltexture, flags);
+    glsl_SetTextureDims(0, gltexture->realtexwidth, gltexture->realtexheight);
     return;
   }
 
@@ -1162,6 +1167,7 @@ void gld_BindRaw(GLTexture *gltexture, unsigned int flags)
   gld_BuildTexture(gltexture, buffer, false, gltexture->buffer_width, gltexture->buffer_height);
 
   gld_SetTexClamp(gltexture, flags);
+  glsl_SetTextureDims(0, gltexture->realtexwidth, gltexture->realtexheight);
 }
 
 
@@ -1271,6 +1277,7 @@ void gld_BindColormapTexture(GLTexture *gltexture, int palette_index, int gamma_
   {
     glBindTexture(GL_TEXTURE_2D, *gltexture->texid_p);
     GLEXT_glActiveTextureARB(GL_TEXTURE0_ARB);
+    glsl_SetTextureDims(2, gltexture->realtexwidth, gltexture->realtexheight);
     return;
   }
 
@@ -1289,6 +1296,7 @@ void gld_BindColormapTexture(GLTexture *gltexture, int palette_index, int gamma_
 
   // 'pop' the active texture back to the default.
   GLEXT_glActiveTextureARB(GL_TEXTURE0_ARB);
+  glsl_SetTextureDims(2, gltexture->realtexwidth, gltexture->realtexheight);
 }
 
 void gld_InitColormapTextures(dboolean fullbright)
@@ -1355,6 +1363,8 @@ void gld_InitFuzzTexture(void)
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 
     GLEXT_glActiveTextureARB(GL_TEXTURE0_ARB);
+
+    glsl_SetTextureDims(1, sizeof(fuzz) / sizeof(*fuzz), 1);
   }
 }
 


### PR DESCRIPTION
Since GLSL 1.10 doesn't let you query the size of a texture, we have to pass texture dimensions manually.  Make doing this generic and automatic, and use it for the fuzz shader.