### PR TITLE
Default demos save ability fix

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -149,6 +149,7 @@ static int demolength; // check for overrun (missing DEMOMARKER)
 gameaction_t    gameaction;
 gamestate_t     gamestate;
 dboolean        in_game;
+dboolean        can_save;
 int             gameskill;
 int             gameepisode;
 int             gamemap;
@@ -3943,6 +3944,8 @@ void G_DoPlayDemo(void)
 
     lprintf(LO_INFO, "Playing demo:\n  Name: %s\n  Compatibility: %s\n",
                      defdemoname, comp_lev_str[compatibility_level]);
+
+	can_save = false;   // Disable save game when in a default demo playback
 
     gameaction = ga_nothing;
   }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -3945,7 +3945,7 @@ void G_DoPlayDemo(void)
     lprintf(LO_INFO, "Playing demo:\n  Name: %s\n  Compatibility: %s\n",
                      defdemoname, comp_lev_str[compatibility_level]);
 
-	can_save = false;   // Disable save game when in a default demo playback
+    can_save = false;   // Disable save game when in a default demo playback
 
     gameaction = ga_nothing;
   }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -158,6 +158,8 @@
 
 extern dboolean  message_dontfuckwithme;
 
+extern dboolean can_save;
+
 extern const char* g_menu_flat;
 extern int g_menu_save_page_size;
 extern int g_menu_font_spacing;
@@ -697,6 +699,7 @@ static void M_FinishGameSelection(void)
     SB_SetClassData();
 
   M_ClearMenus();
+  can_save = true;
 }
 
 // CPhipps - static
@@ -905,6 +908,7 @@ void M_LoadGame (int choice)
 
   M_SetupNextMenu(&LoadDef);
   M_ReadSaveStrings();
+  can_save = true;
 }
 
 /////////////////////////////
@@ -1057,7 +1061,7 @@ void M_SaveGame (int choice)
 {
   delete_verify = false;
 
-  if (gamestate != GS_LEVEL)
+  if (gamestate != GS_LEVEL || !can_save)
     return;
 
   M_SetupNextMenu(&SaveDef);
@@ -1280,7 +1284,7 @@ void M_MusicVol(int choice)
 
 void M_QuickSave(void)
 {
-  if (gamestate != GS_LEVEL)
+  if (gamestate != GS_LEVEL || !can_save)
     return;
 
   G_SaveGame(QUICKSAVESLOT, "quicksave");
@@ -1320,6 +1324,7 @@ void M_QuickLoad(void)
   {
     G_LoadGame(QUICKSAVESLOT);
     doom_printf("quickload");
+	can_save = true;
   }
   else
   {

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1324,7 +1324,7 @@ void M_QuickLoad(void)
   {
     G_LoadGame(QUICKSAVESLOT);
     doom_printf("quickload");
-	can_save = true;
+    can_save = true;
   }
   else
   {

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -867,6 +867,7 @@ void M_LoadSelect(int choice)
   // killough 3/16/98, 5/15/98: add slot, cmd
   G_LoadGame(choice + save_page * g_menu_save_page_size);
   M_ClearMenus();
+  can_save = true;
 }
 
 //
@@ -908,7 +909,6 @@ void M_LoadGame (int choice)
 
   M_SetupNextMenu(&LoadDef);
   M_ReadSaveStrings();
-  can_save = true;
 }
 
 /////////////////////////////


### PR DESCRIPTION
This simply prevents the ability to save a game during a default demo run when idling in the Menu on initial start. Does not affect recorded demo's.