### PR TITLE
Add show WPN argument to weapon_text HUD component

### DIFF
--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -22,6 +22,7 @@
 typedef struct {
   dsda_text_t component;
   dboolean grid;
+  dboolean show_wpn;
 } local_component_t;
 
 static local_component_t* local;
@@ -31,50 +32,95 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 
   player = &players[displayplayer];
 
-  if (local->grid)
-    snprintf(
-      str,
-      max_size,
-      "%sW %s%c %s%c %c\n"
-      "%sP %s%c %c %c\n"
-      "%sN %s%c %c %c",
-      dsda_TextColor(dsda_tc_exhud_weapon_label),
-      player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
-                                    dsda_TextColor(dsda_tc_exhud_weapon_owned),
-      player->weaponowned[0] ? '1' : ' ',
-      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-      player->weaponowned[1] ? '2' : ' ',
-      player->weaponowned[2] ? '3' : ' ',
-      dsda_TextColor(dsda_tc_exhud_weapon_label),
-      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-      player->weaponowned[3] ? '4' : ' ',
-      player->weaponowned[4] ? '5' : ' ',
-      player->weaponowned[5] ? '6' : ' ',
-      dsda_TextColor(dsda_tc_exhud_weapon_label),
-      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-      player->weaponowned[6] ? '7' : ' ',
-      player->weaponowned[7] ? '8' : ' ',
-      player->weaponowned[8] ? '9' : ' '
-    );
-  else
-    snprintf(
-      str,
-      max_size,
-      "%sWPN %s%c %s%c %c %c %c %c %c %c %c",
-      dsda_TextColor(dsda_tc_exhud_weapon_label),
-      player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
-                                    dsda_TextColor(dsda_tc_exhud_weapon_owned),
-      player->weaponowned[0] ? '1' : ' ',
-      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-      player->weaponowned[1] ? '2' : ' ',
-      player->weaponowned[2] ? '3' : ' ',
-      player->weaponowned[3] ? '4' : ' ',
-      player->weaponowned[4] ? '5' : ' ',
-      player->weaponowned[5] ? '6' : ' ',
-      player->weaponowned[6] ? '7' : ' ',
-      player->weaponowned[7] ? '8' : ' ',
-      player->weaponowned[8] ? '9' : ' '
-    );
+  if (local->show_wpn) {
+    if (local->grid)
+      snprintf(
+        str,
+        max_size,
+        "%sW %s%c %s%c %c\n"
+        "%sP %s%c %c %c\n"
+        "%sN %s%c %c %c",
+        dsda_TextColor(dsda_tc_exhud_weapon_label),
+        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
+                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[0] ? '1' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[1] ? '2' : ' ',
+        player->weaponowned[2] ? '3' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_label),
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[3] ? '4' : ' ',
+        player->weaponowned[4] ? '5' : ' ',
+        player->weaponowned[5] ? '6' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_label),
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[6] ? '7' : ' ',
+        player->weaponowned[7] ? '8' : ' ',
+        player->weaponowned[8] ? '9' : ' '
+      );
+    else
+      snprintf(
+        str,
+        max_size,
+        "%sWPN %s%c %s%c %c %c %c %c %c %c %c",
+        dsda_TextColor(dsda_tc_exhud_weapon_label),
+        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
+                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[0] ? '1' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[1] ? '2' : ' ',
+        player->weaponowned[2] ? '3' : ' ',
+        player->weaponowned[3] ? '4' : ' ',
+        player->weaponowned[4] ? '5' : ' ',
+        player->weaponowned[5] ? '6' : ' ',
+        player->weaponowned[6] ? '7' : ' ',
+        player->weaponowned[7] ? '8' : ' ',
+        player->weaponowned[8] ? '9' : ' '
+      );
+  }
+  else {
+    if (local->grid)
+      snprintf(
+        str,
+        max_size,
+        "%s%c %s%c %c\n"
+        "%s%c %c %c\n"
+        "%s%c %c %c",
+        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
+                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[0] ? '1' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[1] ? '2' : ' ',
+        player->weaponowned[2] ? '3' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[3] ? '4' : ' ',
+        player->weaponowned[4] ? '5' : ' ',
+        player->weaponowned[5] ? '6' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[6] ? '7' : ' ',
+        player->weaponowned[7] ? '8' : ' ',
+        player->weaponowned[8] ? '9' : ' '
+      );
+    else
+      snprintf(
+        str,
+        max_size,
+        "%s%c %s%c %c %c %c %c %c %c %c",
+        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
+                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[0] ? '1' : ' ',
+        dsda_TextColor(dsda_tc_exhud_weapon_owned),
+        player->weaponowned[1] ? '2' : ' ',
+        player->weaponowned[2] ? '3' : ' ',
+        player->weaponowned[3] ? '4' : ' ',
+        player->weaponowned[4] ? '5' : ' ',
+        player->weaponowned[5] ? '6' : ' ',
+        player->weaponowned[6] ? '7' : ' ',
+        player->weaponowned[7] ? '8' : ' ',
+        player->weaponowned[8] ? '9' : ' '
+      );
+  }
+
 }
 
 void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
@@ -82,6 +128,10 @@ void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int a
   local = *data;
 
   local->grid = args[0];
+  if (arg_count > 1)
+    local->show_wpn = args[1];
+  else
+    local->show_wpn = true;
   dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 

--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -23,6 +23,10 @@ typedef struct {
   dsda_text_t component;
   dboolean grid;
   dboolean show_wpn;
+  char label_w[5];
+  char label_p[5];
+  char label_n[5];
+  char label_wpn[7];
 } local_component_t;
 
 static local_component_t* local;
@@ -32,95 +36,50 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 
   player = &players[displayplayer];
 
-  if (local->show_wpn) {
-    if (local->grid)
-      snprintf(
-        str,
-        max_size,
-        "%sW %s%c %s%c %c\n"
-        "%sP %s%c %c %c\n"
-        "%sN %s%c %c %c",
-        dsda_TextColor(dsda_tc_exhud_weapon_label),
-        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
-                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[0] ? '1' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[1] ? '2' : ' ',
-        player->weaponowned[2] ? '3' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_label),
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[3] ? '4' : ' ',
-        player->weaponowned[4] ? '5' : ' ',
-        player->weaponowned[5] ? '6' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_label),
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[6] ? '7' : ' ',
-        player->weaponowned[7] ? '8' : ' ',
-        player->weaponowned[8] ? '9' : ' '
-      );
-    else
-      snprintf(
-        str,
-        max_size,
-        "%sWPN %s%c %s%c %c %c %c %c %c %c %c",
-        dsda_TextColor(dsda_tc_exhud_weapon_label),
-        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
-                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[0] ? '1' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[1] ? '2' : ' ',
-        player->weaponowned[2] ? '3' : ' ',
-        player->weaponowned[3] ? '4' : ' ',
-        player->weaponowned[4] ? '5' : ' ',
-        player->weaponowned[5] ? '6' : ' ',
-        player->weaponowned[6] ? '7' : ' ',
-        player->weaponowned[7] ? '8' : ' ',
-        player->weaponowned[8] ? '9' : ' '
-      );
-  }
-  else {
-    if (local->grid)
-      snprintf(
-        str,
-        max_size,
-        "%s%c %s%c %c\n"
-        "%s%c %c %c\n"
-        "%s%c %c %c",
-        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
-                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[0] ? '1' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[1] ? '2' : ' ',
-        player->weaponowned[2] ? '3' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[3] ? '4' : ' ',
-        player->weaponowned[4] ? '5' : ' ',
-        player->weaponowned[5] ? '6' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[6] ? '7' : ' ',
-        player->weaponowned[7] ? '8' : ' ',
-        player->weaponowned[8] ? '9' : ' '
-      );
-    else
-      snprintf(
-        str,
-        max_size,
-        "%s%c %s%c %c %c %c %c %c %c %c",
-        player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
-                                      dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[0] ? '1' : ' ',
-        dsda_TextColor(dsda_tc_exhud_weapon_owned),
-        player->weaponowned[1] ? '2' : ' ',
-        player->weaponowned[2] ? '3' : ' ',
-        player->weaponowned[3] ? '4' : ' ',
-        player->weaponowned[4] ? '5' : ' ',
-        player->weaponowned[5] ? '6' : ' ',
-        player->weaponowned[6] ? '7' : ' ',
-        player->weaponowned[7] ? '8' : ' ',
-        player->weaponowned[8] ? '9' : ' '
-      );
-  }
-
+  if (local->grid)
+    snprintf(
+      str,
+      max_size,
+      "%s%s%c %s%c %c\n"
+      "%s%s%c %c %c\n"
+      "%s%s%c %c %c",
+      local->label_w,
+      player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
+                                    dsda_TextColor(dsda_tc_exhud_weapon_owned),
+      player->weaponowned[0] ? '1' : ' ',
+      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+      player->weaponowned[1] ? '2' : ' ',
+      player->weaponowned[2] ? '3' : ' ',
+      local->label_p,
+      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+      player->weaponowned[3] ? '4' : ' ',
+      player->weaponowned[4] ? '5' : ' ',
+      player->weaponowned[5] ? '6' : ' ',
+      local->label_n,
+      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+      player->weaponowned[6] ? '7' : ' ',
+      player->weaponowned[7] ? '8' : ' ',
+      player->weaponowned[8] ? '9' : ' '
+    );
+  else
+    snprintf(
+      str,
+      max_size,
+      "%s%s%c %s%c %c %c %c %c %c %c %c",
+      local->label_wpn,
+      player->powers[pw_strength] ? dsda_TextColor(dsda_tc_exhud_weapon_berserk) :
+                                    dsda_TextColor(dsda_tc_exhud_weapon_owned),
+      player->weaponowned[0] ? '1' : ' ',
+      dsda_TextColor(dsda_tc_exhud_weapon_owned),
+      player->weaponowned[1] ? '2' : ' ',
+      player->weaponowned[2] ? '3' : ' ',
+      player->weaponowned[3] ? '4' : ' ',
+      player->weaponowned[4] ? '5' : ' ',
+      player->weaponowned[5] ? '6' : ' ',
+      player->weaponowned[6] ? '7' : ' ',
+      player->weaponowned[7] ? '8' : ' ',
+      player->weaponowned[8] ? '9' : ' '
+    );
 }
 
 void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
@@ -132,6 +91,19 @@ void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int a
     local->show_wpn = args[1];
   else
     local->show_wpn = true;
+
+  if (local->show_wpn) {
+    snprintf(local->label_w, sizeof(local->label_w), "%sW ", dsda_TextColor(dsda_tc_exhud_weapon_label));
+    snprintf(local->label_p, sizeof(local->label_p), "%sP ", dsda_TextColor(dsda_tc_exhud_weapon_label));
+    snprintf(local->label_n, sizeof(local->label_n), "%sN ", dsda_TextColor(dsda_tc_exhud_weapon_label));
+    snprintf(local->label_wpn, sizeof(local->label_wpn), "%sWPN ", dsda_TextColor(dsda_tc_exhud_weapon_label));
+  }
+  else {
+    local->label_w[0] = '\0';
+    local->label_p[0] = '\0';
+    local->label_n[0] = '\0';
+    local->label_wpn[0] = '\0';
+  }
   dsda_InitTextHC(&local->component, x_offset, y_offset, vpt);
 }
 

--- a/prboom2/src/dsda/hud_components/weapon_text.c
+++ b/prboom2/src/dsda/hud_components/weapon_text.c
@@ -22,7 +22,6 @@
 typedef struct {
   dsda_text_t component;
   dboolean grid;
-  dboolean show_wpn;
   char label_w[5];
   char label_p[5];
   char label_n[5];
@@ -83,16 +82,18 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
 }
 
 void dsda_InitWeaponTextHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  dboolean show_wpn;
+
   *data = Z_Calloc(1, sizeof(local_component_t));
   local = *data;
 
   local->grid = args[0];
   if (arg_count > 1)
-    local->show_wpn = args[1];
+    show_wpn = args[1];
   else
-    local->show_wpn = true;
+    show_wpn = true;
 
-  if (local->show_wpn) {
+  if (show_wpn) {
     snprintf(local->label_w, sizeof(local->label_w), "%sW ", dsda_TextColor(dsda_tc_exhud_weapon_label));
     snprintf(local->label_p, sizeof(local->label_p), "%sP ", dsda_TextColor(dsda_tc_exhud_weapon_label));
     snprintf(local->label_n, sizeof(local->label_n), "%sN ", dsda_TextColor(dsda_tc_exhud_weapon_label));


### PR DESCRIPTION
This adds a new argument to the `weapon_text` HUD component. It lets the player toggle whether the WPN text of the component shows up.

![image](https://github.com/kraflab/dsda-doom/assets/83483941/39ac0aea-7fc4-4c69-85c3-491296bb1521)
![image](https://github.com/kraflab/dsda-doom/assets/83483941/8f7f4cfc-9726-4af8-baa5-5c04cc06782d)
![image](https://github.com/kraflab/dsda-doom/assets/83483941/0eeb3179-1dd4-4a56-9a37-2295e68df27b)
![image](https://github.com/kraflab/dsda-doom/assets/83483941/a2c03158-b2a2-499a-94f5-e759ae845acb)
