### PR TITLE
Add an option to enable quit sounds

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1211,6 +1211,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "ansi_endoom", dsda_config_ansi_endoom,
     dsda_config_int, 0, 2, { 0 }
   },
+  [dsda_config_quit_sounds] = {
+    "quit_sounds", dsda_config_quit_sounds,
+    CONF_BOOL(0),
+  },
   [dsda_config_announce_map] = {
     "announce_map", dsda_config_announce_map,
     CONF_BOOL(0),

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -272,6 +272,7 @@ typedef enum {
   dsda_config_swap_analogs,
   dsda_config_invert_analog_look,
   dsda_config_ansi_endoom,
+  dsda_config_quit_sounds,
   dsda_config_announce_map,
   dsda_config_count,
 } dsda_config_identifier_t;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1157,6 +1157,27 @@ static void M_QuitResponse(dboolean affirmative)
   if (!affirmative)
     return;
 
+  if (!netgame // killough 12/98
+      && !nosfxparm
+      && dsda_IntConfig(dsda_config_quit_sounds))
+  {
+    int i;
+
+    if (gamemode == commercial)
+      S_StartVoidSound(quitsounds2[(gametic>>2)&7]);
+    else
+      S_StartVoidSound(quitsounds[(gametic>>2)&7]);
+
+    // wait till all sounds stopped or 3 seconds are over
+    i = 30;
+    while (i > 0) {
+      I_uSleep(100000); // CPhipps - don't thrash cpu in this loop
+      if (!I_AnySoundStillPlaying())
+        break;
+      i--;
+    }
+  }
+
   //e6y: I_SafeExit instead of exit - prevent recursive exits
   I_SafeExit(0); // killough
 }

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -91,6 +91,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_screenshot_dir),
   MIGRATED_SETTING(dsda_config_startup_delay_ms),
   MIGRATED_SETTING(dsda_config_ansi_endoom),
+  MIGRATED_SETTING(dsda_config_quit_sounds),
   MIGRATED_SETTING(dsda_config_announce_map),
 
   SETTING_HEADING("Game settings"),


### PR DESCRIPTION
If ENDOOM is enabled, play a random sound on confirming a quit message as per vanilla behaviour.