### PR TITLE
build: resolve cmake processing error on Linux

### DIFF
--- a/prboom2/cmake/FindLibMad.cmake
+++ b/prboom2/cmake/FindLibMad.cmake
@@ -59,13 +59,13 @@ select_dll_configurations(LibMad)
 find_library(
   LibMad_LIBRARY_RELEASE
   NAMES mad
-  PATH_SUFFIXES ../../lib
+  PATH_SUFFIXES ${CMAKE_CURRENT_BINARY_DIR}/../../lib
 )
 
 find_library(
   LibMad_LIBRARY_DEBUG
   NAMES mad
-  PATH_SUFFIXES ../debug/lib
+  PATH_SUFFIXES ${CMAKE_CURRENT_BINARY_DIR}/../debug/lib
 )
 
 include(SelectLibraryConfigurations)


### PR DESCRIPTION
Introduced by commit 959f50eb79af5b1e08b3387d33b5bf91c7c8b530 was this odd build failure:

```
$ cmake . && make dsda-doom-wad
-- Configuring done (1.1s)
-- Generating done (0.0s)
-- Build files have been written to: ~/dsda-doom/prboom2 [ 75%] Built target rdatawad
[100%] Built target dsda-doom-wad
$ make
[  3%] Built target rdatawad
[  4%] Built target dsda-doom-wad
src/CMakeFiles/dsda-doom.dir/build.make:3950: warning: overriding recipe for target 'dsda-doom' src/CMakeFiles/dsda-doom.dir/build.make:3940: warning: ignoring old recipe for target 'dsda-doom'
```

It appears that the path suffix at some points gets a match with /usr as an anchor. Specifying the full build path seems to sidestep the issue.

As the whole PATH_SUFFIX thing seems to be a Windows-centric addition (under Linux it finds the system libmad anyway), please give this a test on that platform.

Could fix #434.