### PR TITLE
Render at full window/screen resolution in HiDPI

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1168,7 +1168,7 @@ void I_InitGraphics(void)
 
 void I_UpdateVideoMode(void)
 {
-  int init_flags = 0;
+  int init_flags = SDL_WINDOW_ALLOW_HIGHDPI;
   int screen_multiply;
   int actualheight;
   int render_vsync;
@@ -1214,7 +1214,7 @@ void I_UpdateVideoMode(void)
 
   // Initialize SDL with this graphics mode
   if (V_IsOpenGLMode()) {
-    init_flags = SDL_WINDOW_OPENGL;
+    init_flags |= SDL_WINDOW_OPENGL;
   }
 
   if (desired_fullscreen)

--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -42,7 +42,7 @@ static int gl_clear_box_width;
 static int gl_clear_box_height;
 
 void dsda_GLGetSDLWindowSize(SDL_Window* sdl_window) {
-  SDL_GetWindowSize(sdl_window, &gl_window_width, &gl_window_height);
+  SDL_GL_GetDrawableSize(sdl_window, &gl_window_width, &gl_window_height);
 }
 
 void dsda_GLSetRenderViewportParams() {


### PR DESCRIPTION
If an application doesn't explicitly indicate HiDPI support, most OSes/desktops report a lower than actual window resolution and automatically scale the application's output up. dsda-doom handles its own scaling with GL, so use the full available resolution.