### PR TITLE
OPL: Reset start_music_volume on song restart

### DIFF
--- a/prboom2/src/MUSIC/oplplayer.c
+++ b/prboom2/src/MUSIC/oplplayer.c
@@ -1384,6 +1384,8 @@ static void RestartSong(void)
 
     running_tracks = num_tracks;
 
+    start_music_volume = current_music_volume;
+
     // fix buggy songs that forget to terminate notes held over loop point
     // sdl_mixer does this as well
     for (i=0; i<OPL_NUM_VOICES; ++i)


### PR DESCRIPTION
Might solve this issue: [[doomworld]](https://www.doomworld.com/forum/topic/141111-dsda-doom-v0274-2023-11-18/?do=findComment&comment=2735774)