### PR TITLE
Parse ambient SNDINFO

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -11,6 +11,8 @@ set(COMMON_SRC
     doomtype.h
     dsda.c
     dsda.h
+    dsda/ambient.cpp
+    dsda/ambient.h
     dsda/analysis.c
     dsda/analysis.h
     dsda/args.c

--- a/prboom2/src/dsda/ambient.cpp
+++ b/prboom2/src/dsda/ambient.cpp
@@ -1,0 +1,176 @@
+//
+// Copyright(C) 2023 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Ambient
+//
+
+#include <string>
+#include <cstring>
+#include <unordered_map>
+
+extern "C" {
+#include "lprintf.h"
+#include "sounds.h"
+#include "w_wad.h"
+#include "z_zone.h"
+
+#include "dsda/sfx.h"
+}
+
+#include "scanner.h"
+
+#include "ambient.h"
+
+typedef struct {
+  char* lump_name;
+  int sfx_id;
+} named_sfx_t;
+
+std::unordered_map<std::string, named_sfx_t> name_to_sfx;
+std::unordered_map<int, ambient_sfx_t> id_to_ambient_sfx;
+
+static void dsda_ParseAmbient(Scanner &scanner) {
+  ambient_sfx_t amb_sfx = { 0 };
+  int id;
+
+  scanner.MustGetInteger();
+  id = scanner.number;
+
+  scanner.MustGetString();
+  amb_sfx.sound_name = Z_Strdup(scanner.string);
+
+  scanner.MustGetString();
+  if (!stricmp(scanner.string, "point")) {
+    amb_sfx.attenuation = scanner.CheckFloat() ? scanner.decimal : 1.0;
+    scanner.MustGetString();
+  }
+  else if (!stricmp(scanner.string, "world") || !stricmp(scanner.string, "surround")) {
+    amb_sfx.attenuation = 0;
+    scanner.MustGetString();
+  }
+  else {
+    amb_sfx.attenuation = 0;
+  }
+
+  if (!stricmp(scanner.string, "continuous")) {
+    amb_sfx.min_tics = -1;
+    amb_sfx.max_tics = -1;
+  }
+  else if (!stricmp(scanner.string, "random")) {
+    scanner.MustGetFloat();
+    amb_sfx.min_tics = 35 * scanner.decimal;
+    scanner.MustGetFloat();
+    amb_sfx.max_tics = 35 * scanner.decimal;
+  }
+  else if (!stricmp(scanner.string, "periodic")) {
+    scanner.MustGetFloat();
+    amb_sfx.min_tics = 35 * scanner.decimal;
+    amb_sfx.max_tics = amb_sfx.min_tics;
+  }
+
+  scanner.MustGetFloat();
+  amb_sfx.volume = BETWEEN(0.0, 1.0, scanner.decimal);
+
+  if (!amb_sfx.min_tics && !amb_sfx.max_tics) {
+    lprintf(LO_WARN, "Ambient sound %d has invalid parameters\n", id);
+    Z_Free(amb_sfx.sound_name);
+    return;
+  }
+
+  if (id_to_ambient_sfx[id].sound_name)
+    Z_Free(id_to_ambient_sfx[id].sound_name);
+
+  id_to_ambient_sfx[id] = amb_sfx;
+}
+
+static void dsda_ParseSndInfoLine(Scanner &scanner) {
+  if (!scanner.CheckString()) {
+    scanner.GetNextToken();
+    scanner.SkipLine();
+    return;
+  }
+
+  if (!stricmp(scanner.string, "$ambient"))
+    dsda_ParseAmbient(scanner);
+  else if (scanner.string[0] == '$') {
+    scanner.SkipLine();
+    return;
+  }
+  else {
+    std::string name(scanner.string);
+
+    scanner.CheckToken('='); // Optional
+    scanner.MustGetString();
+
+    if (!W_LumpNameExists(scanner.string)) {
+      lprintf(LO_WARN, "Sound lump \"%s\" does not exist\n", scanner.string);
+      return;
+    }
+
+    if (name_to_sfx[name].lump_name)
+      Z_Free(name_to_sfx[name].lump_name);
+
+    name_to_sfx[name].lump_name = Z_Strdup(scanner.string);
+  }
+}
+
+static void dsda_ResolveAmbientSounds(void) {
+  for (auto &named_sfx : name_to_sfx) {
+    sfxinfo_t* new_sfx;
+    int id;
+
+    new_sfx = dsda_NewSFX(&id);
+    new_sfx->name = named_sfx.second.lump_name;
+    named_sfx.second.sfx_id = id;
+
+    lprintf(LO_DEBUG, "Named sound: %s -> %s %d\n", named_sfx.first.c_str(), new_sfx->name, id);
+  }
+
+  for (auto &amb_sfx : id_to_ambient_sfx) {
+    amb_sfx.second.sfx_id = name_to_sfx[amb_sfx.second.sound_name].sfx_id;
+
+    if (!amb_sfx.second.sfx_id)
+      lprintf(LO_WARN, "Sound \"%s\" does not exist\n", amb_sfx.second.sound_name);
+
+    lprintf(LO_DEBUG, "Ambient sound: %d att: %f, vol: %f, t: %d %d, sfx: %d\n",
+                     amb_sfx.first,
+                     amb_sfx.second.attenuation,
+                     amb_sfx.second.volume,
+                     amb_sfx.second.min_tics,
+                     amb_sfx.second.max_tics,
+                     amb_sfx.second.sfx_id);
+  }
+}
+
+ambient_sfx_t* dsda_AmbientSFX(int id) {
+  return id_to_ambient_sfx[id].sfx_id ? &id_to_ambient_sfx[id] : NULL;
+}
+
+void dsda_LoadAmbientSndInfo(void) {
+  int lump;
+
+  lump = W_CheckNumForName("SNDINFO");
+
+  if (lump == LUMP_NOT_FOUND)
+    return;
+
+  Scanner scanner((const char*) W_LumpByNum(lump), W_LumpLength(lump));
+
+  scanner.SetErrorCallback(I_Error);
+
+  while (scanner.TokensLeft())
+    dsda_ParseSndInfoLine(scanner);
+
+  dsda_ResolveAmbientSounds();
+}

--- a/prboom2/src/dsda/ambient.h
+++ b/prboom2/src/dsda/ambient.h
@@ -1,0 +1,41 @@
+//
+// Copyright(C) 2023 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Ambient
+//
+
+#ifndef __DSDA_AMBIENT__
+#define __DSDA_AMBIENT__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  char* sound_name;
+  int sfx_id;
+  float attenuation;
+  float volume;
+  int min_tics;
+  int max_tics;
+} ambient_sfx_t;
+
+ambient_sfx_t* dsda_AmbientSFX(int id);
+void dsda_LoadAmbientSndInfo(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/prboom2/src/dsda/sfx.h
+++ b/prboom2/src/dsda/sfx.h
@@ -23,6 +23,7 @@
 int dsda_GetDehSFXIndex(const char* key, size_t length);
 int dsda_GetOriginalSFXIndex(const char* key);
 sfxinfo_t* dsda_GetDehSFX(int index);
+sfxinfo_t* dsda_NewSFX(int* index);
 void dsda_InitializeSFX(sfxinfo_t* source, int count);
 void dsda_FreeDehSFX(void);
 dboolean dsda_BlockSFX(sfxinfo_t *sfx);

--- a/prboom2/src/dsda/sndinfo.c
+++ b/prboom2/src/dsda/sndinfo.c
@@ -22,6 +22,7 @@
 #include "sc_man.h"
 #include "sounds.h"
 
+#include "dsda/ambient.h"
 #include "dsda/map_format.h"
 
 #include "sndinfo.h"
@@ -45,8 +46,10 @@ const char* dsda_SndInfoMapSongLumpName(int map) {
 void dsda_LoadSndInfo(void) {
   int i;
 
-  if (!hexen)
+  if (!hexen) {
+    dsda_LoadAmbientSndInfo();
     return;
+  }
 
   SC_OpenLump("sndinfo");
 

--- a/prboom2/src/scanner.cpp
+++ b/prboom2/src/scanner.cpp
@@ -249,7 +249,7 @@ bool Scanner::GetNextToken(bool expandState)
 
 	char cur = data[scanPos++];
 	// Determine by first character
-	if(cur == '_' || (cur >= 'A' && cur <= 'Z') || (cur >= 'a' && cur <= 'z'))
+	if(cur == '_' || cur == '$' || (cur >= 'A' && cur <= 'Z') || (cur >= 'a' && cur <= 'z'))
 		nextState.token = TK_Identifier;
 	else if(cur >= '0' && cur <= '9')
 	{

--- a/prboom2/src/scanner.cpp
+++ b/prboom2/src/scanner.cpp
@@ -454,6 +454,11 @@ void Scanner::IncrementLine()
 	lineStart = scanPos;
 }
 
+void Scanner::SkipLine()
+{
+	while (tokenLine == line && GetNextToken());
+}
+
 void Scanner::Error(int token)
 {
 	if (token < TK_NumSpecialTokens && this->token >= TK_Identifier && this->token < TK_NumSpecialTokens)

--- a/prboom2/src/scanner.h
+++ b/prboom2/src/scanner.h
@@ -85,6 +85,7 @@ class Scanner
 		void		MustGetFloat();
 		void		MustGetString();
 		void		ExpandState();
+		void		SkipLine();
 		int			GetLine() const { return tokenLine; }
 		int			GetLinePos() const { return tokenLinePosition; }
 		bool		GetNextToken(bool expandState=true);


### PR DESCRIPTION
This PR sets up SNDINFO parsing in doom for ambient sound effects. It stores the data and allocates new sfx slots. The remaining tasks are setting up the playback logic and catching the ambient sound map objects.