### PR TITLE
Update HUD doc with show_labels for the stat_totals component

### DIFF
--- a/docs/hud.md
+++ b/docs/hud.md
@@ -48,11 +48,12 @@ You can find the current default configuration [here](../prboom2/data/lumps/dsda
 Unless otherwise specified, argument values are integers. For toggles, a 1 means on and a 0 means off. For example, `stat_totals 2 8 bottom_left 1 0 1` would turn off items but keep kills and secrets enabled.
 
 - `stat_totals`: shows the kills / secrets / items on the current map
-  - Supports 5 arguments: `show_kills show_items show_secrets vertical hide_totals`
+  - Supports 6 arguments: `show_kills show_items show_secrets vertical show_labels hide_totals`
   - `show_kills`: shows kills in the component
   - `show_items`: shows items in the component
   - `show_secrets`: shows secrets in the component
   - `vertical`: displays the stats vertically rather than horizontally
+  - `show_labels`: shows the "K" "I" "S" labels
   - `hide_totals`: hides the total counts until they are reached
 - `composite_time`: shows the current level time and the total time
   - Supports 1 argument: `show_label`


### PR DESCRIPTION
This adds missing documentation to the HUD doc. Before, it was missing the `show_labels` argument for the `stat_totals` HUD component.