### PR TITLE
GL: add smooth fade mode

### DIFF
--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TABLES
     lumps/glshadow.lmp
     lumps/gls_main.lmp
     lumps/gls_fuzz.lmp
+    lumps/glh_idx.lmp
     lumps/m_ammo.lmp
     lumps/m_armour.lmp
     lumps/m_arrow.lmp

--- a/prboom2/data/lumps/glh_idx.lmp
+++ b/prboom2/data/lumps/glh_idx.lmp
@@ -1,0 +1,45 @@
+// [XA] New "indexed" lightmode shader, which approximates
+// Doom's software lighting algorithm using the COLORMAP.
+// Looks very very close to the software renderer,
+// palette edits included, all while running on the GPU. :)
+
+// Big thanks to Jazz Mickle for pioneering this technique
+// and publishing an article explaining how it all works.
+// https://medium.com/@jmickle_/writing-a-doom-style-shader-for-unity-63fa13678634
+
+// [XA] adjusted this value a bit from the truecolor shader,
+// to taste -- seems to match software pretty damn closely
+#define DOOMLIGHTFACTOR 200.0
+
+uniform float lightlevel;
+uniform sampler2D colormap;
+
+// Returns color index based on R texel component
+float indexColor(float r)
+{
+  return r * 255.0;
+}
+
+// Returns light index based on depth and light level.
+// Based on equations from EDGE.
+float indexLight(float z)
+{
+  // Quantize light level to nearest of 64 discrete values
+  float L = floor(63.0 * lightlevel + 0.5);
+  // Compute minimal light index (brightest) for light level
+  float min_L = clamp(36.0 - L, 0.0, 31.0);
+  // Compute and clamp light index
+  return clamp(59.0 + DOOMLIGHTFACTOR - L - DOOMLIGHTFACTOR / max(0.0, z), min_L, 31.0);
+}
+
+// Returns RGB palette value based on color and light indices
+vec3 indexRGB(float ci, float li)
+{
+  // - Round to nearest integer indices
+  // - Re-clamp light index to valid range in case it was modified by caller
+  // - Convert to texture coordinates
+  ci = floor(ci + 0.5) / 256.0;
+  // There are 33 colormaps (32 + invuln), thus the 33 divisor
+  li = clamp(floor(li + 0.5), 0.0, 31.0) / 33.0;
+  return texture2D(colormap, vec2(ci, li)).rgb;
+}

--- a/prboom2/data/lumps/gls_main.lmp
+++ b/prboom2/data/lumps/gls_main.lmp
@@ -1,4 +1,5 @@
 #version 110
+#extension GL_GOOGLE_include_directive : require
 
 #ifdef VERTEX
 void main()
@@ -10,54 +11,31 @@ void main()
 #endif
 
 #ifdef FRAGMENT
+#include "glh_idx.lmp"
+
 uniform sampler2D tex;
-uniform sampler2D colormap;
-uniform float lightlevel;
-
-// [XA] New "indexed" lightmode shader, which approximates
-// Doom's software lighting algorithm using the COLORMAP.
-// Looks very very close to the software renderer,
-// palette edits included, all while running on the GPU. :)
-
-// Big thanks to Jazz Mickle for pioneering this technique
-// and publishing an article explaining how it all works.
-// https://medium.com/@jmickle_/writing-a-doom-style-shader-for-unity-63fa13678634
-
-// Also thanks to Gooberman, since I borrowed his method for
-// fixing rounding issues for the colorIndex variable below.
-// A little bit of fudgery goes a long way... :P
-// https://github.com/GooberMan/rum-and-raisin-doom/commit/91500a86b02243dd90958aae4427051ad5c63b0d
-
-// [XA] adjusted this value a bit from the truecolor shader,
-// to taste -- seems to match software pretty damn closely
-#define DOOMLIGHTFACTOR 200.0
+uniform int fade_mode;
 
 void main()
 {
-  vec4 color = gl_Color;
-
-  // grab the texel and its color index,
-  // which is stuffed into the R channel
+  // grab the texel and its color index, which is stuffed into the R channel
   vec4 texel = texture2D(tex, gl_TexCoord[0].st);
-  float colorIndex = texel.r * 0.99609375 + 0.0009765625; // equivalent to (texel.r * 255 / 256) + (1 / 1024)
+  float ci = indexColor(texel.r);
+  float li = indexLight(gl_FragCoord.z);
+  vec3 color;
 
-  // calculate light level based on distance.
-  // equation originally from EDGE. now translated
-  // to an actual colormap lookup, for science.
-  float L = 63.0 * lightlevel;
-  float min_L = clamp(36.0 - L, 0.0, 31.0);
-  float dist = max(0.0, gl_FragCoord.z);
-  float index = 59.0 + DOOMLIGHTFACTOR - L - DOOMLIGHTFACTOR / dist;
-  float doomlight = (clamp(index, min_L, 31.0) / 31.0);
+  if (fade_mode == 1)
+  {
+    // Smooth fade mode.
+    color = mix(indexRGB(ci, floor(li)), indexRGB(ci, floor(li + 1.0)), fract(li));
+  }
+  else
+  {
+    // Normal (banded) fade mode.
+    color = indexRGB(ci, li);
+  }
 
-  // Map light level (1.0 to 0.0) to colormap index (0 to 31)
-  // and pluck the actual RGB color from the colormap; note
-  // that we're dividing by 32 at the end since there's an
-  // extra 32nd row in the colormap image for the invuln pal
-  float lightIndex = doomlight * 0.96875; // equivalent to (doomlight * 31 / 32)
-  gl_FragColor = color * texture2D(colormap, vec2(colorIndex, lightIndex));
-
-  // reapply transparency & translucency
-  gl_FragColor.a = color.a * texel.g;
+  // Apply color and alpha
+  gl_FragColor = vec4(gl_Color.rgb * color, gl_Color.a * texel.g);
 }
 #endif

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1145,6 +1145,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "render_stretchsky", dsda_config_render_stretchsky,
     CONF_BOOL(1)
   },
+  [dsda_config_gl_fade_mode] = {
+    "gl_fade_mode", dsda_config_gl_fade_mode,
+    dsda_config_int, 0, 1, { 0 }
+  },
   [dsda_config_boom_translucent_sprites] = {
     "boom_translucent_sprites", dsda_config_boom_translucent_sprites,
     CONF_BOOL(1), NULL, NOT_STRICT, deh_changeCompTranslucency

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -120,6 +120,7 @@ typedef enum {
   dsda_config_gl_render_fov,
   dsda_config_gl_health_bar,
   dsda_config_gl_usevbo,
+  dsda_config_gl_fade_mode,
   dsda_config_use_mouse,
   dsda_config_mouse_sensitivity_horiz,
   dsda_config_mouse_sensitivity_vert,

--- a/prboom2/src/gl_shader.c
+++ b/prboom2/src/gl_shader.c
@@ -54,6 +54,7 @@
 #include "e6y.h"
 #include "r_things.h"
 #include "doomdef.h"
+#include "dsda/configuration.h"
 
 #include "dsda/utility/string_view.h"
 
@@ -571,7 +572,8 @@ enum
 {
   MAIN_UNIF_TEX,
   MAIN_UNIF_COLORMAP,
-  MAIN_UNIF_LIGHTLEVEL
+  MAIN_UNIF_LIGHTLEVEL,
+  MAIN_UNIF_FADE_MODE
 };
 
 enum
@@ -595,6 +597,7 @@ static const shader_info_t main_info =
     UNIF(MAIN_UNIF_TEX, "tex", UNIF_TEX0),
     UNIF(MAIN_UNIF_COLORMAP, "colormap", UNIF_TEX2),
     UNIF(MAIN_UNIF_LIGHTLEVEL, "lightlevel", UNIF_1F),
+    UNIF(MAIN_UNIF_FADE_MODE, "fade_mode", UNIF_1I),
     UNIF_END
   }
 };
@@ -632,7 +635,11 @@ void glsl_PopNullShader(void)
 
 void glsl_PushMainShader(void)
 {
-  glsl_ShaderPush(sh_main, UNIF_VAL_END);
+  int mode = dsda_IntConfig(dsda_config_gl_fade_mode);
+
+  glsl_ShaderPush(sh_main,
+                  MAIN_UNIF_FADE_MODE, mode,
+                  UNIF_VAL_END);
 }
 
 void glsl_PopMainShader(void)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2958,6 +2958,8 @@ static const char* fake_contrast_list[] =
   NULL
 };
 
+static const char *gl_fade_mode_list[] = { "Normal", "Smooth", NULL };
+
 setup_menu_t audiovideo_settings[] = {
   { "Video", S_SKIP | S_TITLE, m_null, G_X},
   { "Video mode", S_CHOICE | S_STR, m_conf, G_X, dsda_config_videomode, 0, videomodes },
@@ -2969,6 +2971,7 @@ setup_menu_t audiovideo_settings[] = {
   { "Uncapped Framerate", S_YESNO, m_conf, G_X, dsda_config_uncapped_framerate },
   { "FPS Limit", S_NUM, m_conf, G_X, dsda_config_fps_limit },
   { "Fake Contrast", S_CHOICE, m_conf, G_X, dsda_config_fake_contrast_mode, 0, fake_contrast_list },
+  { "GL Light Fade", S_CHOICE, m_conf, G_X, dsda_config_gl_fade_mode, 0, gl_fade_mode_list },
   EMPTY_LINE,
   { "Sound & Music", S_SKIP | S_TITLE, m_null, G_X},
   { "Number of Sound Channels", S_NUM, m_conf, G_X, dsda_config_snd_channels },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -170,6 +170,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_gl_skymode),
   MIGRATED_SETTING(dsda_config_gl_health_bar),
   MIGRATED_SETTING(dsda_config_gl_usevbo),
+  MIGRATED_SETTING(dsda_config_gl_fade_mode),
 
   SETTING_HEADING("Mouse settings"),
   MIGRATED_SETTING(dsda_config_use_mouse),


### PR DESCRIPTION
This refactors some of the indexed lighting calculations into a header so they can be used elsewhere in the future (e.g. a sky dome shader that uses indexed textures)