### PR TITLE
CI: fix brew errors installing python

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -123,19 +123,20 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install \
-            cmake \
-            ninja \
-            pkg-config \
-            dumb \
-            fluid-synth \
-            libvorbis \
-            libzip \
-            mad \
-            portmidi \
-            sdl2 \
-            sdl2_image \
-            sdl2_mixer
+          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
+            brew install \
+              cmake \
+              ninja \
+              pkg-config \
+              dumb \
+              fluid-synth \
+              libvorbis \
+              libzip \
+              mad \
+              portmidi \
+              sdl2 \
+              sdl2_image \
+              sdl2_mixer
 
       - name: Configure
         run: |


### PR DESCRIPTION
Don't try to reinstall half of all open source software in existence during the build.