### PR TITLE
Fix player sounds being cut off by item pickups in vanilla complevels

### DIFF
--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -254,8 +254,10 @@ dboolean P_GiveWeapon(player_t *player, weapontype_t weapon, dboolean dropped)
       /* cph 20028/10 - for old-school DM addicts, allow old behavior
        * where only consoleplayer's pickup sounds are heard */
       // displayplayer, not consoleplayer, for viewing multiplayer demos
-      if (!comp[comp_sound] || player == &players[displayplayer])
+      if (!comp[comp_sound])
         S_StartSound (player->mo, sfx_wpnup|PICKUP_SOUND); // killough 4/25/98
+      else if (player == &players[displayplayer])
+        S_StartVoidSound (sfx_wpnup|PICKUP_SOUND);
       return false;
     }
 
@@ -799,8 +801,10 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
   /* cph 20028/10 - for old-school DM addicts, allow old behavior
    * where only consoleplayer's pickup sounds are heard */
   // displayplayer, not consoleplayer, for viewing multiplayer demos
-  if (!comp[comp_sound] || player == &players[displayplayer])
+  if (!comp[comp_sound])
     S_StartSound (player->mo, sound | PICKUP_SOUND);   // killough 4/25/98
+  else if (player == &players[displayplayer])
+    S_StartVoidSound (sound | PICKUP_SOUND);
 }
 
 //


### PR DESCRIPTION
This is a different fix to the same problem that https://github.com/coelckers/prboom-plus/pull/330 was trying to solve.

When picking up an item, the vanilla code calls `S_StartSound` with a `NULL` origin, so the pickup sound does not cut off player sounds, which use `player->mo` as the origin. Boom changes the origin to the player and makes weapon pickups audible to other players, but also changes `s_sound.c` to distinguish between pickup sounds and non-pickup sounds so they don't cut each other off. `comp_sound` disables the pickup sound logic in `s_sound.c`, but did not change the sound origin back to `NULL` until this commit.