### PR TITLE
Drop glbsp support

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -814,7 +814,6 @@ void D_StartTitle (void)
 //         - modified to allocate & use new wadfiles array
 void D_AddFile (const char *file, wad_source_t source)
 {
-  char *gwa_filename=NULL;
   int len;
 
   // There can only be one iwad source!
@@ -839,20 +838,6 @@ void D_AddFile (const char *file, wad_source_t source)
     gamemission = pack_nerve;
 
   numwadfiles++;
-  // proff: automatically try to add the gwa files
-  // proff - moved from w_wad.c
-  gwa_filename=AddDefaultExtension(strcpy(Z_Malloc(strlen(file)+5), file), ".wad");
-  if (dsda_HasFileExt(gwa_filename, ".wad"))
-  {
-    char *ext;
-    ext = &gwa_filename[strlen(gwa_filename)-4];
-    ext[1] = 'g'; ext[2] = 'w'; ext[3] = 'a';
-    wadfiles = Z_Realloc(wadfiles, sizeof(*wadfiles)*(numwadfiles+1));
-    wadfiles[numwadfiles].name = gwa_filename;
-    wadfiles[numwadfiles].src = source_pwad; // Ty 08/29/98
-    wadfiles[numwadfiles].handle = 0;
-    numwadfiles++;
-  }
 }
 
 // killough 10/98: support -dehout filename
@@ -1655,10 +1640,6 @@ static void D_DoomMainSetup(void)
     dsda_PrintArgHelp();
     I_SafeExit(0);
   }
-
-  // figgi 09/18/00-- added switch to force classic bsp nodes
-  if (dsda_Flag(dsda_arg_forceoldbsp))
-    forceOldBsp = true;
 
   DoLooseFiles();  // Ty 08/29/98 - handle "loose" files on command line
 

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -351,6 +351,4 @@ extern int monkeys;
 
 extern int HelperThing;          // type of thing to use for helper
 
-extern dboolean forceOldBsp;
-
 #endif

--- a/prboom2/src/dsda/args.c
+++ b/prboom2/src/dsda/args.c
@@ -428,11 +428,6 @@ static arg_config_t arg_config[dsda_arg_count] = {
     "reset gamma and exit",
     arg_null,
   },
-  [dsda_arg_forceoldbsp] = {
-    "-forceoldbsp", NULL, NULL,
-    "force classic bsp nodes",
-    arg_null,
-  },
   [dsda_arg_force_old_zdoom_nodes] = {
     "-force_old_zdoom_nodes", NULL, NULL,
     "force extended (non-gl) zdoom nodes",

--- a/prboom2/src/dsda/args.h
+++ b/prboom2/src/dsda/args.h
@@ -96,7 +96,6 @@ typedef enum {
   dsda_arg_quiet,
   dsda_arg_v,
   dsda_arg_resetgamma,
-  dsda_arg_forceoldbsp,
   dsda_arg_force_old_zdoom_nodes,
   dsda_arg_sigsegv,
   dsda_arg_deathmatch,

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -3200,7 +3200,8 @@ byte *G_WriteOptions(byte *demo_p)
       *demo_p++ = comp[i] != 0;
   }
 
-  *demo_p++ = (compatibility_level >= prboom_2_compatibility) && forceOldBsp; // cph 2002/07/20
+  // unused forceOldBsp
+  *demo_p++ = 0;
 
   //----------------
   // Padding at end
@@ -3292,7 +3293,8 @@ const byte *G_ReadOptions(const byte *demo_p)
         comp[i] = *demo_p++;
     }
 
-    forceOldBsp = *demo_p++; // cph 2002/07/20
+    // unused forceOldBsp
+    demo_p++;
   }
   else  /* defaults for versions <= 2.02 */
   {

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -112,16 +112,10 @@ ssline_t *sslines;
 
 byte     *map_subsectors;
 
-////////////////////////////////////////////////////////////////////////////////////////////
-// figgi 08/21/00 -- constants and globals for glBsp support
-#define GL_VERT_OFFSET  4
-
 typedef enum {
   UNKNOWN_NODES = -1,
   DEFAULT_BSP_NODES,
   DEEP_BSP_V4_NODES,
-  GL_V1_NODES,
-  GL_V2_NODES,
   ZDOOM_XNOD_NODES,
   ZDOOM_ZNOD_NODES,
   ZDOOM_XGLN_NODES,
@@ -135,7 +129,6 @@ typedef enum {
 int firstglvertex = 0;
 static nodes_version_t nodesVersion = DEFAULT_BSP_NODES;
 dboolean use_gl_nodes = false;
-dboolean forceOldBsp = false;
 dboolean has_behavior;
 dboolean udmf_map;
 
@@ -149,20 +142,6 @@ typedef struct
   unsigned short  partner; // corresponding partner seg, or -1 on one-sided walls
 } glseg_t;
 
-// fixed 32 bit gl_vert format v2.0+ (glBsp 1.91)
-typedef struct
-{
-  fixed_t x,y;
-} mapglvertex_t;
-
-enum
-{
-   ML_GL_LABEL=0,  // A separator name, GL_ExMx or GL_MAPxx
-   ML_GL_VERTS,     // Extra Vertices
-   ML_GL_SEGS,     // Segs, from linedefs & minisegs
-   ML_GL_SSECT,    // SubSectors, list of segs
-   ML_GL_NODES     // GL BSP nodes
-};
 ////////////////////////////////////////////////////////////////////////////////////////////
 
 
@@ -244,20 +223,10 @@ typedef struct
   int blockmap;
   int behavior;
 
-  int gl_label;
-  int gl_verts;
-  int gl_segs;
-  int gl_ssect;
-  int gl_nodes;
-
   int znodes;
 } level_components_t;
 
 static level_components_t level_components;
-
-static dboolean P_GLLumpsExist(void) {
-  return level_components.gl_label != LUMP_NOT_FOUND;
-}
 
 // e6y: Smart malloc
 // Used by P_SetupLevel() for smart data loading
@@ -315,29 +284,6 @@ static void P_GetNodesVersion(void)
 {
   nodesVersion = DEFAULT_BSP_NODES;
   use_gl_nodes = false;
-
-  if (P_GLLumpsExist() &&
-      (mbf21 || forceOldBsp == false) &&
-      (compatibility_level >= prboom_2_compatibility))
-  {
-    if (!CheckForIdentifier(level_components.gl_verts, "gNd", 3))
-    {
-      use_gl_nodes = true;
-      nodesVersion = GL_V1_NODES;
-      lprintf(LO_DEBUG, "P_GetNodesVersion: using v1 gl nodes\n");
-    }
-    else if (CheckForIdentifier(level_components.gl_verts, "gNd2", 4) &&
-             !CheckForIdentifier(level_components.gl_segs, "gNd3", 4))
-    {
-      use_gl_nodes = true;
-      nodesVersion = GL_V2_NODES;
-      lprintf(LO_DEBUG, "P_GetNodesVersion: using v2 gl nodes\n");
-    }
-    else
-    {
-      lprintf(LO_DEBUG, "P_GetNodesVersion: ignoring unsupported gl nodes version");
-    }
-  }
 
   if (nodesVersion == DEFAULT_BSP_NODES)
   {
@@ -417,9 +363,8 @@ static void P_GetNodesVersion(void)
 // figgi -- FIXME: Automap showes wrong zoom boundaries when starting game
 //           when P_LoadVertexes is used with classic BSP nodes.
 
-static void P_LoadVertexes(int lump, int gllump)
+static void P_LoadVertexes(int lump)
 {
-  const byte         *gldata;
   int                 i;
   const mapvertex_t*  ml;
 
@@ -428,44 +373,8 @@ static void P_LoadVertexes(int lump, int gllump)
   numvertexes   = W_LumpLength(lump) / sizeof(mapvertex_t);
   firstglvertex = numvertexes;
 
-  if (use_gl_nodes)
-  {
-    gldata = W_LumpByNum(gllump);
-
-    if (nodesVersion == GL_V2_NODES) // 32 bit GL_VERT format (16.16 fixed)
-    {
-      const mapglvertex_t*  mgl;
-
-      numvertexes += (W_LumpLength(gllump) - GL_VERT_OFFSET)/sizeof(mapglvertex_t);
-      vertexes = malloc_IfSameLevel(vertexes, numvertexes * sizeof(vertex_t));
-      mgl      = (const mapglvertex_t *) (gldata + GL_VERT_OFFSET);
-
-      for (i = firstglvertex; i < numvertexes; i++)
-      {
-        vertexes[i].x = mgl->x;
-        vertexes[i].y = mgl->y;
-        mgl++;
-      }
-    }
-    else
-    {
-      numvertexes += W_LumpLength(gllump)/sizeof(mapvertex_t);
-      vertexes = malloc_IfSameLevel(vertexes, numvertexes * sizeof(vertex_t));
-      ml       = (const mapvertex_t *)gldata;
-
-      for (i = firstglvertex; i < numvertexes; i++)
-      {
-        vertexes[i].x = LittleShort(ml->x)<<FRACBITS;
-        vertexes[i].y = LittleShort(ml->y)<<FRACBITS;
-        ml++;
-      }
-    }
-  }
-  else
-  {
-    // Allocate zone memory for buffer.
-    vertexes = calloc_IfSameLevel(vertexes, numvertexes, sizeof(vertex_t));
-  }
+  // Allocate zone memory for buffer.
+  vertexes = calloc_IfSameLevel(vertexes, numvertexes, sizeof(vertex_t));
 
   // Load data into cache.
   // cph 2006/07/29 - cast to mapvertex_t here, making the loop below much neater
@@ -481,7 +390,7 @@ static void P_LoadVertexes(int lump, int gllump)
   }
 }
 
-static void P_LoadUDMFVertexes(int lump, int gllump)
+static void P_LoadUDMFVertexes(int lump)
 {
   int i;
 
@@ -786,64 +695,6 @@ static void P_LoadSegs_V4(int lump)
     // with certain nodebuilders. Fixes among others, line 20365
     // of DV.wad, map 5
     li->offset = GetOffset(li->v1, (ml->side ? ldef->v2 : ldef->v1));
-  }
-}
-
-
-/*******************************************
- * Name     : P_LoadGLSegs           *
- * created  : 08/13/00             *
- * modified : 09/18/00, adapted for PrBoom *
- * author   : figgi              *
- * what   : support for gl nodes       *
- *******************************************/
-static void P_LoadGLSegs(int lump)
-{
-  int     i;
-  const glseg_t   *ml;
-  line_t    *ldef;
-
-  numsegs = W_LumpLength(lump) / sizeof(glseg_t);
-  segs = malloc_IfSameLevel(segs, numsegs * sizeof(seg_t));
-  memset(segs, 0, numsegs * sizeof(seg_t));
-  ml = (const glseg_t*)W_LumpByNum(lump);
-
-  if ((!ml) || (!numsegs))
-    I_Error("P_LoadGLSegs: no glsegs in level");
-
-  for(i = 0; i < numsegs; i++)
-  {             // check for gl-vertices
-    segs[i].v1 = &vertexes[checkGLVertex(LittleShort(ml->v1))];
-    segs[i].v2 = &vertexes[checkGLVertex(LittleShort(ml->v2))];
-
-    if(ml->linedef != (unsigned short)-1) // skip minisegs
-    {
-      ldef = &lines[ml->linedef];
-      segs[i].linedef = ldef;
-      segs[i].angle = R_PointToAngle2(segs[i].v1->x,segs[i].v1->y,segs[i].v2->x,segs[i].v2->y);
-
-      segs[i].sidedef = &sides[ldef->sidenum[ml->side]];
-      segs[i].frontsector = sides[ldef->sidenum[ml->side]].sector;
-      if (ldef->flags & ML_TWOSIDED)
-        segs[i].backsector = sides[ldef->sidenum[ml->side^1]].sector;
-      else
-        segs[i].backsector = 0;
-
-      if (ml->side)
-        segs[i].offset = GetOffset(segs[i].v1, ldef->v2);
-      else
-        segs[i].offset = GetOffset(segs[i].v1, ldef->v1);
-    }
-    else
-    {
-      segs[i].angle  = 0;
-      segs[i].offset  = 0;
-      segs[i].linedef = NULL;
-      segs[i].sidedef = NULL;
-      segs[i].frontsector = NULL;
-      segs[i].backsector  = NULL;
-    }
-    ml++;
   }
 }
 
@@ -3553,7 +3404,7 @@ static void P_UpdateMapFormat()
   }
 }
 
-static void P_UpdateLevelComponents(int lumpnum, int gl_lumpnum) {
+static void P_UpdateLevelComponents(int lumpnum) {
   level_components.label = lumpnum;
   level_components.things = lumpnum + ML_THINGS;
   level_components.linedefs = lumpnum + ML_LINEDEFS;
@@ -3567,23 +3418,6 @@ static void P_UpdateLevelComponents(int lumpnum, int gl_lumpnum) {
   level_components.blockmap = lumpnum + ML_BLOCKMAP;
   level_components.behavior = lumpnum + ML_BEHAVIOR;
 
-  if (gl_lumpnum > lumpnum)
-  {
-    level_components.gl_label = gl_lumpnum;
-    level_components.gl_verts = gl_lumpnum + ML_GL_VERTS;
-    level_components.gl_segs = gl_lumpnum + ML_GL_SEGS;
-    level_components.gl_ssect = gl_lumpnum + ML_GL_SSECT;
-    level_components.gl_nodes = gl_lumpnum + ML_GL_NODES;
-  }
-  else
-  {
-    level_components.gl_label = LUMP_NOT_FOUND;
-    level_components.gl_verts = LUMP_NOT_FOUND;
-    level_components.gl_segs = LUMP_NOT_FOUND;
-    level_components.gl_ssect = LUMP_NOT_FOUND;
-    level_components.gl_nodes = LUMP_NOT_FOUND;
-  }
-
   level_components.znodes = LUMP_NOT_FOUND;
 
   P_VerifyLevelComponents(lumpnum);
@@ -3591,7 +3425,7 @@ static void P_UpdateLevelComponents(int lumpnum, int gl_lumpnum) {
   has_behavior = P_CheckForBehavior(lumpnum);
 }
 
-static void P_UpdateUDMFLevelComponents(int lumpnum, int gl_lumpnum)
+static void P_UpdateUDMFLevelComponents(int lumpnum)
 {
   int i;
 
@@ -3607,11 +3441,6 @@ static void P_UpdateUDMFLevelComponents(int lumpnum, int gl_lumpnum)
   level_components.reject = LUMP_NOT_FOUND;
   level_components.blockmap = LUMP_NOT_FOUND;
   level_components.behavior = LUMP_NOT_FOUND;
-  level_components.gl_label = LUMP_NOT_FOUND;
-  level_components.gl_verts = LUMP_NOT_FOUND;
-  level_components.gl_segs = LUMP_NOT_FOUND;
-  level_components.gl_ssect = LUMP_NOT_FOUND;
-  level_components.gl_nodes = LUMP_NOT_FOUND;
   level_components.znodes = LUMP_NOT_FOUND;
 
   for (i = lumpnum + ML_TEXTMAP + 1; ; ++i)
@@ -3673,11 +3502,11 @@ void P_UpdateMapLoader(int lumpnum)
 // Checking for presence of necessary lumps
 //
 
-void P_CheckLevelWadStructure(int lumpnum, int gl_lumpnum)
+void P_CheckLevelWadStructure(int lumpnum)
 {
   P_UpdateMapLoader(lumpnum);
 
-  map_loader.update_level_components(lumpnum, gl_lumpnum);
+  map_loader.update_level_components(lumpnum);
 
   P_UpdateMapFormat();
 }
@@ -3795,9 +3624,6 @@ void P_SetupLevel(int episode, int map, int playermask, int skill)
   char  lumpname[9];
   int   lumpnum;
 
-  char  gl_lumpname[9];
-  int   gl_lumpnum;
-
   //e6y
   totallive = 0;
 
@@ -3835,21 +3661,10 @@ void P_SetupLevel(int episode, int map, int playermask, int skill)
 
   P_InitThinkers();
 
-  if (strlen(lumpname) < 6)
-  {
-    snprintf(gl_lumpname, sizeof(gl_lumpname), "GL_%s", lumpname);
-    gl_lumpnum = W_CheckNumForName(gl_lumpname); // figgi
-  }
-  else
-  {
-    gl_lumpname[0] = '\0';
-    gl_lumpnum = LUMP_NOT_FOUND;
-  }
-
   // e6y
   // Refuse to load a map with incomplete pwad structure.
   // Avoid segfaults on levels without nodes.
-  P_CheckLevelWadStructure(lumpnum, gl_lumpnum);
+  P_CheckLevelWadStructure(lumpnum);
 
   dsda_ApplyLevelCompatibility(lumpnum);
 
@@ -3897,7 +3712,7 @@ void P_SetupLevel(int episode, int map, int playermask, int skill)
 
   dsda_ResetHealthGroups();
 
-  map_loader.load_vertexes(level_components.vertexes, level_components.gl_verts);
+  map_loader.load_vertexes(level_components.vertexes);
   map_loader.load_sectors(level_components.sectors);
   map_loader.allocate_sidedefs(level_components.sidedefs);
   map_loader.load_linedefs(level_components.linedefs);
@@ -3923,14 +3738,6 @@ void P_SetupLevel(int episode, int map, int playermask, int skill)
 
   switch (nodesVersion)
   {
-    case GL_V1_NODES:
-    case GL_V2_NODES:
-      P_LoadSubsectors(level_components.gl_ssect);
-      P_LoadNodes(level_components.gl_nodes);
-      P_LoadGLSegs(level_components.gl_segs);
-
-      break;
-
     case ZDOOM_XNOD_NODES:
     case ZDOOM_ZNOD_NODES:
       P_LoadZNodes(level_components.nodes, 0);

--- a/prboom2/src/p_setup.h
+++ b/prboom2/src/p_setup.h
@@ -70,13 +70,13 @@ void P_RestoreOriginalBlockMap(void);
 
 typedef struct
 {
-  void (*load_vertexes)(int lump, int gllump);
+  void (*load_vertexes)(int lump);
   void (*load_sectors)(int lump);
   void (*load_things)(int lump);
   void (*load_linedefs)(int lump);
   void (*allocate_sidedefs)(int lump);
   void (*load_sidedefs)(int lump);
-  void (*update_level_components)(int lumpnum, int gl_lumpnum);
+  void (*update_level_components)(int lumpnum);
   void (*po_load_things)(int lump);
 } map_loader_t;
 

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -55,6 +55,8 @@
 #include "lprintf.h"
 #include "e6y.h"
 
+#include "dsda/utility.h"
+
 //
 // GLOBALS
 //
@@ -151,14 +153,11 @@ static void W_AddFile(wadfile_info_t *wadfile)
 
   wadfile->handle = M_OpenRB(wadfile->name);
   if (wadfile->handle == -1)
-    {
-      if (  strlen(wadfile->name)<=4 ||      // add error check -- killough
-	         (strcasecmp(wadfile->name+strlen(wadfile->name)-4 , ".lmp" ) &&
-	          strcasecmp(wadfile->name+strlen(wadfile->name)-4 , ".gwa" ) )
-         )
-	I_Error("W_AddFile: couldn't open %s",wadfile->name);
-      return;
-    }
+  {
+    if (!dsda_HasFileExt(wadfile->name, ".lmp"))
+      I_Error("W_AddFile: couldn't open %s",wadfile->name);
+    return;
+  }
 
   //jff 8/3/98 use logical output routine
   lprintf (LO_INFO," adding %s\n",wadfile->name);
@@ -178,12 +177,7 @@ static void W_AddFile(wadfile_info_t *wadfile)
     }
   }
 
-  if (  strlen(wadfile->name)<=4 ||
-	      (
-          strcasecmp(wadfile->name+strlen(wadfile->name)-4,".wad") &&
-	        strcasecmp(wadfile->name+strlen(wadfile->name)-4,".gwa")
-        )
-     )
+  if (!dsda_HasFileExt(wadfile->name, ".wad"))
     {
       // single lump file
       fileinfo = &singleinfo;


### PR DESCRIPTION
This legacy format was used very rarely, and wasn't used when recording demos until the post-mbf compatibility tweaks were inherited by mbf21. Can roll back if an issue is found, but this is just some cleanup and also gets around the "it doesn't support map numbers over 99" problem.