### PR TITLE
Change data directory if running as Flatpak

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -295,8 +295,14 @@ const char *I_DoomExeDir(void)
   static char *base;
   if (!base)        // cache multiple requests
   {
-    char *home = M_getenv("HOME");
-    size_t len = strlen(home);
+    char *home;
+    size_t len;
+    // check if we're in Flatpak
+    if (access("/.flatpak-info", F_OK) == 0)
+      home = M_getenv("XDG_DATA_HOME");
+    else
+      home = M_getenv("HOME");
+    len = strlen(home);
 
     base = Z_Malloc(len + strlen(prboom_dir) + 1);
     strcpy(base, home);


### PR DESCRIPTION
This is part of an attempt I'm making to create a Flatpak port of DSDA-Doom to make it easier to install for more Linux users (see #460). This change has the application check if it is running under Flatpak by checking if the `/.flatpak-info` file exists, and if it does, it changes where the `.dsda-doom` folder is stored to be within the application's personal filesystem. Without this change, the application would need access to all files in the user's home folder.