### PR TITLE
Add proof of concept finite height toggle

### DIFF
--- a/prboom2/src/dsda/args.c
+++ b/prboom2/src/dsda/args.c
@@ -673,6 +673,11 @@ static arg_config_t arg_config[dsda_arg_count] = {
     "sets a special flag to compensate for sync errors in certain demos",
     arg_null,
   },
+  [dsda_arg_debug_finite_height] = {
+    "-debug_finite_height", NULL, NULL,
+    "turns on finite height (temporary arg for testing)",
+    arg_null,
+  },
 };
 
 static dsda_arg_t arg_value[dsda_arg_count];

--- a/prboom2/src/dsda/args.h
+++ b/prboom2/src/dsda/args.h
@@ -145,6 +145,7 @@ typedef enum {
   dsda_arg_do_not_use_misc12_frame_parameters_in_a_mushroom,
   dsda_arg_apply_mbf_codepointers_to_any_complevel,
   dsda_arg_reset_monsterspawner_params_after_loading,
+  dsda_arg_debug_finite_height,
   dsda_arg_count,
 } dsda_arg_identifier_t;
 

--- a/prboom2/src/dsda/mapinfo.c
+++ b/prboom2/src/dsda/mapinfo.c
@@ -21,6 +21,7 @@
 #include "doomstat.h"
 #include "m_misc.h"
 
+#include "dsda/args.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo/hexen.h"
 #include "dsda/mapinfo/u.h"
@@ -124,9 +125,14 @@ int dsda_SkipDrawShowNextLoc(void) {
 }
 
 static void dsda_UpdateMapInfo(void) {
+  map_info.finite_height = false;
+
   dsda_HexenUpdateMapInfo();
   dsda_UUpdateMapInfo();
   dsda_LegacyUpdateMapInfo();
+
+  if (!demorecording && !demoplayback && dsda_Flag(dsda_arg_debug_finite_height))
+    map_info.finite_height = true;
 }
 
 void dsda_UpdateGameMap(int episode, int map) {

--- a/prboom2/src/dsda/mapinfo.c
+++ b/prboom2/src/dsda/mapinfo.c
@@ -28,6 +28,8 @@
 
 #include "mapinfo.h"
 
+map_info_t map_info;
+
 int dsda_NameToMap(const char* name, int* episode, int* map) {
   char name_upper[9];
   int episode_from_name = -1;

--- a/prboom2/src/dsda/mapinfo.h
+++ b/prboom2/src/dsda/mapinfo.h
@@ -31,6 +31,12 @@
 #define WD_VICTORY      0x01
 #define WD_START_FINALE 0x02
 
+typedef struct {
+  dboolean finite_height;
+} map_info_t;
+
+extern map_info_t map_info;
+
 void dsda_FirstMap(int* episode, int* map);
 void dsda_NewGameMap(int* episode, int* map);
 void dsda_ResolveWarp(int* args, int arg_count, int* episode, int* map);

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -750,20 +750,23 @@ static dboolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
 
   if (tmthing->flags2 & MF2_PASSMOBJ)
   {                           // check if a mobj passed over/under another object
-    if ((tmthing->type == HERETIC_MT_IMP || tmthing->type == HERETIC_MT_WIZARD)
-        && (thing->type == HERETIC_MT_IMP || thing->type == HERETIC_MT_WIZARD))
-    {                       // don't let imps/wizards fly over other imps/wizards
-      return false;
-    }
+    if (raven)
+    {
+      if ((tmthing->type == HERETIC_MT_IMP || tmthing->type == HERETIC_MT_WIZARD)
+          && (thing->type == HERETIC_MT_IMP || thing->type == HERETIC_MT_WIZARD))
+      {                       // don't let imps/wizards fly over other imps/wizards
+        return false;
+      }
 
-    if (tmthing->type == HEXEN_MT_BISHOP && thing->type == HEXEN_MT_BISHOP)
-    {                       // don't let bishops fly over other bishops
-      return false;
+      if (tmthing->type == HEXEN_MT_BISHOP && thing->type == HEXEN_MT_BISHOP)
+      {                       // don't let bishops fly over other bishops
+        return false;
+      }
     }
 
     if (
-      (hexen ? tmthing->z >= thing->z + thing->height
-             : tmthing->z >  thing->z + thing->height)
+      (map_format.hexen ? tmthing->z >= thing->z + thing->height
+                        : tmthing->z >  thing->z + thing->height)
       && !(thing->flags & MF_SPECIAL)
     )
     {

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -772,8 +772,10 @@ static dboolean PIT_CheckThing(mobj_t *thing) // killough 3/26/98: make static
     {
       return (true);
     }
-    else if (tmthing->z + tmthing->height < thing->z
-             && !(thing->flags & MF_SPECIAL))
+    else if (
+      (map_format.zdoom ? tmthing->z + tmthing->height <= thing->z
+                        : tmthing->z + tmthing->height <  thing->z)
+      && !(thing->flags & MF_SPECIAL))
     {                       // under thing
       return (true);
     }

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1280,7 +1280,14 @@ void P_MobjThinker (mobj_t* mobj)
       if (!(onmo = P_CheckOnmobj(mobj)))
       {
         P_ZMovement(mobj);
+
+        // This bug is part of the original source
         if (hexen && mobj->player && mobj->flags & MF2_ONMOBJ)
+        {
+          mobj->flags2 &= ~MF2_ONMOBJ;
+        }
+
+        if (map_format.zdoom)
         {
           mobj->flags2 &= ~MF2_ONMOBJ;
         }
@@ -1289,11 +1296,11 @@ void P_MobjThinker (mobj_t* mobj)
       {
         if (mobj->player)
         {
-          if (hexen)
+          if (map_format.hexen)
           {
             fixed_t gravity = P_MobjGravity(mobj);
 
-            if (mobj->momz < -gravity * 8 && !(mobj->flags2 & MF2_FLY))
+            if (hexen && mobj->momz < -gravity * 8 && !(mobj->flags2 & MF2_FLY))
             {
               PlayerLandedOnThing(mobj, onmo, gravity);
             }
@@ -1332,6 +1339,16 @@ void P_MobjThinker (mobj_t* mobj)
                 onmo->z = onmo->floorz;
               }
             }
+          }
+        }
+        else if (map_format.zdoom)
+        {
+          mobj->momz = 0;
+
+          if (onmo->z + onmo->height - mobj->z <= 24 * FRACUNIT)
+          {
+            mobj->z = onmo->z + onmo->height;
+            mobj->flags2 |= MF2_ONMOBJ;
           }
         }
       }

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -56,6 +56,7 @@
 
 #include "dsda.h"
 #include "dsda/map_format.h"
+#include "dsda/mapinfo.h"
 #include "dsda/settings.h"
 #include "dsda/spawn_number.h"
 #include "dsda/thing_id.h"
@@ -1671,6 +1672,9 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   else
     if (type == g_mt_player)         // Except in old demos, players
       mobj->flags |= MF_FRIEND;    // are always friends.
+
+  if (map_format.zdoom && map_info.finite_height && mobj->flags & MF_SOLID)
+    mobj->flags2 |= MF2_PASSMOBJ;
 
   mobj->health = info->spawnhealth;
 

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -389,7 +389,7 @@ void P_MovePlayer (player_t* player)
     R_SmoothPlaying_Add(cmd->angleturn << 16);
   }
 
-  onground = mo->z <= mo->floorz;
+  onground = (mo->z <= mo->floorz || mo->flags2 & MF2_ONMOBJ);
 
   if ((player->mo->flags & MF_FLY) && player == &players[consoleplayer] && upmove != 0)
   {


### PR DESCRIPTION
This will be turned on / off via mapinfo most likely. Until that's possible there is a debug arg.

The falling object fix applies even without finite height in advanced formats. I don't see any reason not to have it.