### PR TITLE
Add color coding for big_ammo HUD component

### DIFF
--- a/prboom2/src/dsda/hud_components/big_ammo.c
+++ b/prboom2/src/dsda/hud_components/big_ammo.c
@@ -31,6 +31,9 @@ static void dsda_DrawComponent(void) {
   player_t* player;
   ammotype_t ammo_type;
   int ammo;
+  int cm;
+  int ammopct = 0;
+  int max_ammo;
 
   if (hexen)
     return;
@@ -42,9 +45,24 @@ static void dsda_DrawComponent(void) {
     return;
 
   ammo = player->ammo[ammo_type];
+  max_ammo = player->maxammo[weaponinfo[player->readyweapon].ammo];
+
+  if (ammo == max_ammo)
+    cm = CR_LIGHTBLUE;
+  else {
+    if (max_ammo)
+        ammopct = (ammo * 100) / max_ammo;
+    if (ammopct < hud_ammo_red)
+      cm = CR_RED;
+    else
+      if (ammopct < hud_ammo_yellow)
+        cm = CR_GOLD;
+      else
+        cm = CR_GREEN;
+  }
 
   dsda_DrawBigNumber(local->component.x, local->component.y, PATCH_DELTA_X, 0,
-                     CR_DEFAULT, local->component.vpt, 3, ammo);
+                     cm, local->component.vpt, 3, ammo);
 }
 
 void dsda_InitBigAmmoHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {


### PR DESCRIPTION
This adds color coding to the `big_ammo` HUD component, where the color of the component depends on how much ammo the player has, similar to health and armor HUD components.

![image](https://github.com/kraflab/dsda-doom/assets/83483941/4ad6c7aa-1b5c-4ba7-ae62-c7f0e5accec1)
![image](https://github.com/kraflab/dsda-doom/assets/83483941/9a094ed7-9fef-4748-accc-bc4bf663e0b4)
![image](https://github.com/kraflab/dsda-doom/assets/83483941/935b06c7-1344-4f18-b77b-f241151536c3)
![image](https://github.com/kraflab/dsda-doom/assets/83483941/5f2fc727-dcd3-4b48-9cc1-76e2cf56fc46)
