### PR TITLE
Fix #452 missing sky texture if gameepisode unknown

### DIFF
--- a/prboom2/src/dsda/mapinfo/legacy.c
+++ b/prboom2/src/dsda/mapinfo/legacy.c
@@ -456,21 +456,15 @@ int dsda_LegacySkyTexture(int* sky) {
         *sky = R_TextureNumForName ("SKY2");
   }
   else {
-    switch (gameepisode) {
-      case 1:
-        *sky = R_TextureNumForName ("SKY1");
-        break;
-      case 2:
-        *sky = R_TextureNumForName ("SKY2");
-        break;
-      case 3:
-        *sky = R_TextureNumForName ("SKY3");
-        break;
-      case 4: // Special Edition sky
-        *sky = R_TextureNumForName ("SKY4");
-        break;
-    }
+    // Use sky based on episode number.
+    char skyname[16]; // Enough space even if gameepisode is spurious.
+    snprintf(skyname, sizeof(skyname), "SKY%d", gameepisode);
+    *sky = R_CheckTextureNumForName (skyname);
   }
+
+  // Fallback if no sky was loaded.
+  if (*sky == NO_TEXTURE)
+    *sky = R_TextureNumForName ("SKY1");
 
   return true;
 }


### PR DESCRIPTION
dsda_LegacySkyTexture knows only about epsides 1 through 4, and will use SKY1, SKY2, SKY3, or SKY4 appropriately. But if an unknown episode is encountered, sky is not set at all.

Instead, try to load a SKY# texture matching the episode number, and fall back to SKY1 if not available.

I'm not familiar with all the game extensions that exist, so it's possible this interferes, or perhaps it is doing something that shouldn't be done. But for me this solves the crash and loads the correct sky.