### PR TITLE
Upgrade free look functionality

### DIFF
--- a/docs/mapinfo.md
+++ b/docs/mapinfo.md
@@ -72,6 +72,8 @@ Appends properties to the default map.
 | **AllowRespawn** | Allow the player to respawn in a single-player game without resetting the map. |
 | **NoJump** | Disable jumping (this is the default). |
 | **AllowJump** | Enable jumping. |
+| **NoFreelook** | Disable freelook and manual vertical aiming (this is the default). |
+| **AllowFreelook** | Enable freelook and manual vertical aiming. |
 | **CheckSwitchRange** | Check vertical reachability of switches. |
 | **NoCheckSwitchRange** | Do not check vertical reachability of switches (this is the default). |
 | **ResetHealth** | Reset player health when entering the map. |

--- a/docs/mapinfo.md
+++ b/docs/mapinfo.md
@@ -81,6 +81,10 @@ Appends properties to the default map.
 | :duck: **Passover** | Turns off infinite thing height (objects can move over one another). |
 | :duck: **NoGravity** | Turns off gravity ("Gravity = 0" is not cross-port compatible). |
 | :duck: **ColorMap = "\<Lump\>"** | The default colormap for the map (if not **COLORMAP**). |
+| :duck: **NoVerticalExplosionThrust** | Turns off vertical explosion thrust. This is the default. |
+| :duck: **VerticalExplosionThrust** | Turns on vertical explosion thrust. |
+| :duck: **ExplodeIn2D** | Explosion damage is based on x and y coordinates. This is the default. |
+| :duck: **ExplodeIn3D** | Explosion damage is based on x, y, and z coordinates. |
 
 ### Cluster
 

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -11,6 +11,8 @@ set(COMMON_SRC
     doomtype.h
     dsda.c
     dsda.h
+    dsda/aim.c
+    dsda/aim.h
     dsda/ambient.cpp
     dsda/ambient.h
     dsda/analysis.c

--- a/prboom2/src/d_player.h
+++ b/prboom2/src/d_player.h
@@ -317,7 +317,6 @@ typedef struct
 
 } wbstartstruct_t;
 
-angle_t P_PlayerPitch(player_t* player);
 fixed_t P_PlayerSpeed(player_t* player);
 
 #endif

--- a/prboom2/src/d_ticcmd.h
+++ b/prboom2/src/d_ticcmd.h
@@ -40,6 +40,7 @@ typedef struct {
   byte actions;
   byte save_slot;
   byte load_slot;
+  signed short look;
 } excmd_t;
 
 /* The data sampled per tick (single player)

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -122,7 +122,6 @@ enum {
   comperr_passuse,
   comperr_hangsolid,
   comperr_blockmap,
-  comperr_freeaim,
 
   COMPERR_NUM
 };

--- a/prboom2/src/dsda/aim.c
+++ b/prboom2/src/dsda/aim.c
@@ -56,7 +56,7 @@ void dsda_PlayerAim(mobj_t* source, angle_t angle, aim_t* aim, uint64_t target_m
   if (dsda_FreeAim())
   {
     aim->slope = finetangent[(ANG90 - source->pitch) >> ANGLETOFINESHIFT];
-    aim->z_offset = raven ? aim->slope : 0; // TODO: use aim->slope in doom?
+    aim->z_offset = 0;
   }
   else
   {

--- a/prboom2/src/dsda/aim.c
+++ b/prboom2/src/dsda/aim.c
@@ -1,0 +1,88 @@
+//
+// Copyright(C) 2024 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Aim
+//
+
+#include "p_map.h"
+#include "tables.h"
+
+#include "dsda/excmd.h"
+
+#include "aim.h"
+
+angle_t dsda_PlayerPitch(player_t* player)
+{
+  return dsda_FreeAim() ? player->mo->pitch : -(angle_t)(player->lookdir * ANG1 / M_PI);
+}
+
+fixed_t dsda_PlayerSlope(player_t* player)
+{
+  return dsda_FreeAim() ? finetangent[(ANG90 - player->mo->pitch) >> ANGLETOFINESHIFT] :
+         raven ? ((player->lookdir) << FRACBITS) / 173 :
+         0;
+}
+
+int dsda_PitchToLookDir(angle_t pitch)
+{
+  return -(int) ((((uint64_t) pitch * FIXED_PI) >> FRACBITS) / ANG1);
+}
+
+angle_t dsda_LookDirToPitch(int lookdir)
+{
+  return (angle_t) -FixedDiv(lookdir * ANG1, FIXED_PI);
+}
+
+int dsda_PlayerLookDir(player_t* player)
+{
+  return dsda_FreeAim() ? dsda_PitchToLookDir(player->mo->pitch) : player->lookdir;
+}
+
+void dsda_PlayerAim(mobj_t* source, angle_t angle, aim_t* aim, uint64_t target_mask)
+{
+  aim->angle = angle;
+
+  if (dsda_FreeAim())
+  {
+    aim->slope = finetangent[(ANG90 - source->pitch) >> ANGLETOFINESHIFT];
+    aim->z_offset = raven ? aim->slope : 0; // TODO: use aim->slope in doom?
+  }
+  else
+  {
+    do
+    {
+      aim->slope = P_AimLineAttack(source, aim->angle, 16 * 64 * FRACUNIT, target_mask);
+
+      if (!linetarget)
+      {
+        aim->angle += 1 << 26;
+        aim->slope = P_AimLineAttack(source, aim->angle, 16 * 64 * FRACUNIT, target_mask);
+      }
+
+      if (!linetarget)
+      {
+        aim->angle -= 2 << 26;
+        aim->slope = P_AimLineAttack(source, aim->angle, 16 * 64 * FRACUNIT, target_mask);
+      }
+
+      if (!linetarget) {
+        aim->angle = angle;
+        aim->slope = raven ? ((source->player->lookdir) << FRACBITS) / 173 : 0;
+      }
+    }
+    while (target_mask && (target_mask = 0, !linetarget));  // killough 8/2/98
+
+    aim->z_offset = raven ? ((source->player->lookdir) << FRACBITS) / 173 : 0;
+  }
+}

--- a/prboom2/src/dsda/aim.h
+++ b/prboom2/src/dsda/aim.h
@@ -1,0 +1,36 @@
+//
+// Copyright(C) 2024 by Ryan Krafnick
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//	DSDA Aim
+//
+
+#ifndef __DSDA_AIM__
+#define __DSDA_AIM__
+
+#include "d_player.h"
+
+typedef struct {
+  angle_t angle;
+  fixed_t slope;
+  fixed_t z_offset;
+} aim_t;
+
+angle_t dsda_PlayerPitch(player_t* player);
+fixed_t dsda_PlayerSlope(player_t* player);
+int dsda_PitchToLookDir(angle_t pitch);
+angle_t dsda_LookDirToPitch(int lookdir);
+int dsda_PlayerLookDir(player_t* player);
+void dsda_PlayerAim(mobj_t* source, angle_t angle, aim_t* aim, uint64_t target_mask);
+
+#endif

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -150,9 +150,6 @@ void dsda_TrackConfigFeatures(void) {
   if (dsda_IntConfig(dsda_config_coordinate_display) || dsda_IntConfig(dsda_config_map_coordinates))
     dsda_TrackFeature(uf_coordinates);
 
-  if (dsda_IntConfig(dsda_config_freelook))
-    dsda_TrackFeature(uf_mouselook);
-
   if (dsda_IntConfig(dsda_config_weapon_attack_alignment))
     dsda_TrackFeature(uf_weaponalignment);
 

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -476,10 +476,6 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "comperr_blockmap", dsda_config_comperr_blockmap,
     CONF_BOOL(0), &default_comperr[comperr_blockmap]
   },
-  [dsda_config_comperr_freeaim] = {
-    "comperr_freeaim", dsda_config_comperr_freeaim,
-    CONF_BOOL(0), &default_comperr[comperr_freeaim]
-  },
   [dsda_config_mapcolor_back] = {
     "mapcolor_back", dsda_config_mapcolor_back,
     CONF_COLOR(247), &mapcolor_back

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -322,7 +322,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_freelook] = {
     "allow_freelook", dsda_config_freelook,
-    CONF_BOOL(0), NULL, STRICT_INT(0), M_ChangeSkyMode
+    CONF_BOOL(0), NULL, NOT_STRICT, M_ChangeSkyMode
   },
   [dsda_config_autorun] = {
     "autorun", dsda_config_autorun,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -89,7 +89,6 @@ typedef enum {
   dsda_config_comperr_passuse,
   dsda_config_comperr_hangsolid,
   dsda_config_comperr_blockmap,
-  dsda_config_comperr_freeaim,
   dsda_config_mapcolor_back,
   dsda_config_mapcolor_grid,
   dsda_config_mapcolor_wall,

--- a/prboom2/src/dsda/destructible.c
+++ b/prboom2/src/dsda/destructible.c
@@ -23,10 +23,7 @@
 
 #include "dsda/utility.h"
 
-extern mobj_t* bombsource;
-extern mobj_t* bombspot;
-extern int bombdamage;
-extern int bombdistance;
+extern bomb_t bomb;
 
 typedef struct {
   int health;
@@ -133,27 +130,27 @@ static dboolean dsda_RadiusAttackLine(line_t *line) {
   if (!line->health)
     return true;
 
-  bombside = P_PointOnLineSide(bombspot->x, bombspot->y, line);
+  bombside = P_PointOnLineSide(bomb.spot->x, bomb.spot->y, line);
   if (line->sidenum[bombside] == NO_INDEX)
     return true;
 
   dist = dsda_FixedDistancePointToLine(line->v1->x, line->v1->y,
                                        line->v2->x, line->v2->y,
-                                       bombspot->x, bombspot->y,
+                                       bomb.spot->x, bomb.spot->y,
                                        &target.x, &target.y);
   dist = (dist >> FRACBITS);
-  if (dist >= bombdistance)
+  if (dist >= bomb.distance)
     return true;
 
   // The target is currently "on the line"
   // Move it towards the bomb slightly to make sure it's on the right side
-  if (bombspot->x - target.x > fudge)
+  if (bomb.spot->x - target.x > fudge)
     target.x += fudge;
-  if (target.x - bombspot->x > fudge)
+  if (target.x - bomb.spot->x > fudge)
     target.x -= fudge;
-  if (bombspot->y - target.y > fudge)
+  if (bomb.spot->y - target.y > fudge)
     target.y += fudge;
-  if (target.y - bombspot->y > fudge)
+  if (target.y - bomb.spot->y > fudge)
     target.y -= fudge;
 
   // P_CheckSight needs subsector
@@ -172,7 +169,7 @@ static dboolean dsda_RadiusAttackLine(line_t *line) {
       target.z = frontsector->floorheight;
       target.height = frontsector->ceilingheight - frontsector->floorheight;
 
-      sighted = P_CheckSight(&target, bombspot);
+      sighted = P_CheckSight(&target, bomb.spot);
     }
   }
   else {
@@ -187,14 +184,14 @@ static dboolean dsda_RadiusAttackLine(line_t *line) {
       target.z = back_top;
       target.height = front_top - back_top;
 
-      sighted = P_CheckSight(&target, bombspot);
+      sighted = P_CheckSight(&target, bomb.spot);
     }
 
     if (!sighted && front_bottom < back_bottom) {
       target.z = front_bottom;
       target.height = back_bottom - front_bottom;
 
-      sighted = P_CheckSight(&target, bombspot);
+      sighted = P_CheckSight(&target, bomb.spot);
     }
   }
 
@@ -203,7 +200,7 @@ static dboolean dsda_RadiusAttackLine(line_t *line) {
 
     damage = P_SplashDamage(dist);
 
-    dsda_DamageLinedef(line, bombsource, damage);
+    dsda_DamageLinedef(line, bomb.source, damage);
   }
 
   return true;

--- a/prboom2/src/dsda/excmd.c
+++ b/prboom2/src/dsda/excmd.c
@@ -83,6 +83,13 @@ void dsda_ReadExCmd(ticcmd_t* cmd, const byte** p) {
   if (cmd->ex.actions & XC_LOAD)
     cmd->ex.load_slot = *demo_p++;
 
+  if (cmd->ex.actions & XC_LOOK) {
+    signed short lowbyte = *demo_p++;
+    cmd->ex.look = ((signed short) (*demo_p++) << 8) + lowbyte;
+  }
+  else
+    cmd->ex.look = 0;
+
   *p = demo_p;
 }
 
@@ -96,6 +103,11 @@ void dsda_WriteExCmd(char** p, ticcmd_t* cmd) {
     *demo_p++ = cmd->ex.save_slot;
   if (cmd->ex.actions & XC_LOAD)
     *demo_p++ = cmd->ex.load_slot;
+
+  if (cmd->ex.actions & XC_LOOK) {
+    *demo_p++ = cmd->ex.look & 0xff;
+    *demo_p++ = (cmd->ex.look >> 8) & 0xff;
+  }
 
   *p = demo_p;
 }

--- a/prboom2/src/dsda/excmd.c
+++ b/prboom2/src/dsda/excmd.c
@@ -63,6 +63,12 @@ dboolean dsda_AllowJumping(void) {
          || dsda_AllowCasualExCmdFeatures();
 }
 
+dboolean dsda_AllowFreeLook(void) {
+  return (allow_incompatibility && dsda_IntConfig(dsda_config_freelook))
+         || map_info.flags & MI_ALLOW_FREE_LOOK
+         || dsda_AllowCasualExCmdFeatures();
+}
+
 void dsda_ReadExCmd(ticcmd_t* cmd, const byte** p) {
   const byte* demo_p = *p;
 
@@ -104,6 +110,11 @@ void dsda_PopExCmdQueue(ticcmd_t* cmd) {
 
 void dsda_QueueExCmdJump(void) {
   excmd_queue.actions |= XC_JUMP;
+}
+
+void dsda_QueueExCmdLook(short look) {
+  excmd_queue.actions |= XC_LOOK;
+  excmd_queue.look = look;
 }
 
 void dsda_QueueExCmdSave(int slot) {

--- a/prboom2/src/dsda/excmd.c
+++ b/prboom2/src/dsda/excmd.c
@@ -63,10 +63,13 @@ dboolean dsda_AllowJumping(void) {
          || dsda_AllowCasualExCmdFeatures();
 }
 
-dboolean dsda_AllowFreeLook(void) {
+dboolean dsda_FreeAim(void) {
   return (allow_incompatibility && dsda_IntConfig(dsda_config_freelook))
-         || map_info.flags & MI_ALLOW_FREE_LOOK
-         || dsda_AllowCasualExCmdFeatures();
+         || map_info.flags & MI_ALLOW_FREE_LOOK;
+}
+
+dboolean dsda_AllowFreeLook(void) {
+  return dsda_FreeAim() || dsda_AllowCasualExCmdFeatures();
 }
 
 void dsda_ReadExCmd(ticcmd_t* cmd, const byte** p) {

--- a/prboom2/src/dsda/excmd.h
+++ b/prboom2/src/dsda/excmd.h
@@ -37,6 +37,7 @@ void dsda_EnableCasualExCmdFeatures(void);
 dboolean dsda_AllowCasualExCmdFeatures(void);
 dboolean dsda_AllowJumping(void);
 dboolean dsda_AllowFreeLook(void);
+dboolean dsda_FreeAim(void);
 void dsda_ReadExCmd(ticcmd_t* cmd, const byte** p);
 void dsda_WriteExCmd(char** p, ticcmd_t* cmd);
 void dsda_ResetExCmdQueue(void);

--- a/prboom2/src/dsda/excmd.h
+++ b/prboom2/src/dsda/excmd.h
@@ -25,6 +25,9 @@
 #define XC_LOAD   0x04
 #define XC_GOD    0x08
 #define XC_NOCLIP 0x10
+#define XC_LOOK   0x20
+
+#define XC_LOOK_RESET -32768
 
 void dsda_EnableExCmd(void);
 void dsda_DisableExCmd(void);
@@ -33,11 +36,13 @@ dboolean dsda_ExCmdDemo(void);
 void dsda_EnableCasualExCmdFeatures(void);
 dboolean dsda_AllowCasualExCmdFeatures(void);
 dboolean dsda_AllowJumping(void);
+dboolean dsda_AllowFreeLook(void);
 void dsda_ReadExCmd(ticcmd_t* cmd, const byte** p);
 void dsda_WriteExCmd(char** p, ticcmd_t* cmd);
 void dsda_ResetExCmdQueue(void);
 void dsda_PopExCmdQueue(ticcmd_t* cmd);
 void dsda_QueueExCmdJump(void);
+void dsda_QueueExCmdLook(short look);
 void dsda_QueueExCmdSave(int slot);
 void dsda_QueueExCmdLoad(int slot);
 void dsda_QueueExCmdGod(void);

--- a/prboom2/src/dsda/mapinfo.h
+++ b/prboom2/src/dsda/mapinfo.h
@@ -39,6 +39,7 @@
 #define MI_FILTER_STARTS                  0x00000020ul
 #define MI_ALLOW_RESPAWN                  0x00000040ul
 #define MI_ALLOW_JUMP                     0x00000080ul
+#define MI_ALLOW_FREE_LOOK                0x00000100ul
 #define MI_CHECK_SWITCH_RANGE             0x00000200ul
 #define MI_RESET_HEALTH                   0x00000400ul
 #define MI_RESET_INVENTORY                0x00000800ul

--- a/prboom2/src/dsda/mapinfo.h
+++ b/prboom2/src/dsda/mapinfo.h
@@ -43,6 +43,8 @@
 #define MI_RESET_HEALTH                   0x00000400ul
 #define MI_RESET_INVENTORY                0x00000800ul
 #define MI_USE_PLAYER_START_Z             0x00001000ul
+#define MI_VERTICAL_EXPLOSION_THRUST      0x00002000ul
+#define MI_EXPLODE_IN_3D                  0x00004000ul
 #define MI_SHOW_AUTHOR                    0x00008000ul
 #define MI_PASSOVER                       0x00010000ul
 #define MI_EVEN_LIGHTING                  0x00020000ul

--- a/prboom2/src/dsda/mapinfo/doom/parser.cpp
+++ b/prboom2/src/dsda/mapinfo/doom/parser.cpp
@@ -456,6 +456,18 @@ static void dsda_ParseDoomMapInfoMapBlock(Scanner &scanner, doom_mapinfo_map_t &
     else if (scanner.StringMatch("UsePlayerStartZ")) {
       map.flags |= DMI_USE_PLAYER_START_Z;
     }
+    else if (scanner.StringMatch("NoVerticalExplosionThrust")) {
+      map.flags &= ~DMI_VERTICAL_EXPLOSION_THRUST;
+    }
+    else if (scanner.StringMatch("VerticalExplosionThrust")) {
+      map.flags |= DMI_VERTICAL_EXPLOSION_THRUST;
+    }
+    else if (scanner.StringMatch("ExplodeIn2D")) {
+      map.flags &= ~DMI_EXPLODE_IN_3D;
+    }
+    else if (scanner.StringMatch("ExplodeIn3D")) {
+      map.flags |= DMI_EXPLODE_IN_3D;
+    }
     else if (scanner.StringMatch("Author")) {
       SCAN_STRING(map.author);
     }

--- a/prboom2/src/dsda/mapinfo/doom/parser.cpp
+++ b/prboom2/src/dsda/mapinfo/doom/parser.cpp
@@ -432,6 +432,12 @@ static void dsda_ParseDoomMapInfoMapBlock(Scanner &scanner, doom_mapinfo_map_t &
     else if (scanner.StringMatch("AllowJump")) {
       map.flags |= DMI_ALLOW_JUMP;
     }
+    else if (scanner.StringMatch("NoFreelook")) {
+      map.flags &= ~DMI_ALLOW_FREE_LOOK;
+    }
+    else if (scanner.StringMatch("AllowFreelook")) {
+      map.flags |= DMI_ALLOW_FREE_LOOK;
+    }
     else if (scanner.StringMatch("NoCheckSwitchRange")) {
       map.flags &= ~DMI_CHECK_SWITCH_RANGE;
     }

--- a/prboom2/src/dsda/mapinfo/doom/parser.h
+++ b/prboom2/src/dsda/mapinfo/doom/parser.h
@@ -62,6 +62,8 @@ typedef struct {
 #define DMI_RESET_HEALTH                   0x00000400ul
 #define DMI_RESET_INVENTORY                0x00000800ul
 #define DMI_USE_PLAYER_START_Z             0x00001000ul
+#define DMI_VERTICAL_EXPLOSION_THRUST      0x00002000ul
+#define DMI_EXPLODE_IN_3D                  0x00004000ul
 #define DMI_SHOW_AUTHOR                    0x00008000ul
 #define DMI_PASSOVER                       0x00010000ul
 #define DMI_EVEN_LIGHTING                  0x00020000ul

--- a/prboom2/src/dsda/mapinfo/doom/parser.h
+++ b/prboom2/src/dsda/mapinfo/doom/parser.h
@@ -58,6 +58,7 @@ typedef struct {
 #define DMI_FILTER_STARTS                  0x00000020ul
 #define DMI_ALLOW_RESPAWN                  0x00000040ul
 #define DMI_ALLOW_JUMP                     0x00000080ul
+#define DMI_ALLOW_FREE_LOOK                0x00000100ul
 #define DMI_CHECK_SWITCH_RANGE             0x00000200ul
 #define DMI_RESET_HEALTH                   0x00000400ul
 #define DMI_RESET_INVENTORY                0x00000800ul

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -268,24 +268,8 @@ void M_ChangeSkyMode(void)
     gl_drawskys = gl_skymode;
 }
 
-static int upViewPitchLimit;
-static int downViewPitchLimit;
-
-void M_ChangeMaxViewPitch(void)
-{
-  if (raven || !V_IsOpenGLMode())
-  {
-    upViewPitchLimit = (int) raven_angle_up_limit;
-    downViewPitchLimit = (int) raven_angle_down_limit;
-  }
-  else
-  {
-    upViewPitchLimit = -ANG90 + (1 << ANGLETOFINESHIFT);
-    downViewPitchLimit = ANG90 - (1 << ANGLETOFINESHIFT);
-  }
-
-  CheckPitch(&viewpitch);
-}
+static const int upViewPitchLimit = -ANG90 + (1 << ANGLETOFINESHIFT);
+static const int downViewPitchLimit = ANG90 - (1 << ANGLETOFINESHIFT);
 
 void M_ChangeScreenMultipleFactor(void)
 {

--- a/prboom2/src/e6y.h
+++ b/prboom2/src/e6y.h
@@ -106,7 +106,6 @@ int G_ReloadLevel(void);
 int G_GotoNextLevel(void);
 
 void M_ChangeSkyMode(void);
-void M_ChangeMaxViewPitch(void);
 
 void M_ChangeFOV(void);
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -772,7 +772,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
       }
     }
 
-    if (players[consoleplayer].playerstate == PST_LIVE)
+    if (players[consoleplayer].playerstate == PST_LIVE && !dsda_FreeAim())
     {
         if (look < 0)
         {

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -806,10 +806,19 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
     // TODO: look keybinds
 
-    // TODO: need to restrict input relative to software mode here (for demo compatibility)
-
     if (look)
     {
+      if (!V_IsOpenGLMode())
+      {
+        int target_look = players[consoleplayer].mo->pitch + (look << 16);
+
+        if (target_look < (int) raven_angle_up_limit)
+          look = (raven_angle_up_limit - players[consoleplayer].mo->pitch) >> 16;
+
+        if (target_look > (int) raven_angle_down_limit)
+          look = (raven_angle_down_limit - players[consoleplayer].mo->pitch) >> 16;
+      }
+
       dsda_QueueExCmdLook(look);
     }
   }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1625,6 +1625,11 @@ void G_Ticker (void)
           {
             M_CheatNoClip();
           }
+
+          if (ex->actions & XC_LOOK && !dsda_MouseLook())
+          {
+            dsda_UpdateIntConfig(dsda_config_freelook, 1, false);
+          }
         }
       }
     }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -86,6 +86,7 @@
 #include "e6y.h"//e6y
 
 #include "dsda.h"
+#include "dsda/aim.h"
 #include "dsda/args.h"
 #include "dsda/brute_force.h"
 #include "dsda/build.h"
@@ -4124,7 +4125,7 @@ void P_WalkTicker()
     walkcamera.x = players[0].mo->x;
     walkcamera.y = players[0].mo->y;
     walkcamera.angle = players[0].mo->angle;
-    walkcamera.pitch = P_PlayerPitch(&players[0]);
+    walkcamera.pitch = dsda_PlayerPitch(&players[0]);
   }
 
   if (forward > MAXPLMOVE)
@@ -4179,7 +4180,7 @@ void P_SyncWalkcam(dboolean sync_coords, dboolean sync_sight)
     if (sync_sight)
     {
       walkcamera.angle = players[displayplayer].mo->angle;
-      walkcamera.pitch = P_PlayerPitch(&players[displayplayer]);
+      walkcamera.pitch = dsda_PlayerPitch(&players[displayplayer]);
     }
 
     if(sync_coords)

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1627,7 +1627,7 @@ void G_Ticker (void)
             M_CheatNoClip();
           }
 
-          if (ex->actions & XC_LOOK && !dsda_MouseLook())
+          if (ex->actions & XC_LOOK && ex->look != XC_LOOK_RESET && !dsda_MouseLook())
           {
             dsda_UpdateIntConfig(dsda_config_freelook, 1, false);
           }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -794,7 +794,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
     }
   }
 
-  if (players[consoleplayer].mo->pitch && !dsda_MouseLook())
+  if (players[consoleplayer].mo && players[consoleplayer].mo->pitch && !dsda_MouseLook())
     dsda_QueueExCmdLook(XC_LOOK_RESET);
 
   if (dsda_AllowFreeLook())

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -804,8 +804,6 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
     look = mlooky;
 
-    // TODO: look keybinds
-
     if (look)
     {
       if (!V_IsOpenGLMode())

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -794,6 +794,25 @@ void G_BuildTiccmd(ticcmd_t* cmd)
     }
   }
 
+  if (players[consoleplayer].mo->pitch && !dsda_MouseLook())
+    dsda_QueueExCmdLook(XC_LOOK_RESET);
+
+  if (dsda_AllowFreeLook())
+  {
+    short look;
+
+    look = mlooky;
+
+    // TODO: look keybinds
+
+    // TODO: need to restrict input relative to software mode here (for demo compatibility)
+
+    if (look)
+    {
+      dsda_QueueExCmdLook(look);
+    }
+  }
+
   if (dsda_InputActive(dsda_input_fire))
     cmd->buttons |= BT_ATTACK;
 

--- a/prboom2/src/m_fixed.h
+++ b/prboom2/src/m_fixed.h
@@ -84,6 +84,11 @@ inline static CONSTFUNC fixed_t FixedMul(fixed_t a, fixed_t b)
   return (fixed_t)((int64_t) a*b >> FRACBITS);
 }
 
+inline static CONSTFUNC int64_t FixedMul64(int64_t a, int64_t b)
+{
+  return a * b >> FRACBITS;
+}
+
 /*
  * Fixed Point Division
  */

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3085,7 +3085,6 @@ void M_ChangeFullScreen(void)
 void M_ChangeVideoMode(void)
 {
   V_ChangeScreenResolution();
-  M_ChangeMaxViewPitch();
 }
 
 void M_ChangeUseGLSurface(void)
@@ -6063,7 +6062,6 @@ void M_Init(void)
 
   //e6y
   M_ChangeSpeed();
-  M_ChangeMaxViewPitch();
   M_ChangeSkyMode();
   M_ChangeFOV();
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3028,7 +3028,6 @@ setup_menu_t mapping_settings[] = {
   { "USE PASSES THRU ALL SPECIAL LINES", S_YESNO, m_conf, G_X, dsda_config_comperr_passuse },
   { "WALK UNDER SOLID HANGING BODIES", S_YESNO, m_conf, G_X, dsda_config_comperr_hangsolid },
   { "FIX CLIPPING IN LARGE LEVELS", S_YESNO, m_conf, G_X, dsda_config_comperr_blockmap },
-  { "ALLOW VERTICAL AIMING", S_YESNO, m_conf, G_X, dsda_config_comperr_freeaim },
 
   PREV_PAGE(display_settings),
   NEXT_PAGE(demo_settings),

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -345,7 +345,6 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_comperr_passuse),
   MIGRATED_SETTING(dsda_config_comperr_hangsolid),
   MIGRATED_SETTING(dsda_config_comperr_blockmap),
-  MIGRATED_SETTING(dsda_config_comperr_freeaim),
 
   SETTING_HEADING("Weapon preferences"),
   MIGRATED_SETTING(dsda_config_weapon_choice_1),

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -2118,7 +2118,7 @@ void A_VileAttack(mobj_t *actor)
   // move the fire between the vile and the player
   fire->x = actor->target->x - FixedMul (24*FRACUNIT, finecosine[an]);
   fire->y = actor->target->y - FixedMul (24*FRACUNIT, finesine[an]);
-  P_RadiusAttack(fire, actor, 70, 70, true);
+  P_RadiusAttack(fire, actor, 70, 70, BF_DAMAGESOURCE | BF_HORIZONTAL);
 }
 
 //
@@ -2466,11 +2466,11 @@ void A_Explode(mobj_t *thingy)
 {
   int damage;
   int distance;
-  dboolean damageSelf;
+  int flags;
 
   damage = 128;
   distance = 128;
-  damageSelf = true;
+  flags = BF_DAMAGESOURCE;
 
   if (raven)
   {
@@ -2497,15 +2497,15 @@ void A_Explode(mobj_t *thingy)
         break;
       case HEXEN_MT_HAMMER_MISSILE:        // Fighter Hammer
         damage = 128;
-        damageSelf = false;
+        flags &= ~BF_DAMAGESOURCE;
         break;
       case HEXEN_MT_FSWORD_MISSILE:        // Fighter Runesword
         damage = 64;
-        damageSelf = false;
+        flags &= ~BF_DAMAGESOURCE;
         break;
       case HEXEN_MT_CIRCLEFLAME:   // Cleric Flame secondary flames
         damage = 20;
-        damageSelf = false;
+        flags &= ~BF_DAMAGESOURCE;
         break;
       case HEXEN_MT_SORCBALL1:     // Sorcerer balls
       case HEXEN_MT_SORCBALL2:
@@ -2525,17 +2525,17 @@ void A_Explode(mobj_t *thingy)
         break;
       case HEXEN_MT_DRAGON_FX2:
         damage = 80;
-        damageSelf = false;
+        flags &= ~BF_DAMAGESOURCE;
         break;
       case HEXEN_MT_MSTAFF_FX:
         damage = 64;
         distance = 192;
-        damageSelf = false;
+        flags &= ~BF_DAMAGESOURCE;
         break;
       case HEXEN_MT_MSTAFF_FX2:
         damage = 80;
         distance = 192;
-        damageSelf = false;
+        flags &= ~BF_DAMAGESOURCE;
         break;
       case HEXEN_MT_POISONCLOUD:
         damage = 4;
@@ -2551,7 +2551,7 @@ void A_Explode(mobj_t *thingy)
     }
   }
 
-  P_RadiusAttack(thingy, thingy->target, damage, distance, damageSelf);
+  P_RadiusAttack(thingy, thingy->target, damage, distance, flags);
   if (
     heretic ||
     (
@@ -3007,7 +3007,7 @@ void A_Detonate(mobj_t *mo)
       !prboom_comp[PC_APPLY_MBF_CODEPOINTERS_TO_ANY_COMPLEVEL].state)
     return;
 
-  P_RadiusAttack(mo, mo->target, mo->info->damage, mo->info->damage, true);
+  P_RadiusAttack(mo, mo->target, mo->info->damage, mo->info->damage, BF_DAMAGESOURCE);
 }
 
 //
@@ -3367,7 +3367,7 @@ void A_RadiusDamage(mobj_t *actor)
   if (!mbf21 || !actor->state)
     return;
 
-  P_RadiusAttack(actor, actor->target, actor->state->args[0], actor->state->args[1], true);
+  P_RadiusAttack(actor, actor->target, actor->state->args[0], actor->state->args[1], BF_DAMAGESOURCE);
 }
 
 //
@@ -4805,7 +4805,7 @@ void A_VolcBallImpact(mobj_t * ball)
         ball->z += 28 * FRACUNIT;
         //ball->momz = 3*FRACUNIT;
     }
-    P_RadiusAttack(ball, ball->target, 25, 25, true);
+    P_RadiusAttack(ball, ball->target, 25, 25, BF_DAMAGESOURCE);
     for (i = 0; i < 4; i++)
     {
         tiny = P_SpawnMobj(ball->x, ball->y, ball->z, HERETIC_MT_VOLCANOTBLAST);

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2274,7 +2274,7 @@ dboolean PTR_ShootTraverse (intercept_t* in)
     // hit line
     // position a bit closer
 
-    if (map_format.zdoom)
+    if (comperr(comperr_freeaim))
     {
       int side = P_PointOnLineSide(trace.x, trace.y, li);
       sector_t *sec = side ? li->backsector : li->frontsector;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2274,7 +2274,45 @@ dboolean PTR_ShootTraverse (intercept_t* in)
     // hit line
     // position a bit closer
 
-    frac = in->frac - FixedDiv (4*FRACUNIT,attackrange);
+    if (map_format.zdoom)
+    {
+      int side = P_PointOnLineSide(trace.x, trace.y, li);
+      sector_t *sec = side ? li->backsector : li->frontsector;
+
+      z = shootz + FixedMul(aimslope, FixedMul(in->frac, attackrange));
+
+      if (sec && sec->floorheight > z)
+      {
+        fixed_t dist;
+
+        if (sec->floorpic == skyflatnum)
+          return false;
+
+        dist = FixedDiv(sec->floorheight - shootz, aimslope);
+        frac = FixedDiv(dist, attackrange);
+      }
+      else if (sec && sec->ceilingheight < z)
+      {
+        fixed_t dist;
+
+        if (sec->ceilingpic == skyflatnum)
+          return false;
+
+        // TODO: ceiling puffs get pushed down and look off
+        dist = FixedDiv(sec->ceilingheight - shootz, aimslope);
+        frac = FixedDiv(dist, attackrange);
+      }
+      else
+      {
+        frac = in->frac;
+      }
+    }
+    else
+    {
+      frac = in->frac;
+    }
+
+    frac -= FixedDiv(4 * FRACUNIT, attackrange);
     x = trace.x + FixedMul (trace.dx, frac);
     y = trace.y + FixedMul (trace.dy, frac);
     z = shootz + FixedMul (aimslope, FixedMul(frac, attackrange));

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2689,19 +2689,12 @@ void P_UseLines (player_t*  player)
 // RADIUS ATTACK
 //
 
-//e6y static
-mobj_t *bombsource, *bombspot;
-//e6y static
-int bombdamage;
-int bombdistance;
-
-// hexen
-dboolean DamageSource;
+bomb_t bomb;
 
 //
 // PIT_RadiusAttack
-// "bombsource" is the creature
-// that caused the explosion at "bombspot".
+// "bomb.source" is the creature
+// that caused the explosion at "bomb.spot".
 //
 
 static dboolean P_SplashImmune(mobj_t *target, mobj_t *spot)
@@ -2717,10 +2710,10 @@ int P_SplashDamage(fixed_t dist)
 
   // [XA] independent damage/distance calculation.
   //      same formula as eternity; thanks Quas :P
-  if (!hexen && bombdamage == bombdistance)
-    damage = bombdamage - dist;
+  if (!hexen && bomb.damage == bomb.distance)
+    damage = bomb.damage - dist;
   else
-    damage = (bombdamage * (bombdistance - dist) / bombdistance) + 1;
+    damage = (bomb.damage * (bomb.distance - dist) / bomb.distance) + 1;
 
   return damage;
 }
@@ -2739,16 +2732,16 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
   if (!(thing->flags & (MF_SHOOTABLE | MF_BOUNCES)))
     return true;
 
-  if (P_SplashImmune(thing, bombspot))
+  if (P_SplashImmune(thing, bomb.spot))
     return true;
 
   if (hexen)
   {
-    if (!DamageSource && thing == bombsource)
+    if (!(bomb.flags & BF_DAMAGESOURCE) && thing == bomb.source)
     {                           // don't damage the source of the explosion
       return true;
     }
-    if (D_abs((thing->z - bombspot->z) >> FRACBITS) > 2 * bombdistance)
+    if (D_abs((thing->z - bomb.spot->z) >> FRACBITS) > 2 * bomb.distance)
     {                           // too high/low
       return true;
     }
@@ -2761,29 +2754,29 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
     // killough 8/10/98: allow grenades to hurt anyone, unless
     // fired by Cyberdemons, in which case it won't hurt Cybers.
 
-    if (bombspot->flags & MF_BOUNCES ?
-        thing->type == MT_CYBORG && bombsource->type == MT_CYBORG :
+    if (bomb.spot->flags & MF_BOUNCES ?
+        thing->type == MT_CYBORG && bomb.source->type == MT_CYBORG :
         thing->flags2 & (MF2_NORADIUSDMG | MF2_BOSS) &&
-        !(bombspot->flags2 & MF2_FORCERADIUSDMG))
+        !(bomb.spot->flags2 & MF2_FORCERADIUSDMG))
       return true;
   }
 
-  dx = D_abs(thing->x - bombspot->x);
-  dy = D_abs(thing->y - bombspot->y);
+  dx = D_abs(thing->x - bomb.spot->x);
+  dy = D_abs(thing->y - bomb.spot->y);
 
   dist = dx > dy ? dx : dy;
 
-  if (map_format.zdoom && (bombspot->z < thing->z || bombspot->z >= thing->z + thing->height))
+  if (map_format.zdoom && (bomb.spot->z < thing->z || bomb.spot->z >= thing->z + thing->height))
   {
     fixed_t dz;
 
-    if (bombspot->z > thing->z)
+    if (bomb.spot->z > thing->z)
     {
-      dz = bombspot->z - thing->z - thing->height;
+      dz = bomb.spot->z - thing->z - thing->height;
     }
     else
     {
-      dz = thing->z - bombspot->z;
+      dz = thing->z - bomb.spot->z;
     }
 
     if (dist <= thing->radius)
@@ -2806,10 +2799,10 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
 
   dist >>= FRACBITS;
 
-  if (dist >= bombdistance)
+  if (dist >= bomb.distance)
     return true;  // out of range
 
-  if ( P_CheckSight (thing, bombspot) )
+  if ( P_CheckSight (thing, bomb.spot) )
   {
     // must be in direct path
 
@@ -2820,16 +2813,16 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
       damage >>= 2;
     }
 
-    P_DamageMobj (thing, bombspot, bombsource, damage);
+    P_DamageMobj (thing, bomb.spot, bomb.source, damage);
 
-    if (map_format.zdoom)
+    if (map_format.zdoom && !(bomb.flags & BF_HORIZONTAL))
     {
       fixed_t thrust;
       fixed_t dxy, dz;
       angle_t an;
 
       dxy = P_AproxDistance(dx, dy);
-      dz = thing->z + thing->height / 2 - bombspot->z;
+      dz = thing->z + thing->height / 2 - bomb.spot->z;
       an = R_PointToAngle2(0, 0, dxy, dz);
 
       thrust = damage * (FRACUNIT >> 3) * g_thrust_factor / thing->info->mass;
@@ -2845,7 +2838,7 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
 // P_RadiusAttack
 // Source is the creature that caused the explosion at spot.
 //
-void P_RadiusAttack(mobj_t* spot,mobj_t* source, int damage, int distance, dboolean damageSource)
+void P_RadiusAttack(mobj_t* spot,mobj_t* source, int damage, int distance, int flags)
 {
   int x;
   int y;
@@ -2862,18 +2855,20 @@ void P_RadiusAttack(mobj_t* spot,mobj_t* source, int damage, int distance, dbool
   yl = P_GetSafeBlockY(spot->y - dist - bmaporgy);
   xh = P_GetSafeBlockX(spot->x + dist - bmaporgx);
   xl = P_GetSafeBlockX(spot->x - dist - bmaporgx);
-  bombspot = spot;
+
+  bomb.spot = spot;
   if (heretic && spot->type == HERETIC_MT_POD && spot->target)
   {
-    bombsource = spot->target;
+    bomb.source = spot->target;
   }
   else
   {
-    bombsource = source;
+    bomb.source = source;
   }
-  bombdamage = damage;
-  bombdistance = distance;
-  DamageSource = damageSource;
+  bomb.damage = damage;
+  bomb.distance = distance;
+  bomb.flags = flags;
+
   for (y=yl ; y<=yh ; y++)
     for (x=xl ; x<=xh ; x++)
       P_BlockThingsIterator (x, y, PIT_RadiusAttack );

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2825,16 +2825,16 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
     if (map_format.zdoom)
     {
       fixed_t thrust;
-      fixed_t direction;
+      fixed_t dxy, dz;
+      angle_t an;
+
+      dxy = P_AproxDistance(dx, dy);
+      dz = thing->z + thing->height / 2 - bombspot->z;
+      an = R_PointToAngle2(0, 0, dxy, dz);
 
       thrust = damage * (FRACUNIT >> 3) * g_thrust_factor / thing->info->mass;
-      direction = thing->z + thing->height / 2 - bombspot->z;
 
-      thrust = direction > 0 ?  thrust :
-               direction < 0 ? -thrust :
-               0;
-
-      thing->momz += thrust;
+      thing->momz += FixedMul(thrust, finesine[an >> ANGLETOFINESHIFT]);
     }
   }
 

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -52,6 +52,7 @@
 
 #include "dsda.h"
 #include "dsda/destructible.h"
+#include "dsda/excmd.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
 
@@ -2274,7 +2275,7 @@ dboolean PTR_ShootTraverse (intercept_t* in)
     // hit line
     // position a bit closer
 
-    if (comperr(comperr_freeaim))
+    if (dsda_FreeAim())
     {
       int64_t real_z;
       int side = P_PointOnLineSide(trace.x, trace.y, li);

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2777,7 +2777,6 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
   {
     fixed_t dz;
 
-    // TODO: bombspot position is wrong for floor / ceiling shots
     if (bombspot->z > thing->z)
     {
       dz = bombspot->z - thing->z - thing->height;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2771,11 +2771,41 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
   dx = D_abs(thing->x - bombspot->x);
   dy = D_abs(thing->y - bombspot->y);
 
-  dist = dx>dy ? dx : dy;
-  dist = (dist - thing->radius) >> FRACBITS;
+  dist = dx > dy ? dx : dy;
 
-  if (dist < 0)
-    dist = 0;
+  if (map_format.zdoom && (bombspot->z < thing->z || bombspot->z >= thing->z + thing->height))
+  {
+    fixed_t dz;
+
+    // TODO: bombspot position is wrong for floor / ceiling shots
+    if (bombspot->z > thing->z)
+    {
+      dz = bombspot->z - thing->z - thing->height;
+    }
+    else
+    {
+      dz = thing->z - bombspot->z;
+    }
+
+    if (dist <= thing->radius)
+    {
+      dist = dz;
+    }
+    else
+    {
+      dist -= thing->radius;
+      dist = P_AproxDistance(dist, dz);
+    }
+  }
+  else
+  {
+    dist -= thing->radius;
+
+    if (dist < 0)
+      dist = 0;
+  }
+
+  dist >>= FRACBITS;
 
   if (dist >= bombdistance)
     return true;  // out of range

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2822,6 +2822,21 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
     }
 
     P_DamageMobj (thing, bombspot, bombsource, damage);
+
+    if (map_format.zdoom)
+    {
+      fixed_t thrust;
+      fixed_t direction;
+
+      thrust = damage * (FRACUNIT >> 3) * g_thrust_factor / thing->info->mass;
+      direction = thing->z + thing->height / 2 - bombspot->z;
+
+      thrust = direction > 0 ?  thrust :
+               direction < 0 ? -thrust :
+               0;
+
+      thing->momz += thrust;
+    }
   }
 
   return true;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2766,7 +2766,8 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
 
   dist = dx > dy ? dx : dy;
 
-  if (map_format.zdoom && (bomb.spot->z < thing->z || bomb.spot->z >= thing->z + thing->height))
+  if (map_info.flags & MI_EXPLODE_IN_3D &&
+      (bomb.spot->z < thing->z || bomb.spot->z >= thing->z + thing->height))
   {
     fixed_t dz;
 
@@ -2815,7 +2816,7 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
 
     P_DamageMobj (thing, bomb.spot, bomb.source, damage);
 
-    if (map_format.zdoom && !(bomb.flags & BF_HORIZONTAL))
+    if (map_info.flags & MI_VERTICAL_EXPLOSION_THRUST && !(bomb.flags & BF_HORIZONTAL))
     {
       fixed_t thrust;
       fixed_t dxy, dz;

--- a/prboom2/src/p_map.h
+++ b/prboom2/src/p_map.h
@@ -52,6 +52,18 @@
 //e6y
 #define STAIRS_UNINITIALIZED_CRUSH_FIELD_VALUE -2
 
+#define BF_DAMAGESOURCE 0x01
+#define BF_HORIZONTAL   0x02
+
+typedef struct
+{
+  mobj_t *source;
+  mobj_t *spot;
+  int damage;
+  int distance;
+  int flags;
+} bomb_t;
+
 // killough 3/15/98: add fourth argument to P_TryMove
 dboolean P_TryMove(mobj_t *thing, fixed_t x, fixed_t y, dboolean dropoff);
 
@@ -74,7 +86,7 @@ fixed_t P_AimLineAttack(mobj_t *t1,angle_t angle,fixed_t distance, uint64_t mask
 
 void    P_LineAttack(mobj_t *t1, angle_t angle, fixed_t distance,
                      fixed_t slope, int damage );
-void P_RadiusAttack(mobj_t *spot, mobj_t *source, int damage, int distance, dboolean damageSource);
+void P_RadiusAttack(mobj_t *spot, mobj_t *source, int damage, int distance, int flags);
 dboolean P_CheckPosition(mobj_t *thing, fixed_t x, fixed_t y);
 
 typedef struct

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -56,6 +56,7 @@
 
 #include "dsda.h"
 #include "dsda/ambient.h"
+#include "dsda/excmd.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
 #include "dsda/settings.h"
@@ -2895,8 +2896,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
 
   angle_t an = source->angle;
 
-  // killough 7/19/98: autoaiming was not in original beta
-  if (comperr(comperr_freeaim))
+  if (dsda_FreeAim())
     slope = finetangent[(ANG90 - source->pitch) >> ANGLETOFINESHIFT];
   else
   {
@@ -2965,7 +2965,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
   P_SetTarget(&th->target, source);
   th->angle = an;
 
-  if (comperr(comperr_freeaim))
+  if (dsda_FreeAim())
   {
     fixed_t horizontal_speed;
 

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -55,6 +55,7 @@
 #include "e6y.h"//e6y
 
 #include "dsda.h"
+#include "dsda/aim.h"
 #include "dsda/ambient.h"
 #include "dsda/excmd.h"
 #include "dsda/map_format.h"
@@ -2894,7 +2895,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
   aim_t aim;
 
   // see which target is to be aimed at
-  P_PlayerAim(source, source->angle, &aim, mbf_features ? MF_FRIEND : 0);
+  dsda_PlayerAim(source, source->angle, &aim, mbf_features ? MF_FRIEND : 0);
 
   x = source->x;
   y = source->y;
@@ -3252,7 +3253,7 @@ mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle)
     //
     // see which target is to be aimed at
     //
-    P_PlayerAim(source, angle, &aim, 0);
+    dsda_PlayerAim(source, angle, &aim, 0);
 
     x = source->x;
     y = source->y;
@@ -3561,7 +3562,7 @@ mobj_t *P_SPMAngleXYZ(mobj_t * source, fixed_t x, fixed_t y,
     //
     // see which target is to be aimed at
     //
-    P_PlayerAim(source, angle, &aim, 0);
+    dsda_PlayerAim(source, angle, &aim, 0);
 
     z += 4 * 8 * FRACUNIT + aim.z_offset;
     z -= source->floorclip;

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2964,9 +2964,22 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
 
   P_SetTarget(&th->target, source);
   th->angle = an;
-  th->momx = FixedMul(th->info->speed, finecosine[an>>ANGLETOFINESHIFT]);
-  th->momy = FixedMul(th->info->speed, finesine[an>>ANGLETOFINESHIFT]);
-  th->momz = FixedMul(th->info->speed, slope);
+
+  if (!comperr(comperr_freeaim))
+  {
+    th->momx = FixedMul(th->info->speed, finecosine[an>>ANGLETOFINESHIFT]);
+    th->momy = FixedMul(th->info->speed, finesine[an>>ANGLETOFINESHIFT]);
+    th->momz = FixedMul(th->info->speed, slope);
+  }
+  else
+  {
+    fixed_t horizontal_speed;
+
+    horizontal_speed = FixedMul(th->info->speed, finecosine[source->pitch >> ANGLETOFINESHIFT]);
+    th->momx = FixedMul(horizontal_speed, finecosine[an >> ANGLETOFINESHIFT]);
+    th->momy = FixedMul(horizontal_speed, finesine[an >> ANGLETOFINESHIFT]);
+    th->momz = FixedMul(th->info->speed, -finesine[source->pitch >> ANGLETOFINESHIFT]);
+  }
 
   if (hexen)
   {

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2965,13 +2965,7 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
   P_SetTarget(&th->target, source);
   th->angle = an;
 
-  if (!comperr(comperr_freeaim))
-  {
-    th->momx = FixedMul(th->info->speed, finecosine[an>>ANGLETOFINESHIFT]);
-    th->momy = FixedMul(th->info->speed, finesine[an>>ANGLETOFINESHIFT]);
-    th->momz = FixedMul(th->info->speed, slope);
-  }
-  else
+  if (comperr(comperr_freeaim))
   {
     fixed_t horizontal_speed;
 
@@ -2979,6 +2973,12 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
     th->momx = FixedMul(horizontal_speed, finecosine[an >> ANGLETOFINESHIFT]);
     th->momy = FixedMul(horizontal_speed, finesine[an >> ANGLETOFINESHIFT]);
     th->momz = FixedMul(th->info->speed, -finesine[source->pitch >> ANGLETOFINESHIFT]);
+  }
+  else
+  {
+    th->momx = FixedMul(th->info->speed, finecosine[an>>ANGLETOFINESHIFT]);
+    th->momy = FixedMul(th->info->speed, finesine[an>>ANGLETOFINESHIFT]);
+    th->momz = FixedMul(th->info->speed, slope);
   }
 
   if (hexen)

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2890,60 +2890,34 @@ mobj_t* P_SpawnMissile(mobj_t* source,mobj_t* dest,mobjtype_t type)
 mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
 {
   mobj_t *th;
-  fixed_t x, y, z, slope = 0;
+  fixed_t x, y, z;
+  aim_t aim;
 
   // see which target is to be aimed at
-
-  angle_t an = source->angle;
-
-  if (dsda_FreeAim())
-    slope = finetangent[(ANG90 - source->pitch) >> ANGLETOFINESHIFT];
-  else
-  {
-    // killough 8/2/98: prefer autoaiming at enemies
-    uint64_t mask = mbf_features ? MF_FRIEND : 0;
-
-    do
-    {
-      slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, mask);
-      if (!linetarget)
-        slope = P_AimLineAttack(source, an += 1 << 26, 16 * 64 * FRACUNIT, mask);
-      if (!linetarget)
-        slope = P_AimLineAttack(source, an -= 2 << 26, 16 * 64 * FRACUNIT, mask);
-      if (!linetarget) {
-        an = source->angle;
-        slope = 0;
-
-        if (raven) slope = ((source->player->lookdir) << FRACBITS) / 173;
-      }
-    }
-    while (mask && (mask=0, !linetarget));  // killough 8/2/98
-  }
+  P_PlayerAim(source, source->angle, &aim, mbf_features ? MF_FRIEND : 0);
 
   x = source->x;
   y = source->y;
 
   if (!raven)
   {
-    z = source->z + 4 * 8 * FRACUNIT;
+    z = source->z + 4 * 8 * FRACUNIT + aim.z_offset;
   }
   else
   {
     if (type == HEXEN_MT_LIGHTNING_FLOOR)
     {
       z = ONFLOORZ;
-      slope = 0;
+      aim.slope = 0;
     }
     else if (type == HEXEN_MT_LIGHTNING_CEILING)
     {
       z = ONCEILINGZ;
-      slope = 0;
+      aim.slope = 0;
     }
     else
     {
-      z = source->z + 4 * 8 * FRACUNIT;
-
-      z += ((source->player->lookdir) << FRACBITS) / 173;
+      z = source->z + 4 * 8 * FRACUNIT + aim.z_offset;
 
       if (hexen)
       {
@@ -2963,22 +2937,22 @@ mobj_t* P_SpawnPlayerMissile(mobj_t* source, mobjtype_t type)
     S_StartMobjSound(th, th->info->seesound);
 
   P_SetTarget(&th->target, source);
-  th->angle = an;
+  th->angle = aim.angle;
 
   if (dsda_FreeAim())
   {
     fixed_t horizontal_speed;
 
     horizontal_speed = FixedMul(th->info->speed, finecosine[source->pitch >> ANGLETOFINESHIFT]);
-    th->momx = FixedMul(horizontal_speed, finecosine[an >> ANGLETOFINESHIFT]);
-    th->momy = FixedMul(horizontal_speed, finesine[an >> ANGLETOFINESHIFT]);
+    th->momx = FixedMul(horizontal_speed, finecosine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momy = FixedMul(horizontal_speed, finesine[aim.angle >> ANGLETOFINESHIFT]);
     th->momz = FixedMul(th->info->speed, -finesine[source->pitch >> ANGLETOFINESHIFT]);
   }
   else
   {
-    th->momx = FixedMul(th->info->speed, finecosine[an>>ANGLETOFINESHIFT]);
-    th->momy = FixedMul(th->info->speed, finesine[an>>ANGLETOFINESHIFT]);
-    th->momz = FixedMul(th->info->speed, slope);
+    th->momx = FixedMul(th->info->speed, finecosine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momy = FixedMul(th->info->speed, finesine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momz = FixedMul(th->info->speed, aim.slope);
   }
 
   if (hexen)
@@ -3272,33 +3246,17 @@ dboolean P_SeekerMissile(mobj_t * actor, mobj_t ** seekTarget, angle_t thresh, a
 mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle)
 {
     mobj_t *th;
-    angle_t an;
-    fixed_t x, y, z, slope;
+    fixed_t x, y, z;
+    aim_t aim;
 
     //
     // see which target is to be aimed at
     //
-    an = angle;
-    slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, 0);
-    if (!linetarget)
-    {
-        an += 1 << 26;
-        slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, 0);
-        if (!linetarget)
-        {
-            an -= 2 << 26;
-            slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, 0);
-        }
-        if (!linetarget)
-        {
-            an = angle;
-            slope = ((source->player->lookdir) << FRACBITS) / 173;
-        }
-    }
+    P_PlayerAim(source, angle, &aim, 0);
+
     x = source->x;
     y = source->y;
-    z = source->z + 4 * 8 * FRACUNIT +
-        ((source->player->lookdir) << FRACBITS) / 173;
+    z = source->z + 4 * 8 * FRACUNIT + aim.z_offset;
     if (hexen)
     {
         z -= source->floorclip;
@@ -3313,10 +3271,10 @@ mobj_t *P_SPMAngle(mobj_t * source, mobjtype_t type, angle_t angle)
         S_StartMobjSound(th, th->info->seesound);
     }
     P_SetTarget(&th->target, source);
-    th->angle = an;
-    th->momx = FixedMul(th->info->speed, finecosine[an >> ANGLETOFINESHIFT]);
-    th->momy = FixedMul(th->info->speed, finesine[an >> ANGLETOFINESHIFT]);
-    th->momz = FixedMul(th->info->speed, slope);
+    th->angle = aim.angle;
+    th->momx = FixedMul(th->info->speed, finecosine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momy = FixedMul(th->info->speed, finesine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momz = FixedMul(th->info->speed, aim.slope);
     return (P_CheckMissileSpawn(th) ? th : NULL);
 }
 
@@ -3598,37 +3556,21 @@ mobj_t *P_SPMAngleXYZ(mobj_t * source, fixed_t x, fixed_t y,
                       fixed_t z, mobjtype_t type, angle_t angle)
 {
     mobj_t *th;
-    angle_t an;
-    fixed_t slope;
+    aim_t aim;
 
     //
     // see which target is to be aimed at
     //
-    an = angle;
-    slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, 0);
-    if (!linetarget)
-    {
-        an += 1 << 26;
-        slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, 0);
-        if (!linetarget)
-        {
-            an -= 2 << 26;
-            slope = P_AimLineAttack(source, an, 16 * 64 * FRACUNIT, 0);
-        }
-        if (!linetarget)
-        {
-            an = angle;
-            slope = ((source->player->lookdir) << FRACBITS) / 173;
-        }
-    }
-    z += 4 * 8 * FRACUNIT + ((source->player->lookdir) << FRACBITS) / 173;
+    P_PlayerAim(source, angle, &aim, 0);
+
+    z += 4 * 8 * FRACUNIT + aim.z_offset;
     z -= source->floorclip;
     th = P_SpawnMobj(x, y, z, type);
     P_SetTarget(&th->target, source);
-    th->angle = an;
-    th->momx = FixedMul(th->info->speed, finecosine[an >> ANGLETOFINESHIFT]);
-    th->momy = FixedMul(th->info->speed, finesine[an >> ANGLETOFINESHIFT]);
-    th->momz = FixedMul(th->info->speed, slope);
+    th->angle = aim.angle;
+    th->momx = FixedMul(th->info->speed, finecosine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momy = FixedMul(th->info->speed, finesine[aim.angle >> ANGLETOFINESHIFT]);
+    th->momz = FixedMul(th->info->speed, aim.slope);
     return (P_CheckMissileSpawn(th) ? th : NULL);
 }
 

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -50,6 +50,7 @@
 #include "e6y.h"//e6y
 
 #include "dsda.h"
+#include "dsda/aim.h"
 #include "dsda/excmd.h"
 
 #define LOWERSPEED   (FRACUNIT*6)
@@ -1012,7 +1013,7 @@ static void P_BulletSlope(mobj_t *mo)
 {
   aim_t aim;
 
-  P_PlayerAim(mo, mo->angle, &aim, mbf_features ? MF_FRIEND : 0);
+  dsda_PlayerAim(mo, mo->angle, &aim, mbf_features ? MF_FRIEND : 0);
 
   bulletslope = aim.slope;
 }
@@ -1792,11 +1793,11 @@ void A_FireMacePL1B(player_t * player, pspdef_t * psp)
     ball = P_SpawnMobj(pmo->x, pmo->y, pmo->z + 28 * FRACUNIT
                        - FOOTCLIPSIZE * (pmo->flags2 & 1), HERETIC_MT_MACEFX2);
 
-    ball->momz = 2 * FRACUNIT + (P_PlayerLookDir(player) << (FRACBITS - 5));
+    ball->momz = 2 * FRACUNIT + (dsda_PlayerLookDir(player) << (FRACBITS - 5));
     angle = pmo->angle;
     P_SetTarget(&ball->target, pmo);
     ball->angle = angle;
-    ball->z += P_PlayerLookDir(player) << (FRACBITS - 4);
+    ball->z += dsda_PlayerLookDir(player) << (FRACBITS - 4);
     angle >>= ANGLETOFINESHIFT;
     ball->momx = (pmo->momx >> 1)
         + FixedMul(ball->info->speed, finecosine[angle]);
@@ -1932,7 +1933,7 @@ void A_FireMacePL2(player_t * player, pspdef_t * psp)
     {
         mo->momx += player->mo->momx;
         mo->momy += player->mo->momy;
-        mo->momz = 2 * FRACUNIT + (P_PlayerLookDir(player) << (FRACBITS - 5));
+        mo->momz = 2 * FRACUNIT + (dsda_PlayerLookDir(player) << (FRACBITS - 5));
         if (linetarget)
         {
             P_SetTarget(&mo->special1.m, linetarget);
@@ -2284,12 +2285,12 @@ void A_FirePhoenixPL2(player_t * player, pspdef_t * psp)
     angle = pmo->angle;
     x = pmo->x + (P_SubRandom() << 9);
     y = pmo->y + (P_SubRandom() << 9);
-    z = pmo->z + 26 * FRACUNIT + P_PlayerSlope(player);
+    z = pmo->z + 26 * FRACUNIT + dsda_PlayerSlope(player);
     if (pmo->flags2 & MF2_FEETARECLIPPED)
     {
         z -= FOOTCLIPSIZE;
     }
-    slope = P_PlayerSlope(player) + (FRACUNIT / 10);
+    slope = dsda_PlayerSlope(player) + (FRACUNIT / 10);
     mo = P_SpawnMobj(x, y, z, HERETIC_MT_PHOENIXFX2);
     P_SetTarget(&mo->target, pmo);
     mo->angle = angle;

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -47,7 +47,9 @@
 #include "g_game.h"
 #include "lprintf.h"
 #include "e6y.h"//e6y
+
 #include "dsda.h"
+#include "dsda/excmd.h"
 
 #define LOWERSPEED   (FRACUNIT*6)
 #define RAISESPEED   (FRACUNIT*6)
@@ -1009,7 +1011,7 @@ static void P_BulletSlope(mobj_t *mo)
 {
   angle_t an = mo->angle;    // see which target is to be aimed at
 
-  if (comperr(comperr_freeaim))
+  if (dsda_FreeAim())
     bulletslope = finetangent[(ANG90 - mo->pitch) >> ANGLETOFINESHIFT];
   else
   {

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -1792,11 +1792,11 @@ void A_FireMacePL1B(player_t * player, pspdef_t * psp)
     ball = P_SpawnMobj(pmo->x, pmo->y, pmo->z + 28 * FRACUNIT
                        - FOOTCLIPSIZE * (pmo->flags2 & 1), HERETIC_MT_MACEFX2);
 
-    ball->momz = 2 * FRACUNIT + ((player->lookdir) << (FRACBITS - 5));
+    ball->momz = 2 * FRACUNIT + (P_PlayerLookDir(player) << (FRACBITS - 5));
     angle = pmo->angle;
     P_SetTarget(&ball->target, pmo);
     ball->angle = angle;
-    ball->z += (player->lookdir) << (FRACBITS - 4);
+    ball->z += P_PlayerLookDir(player) << (FRACBITS - 4);
     angle >>= ANGLETOFINESHIFT;
     ball->momx = (pmo->momx >> 1)
         + FixedMul(ball->info->speed, finecosine[angle]);
@@ -1932,7 +1932,7 @@ void A_FireMacePL2(player_t * player, pspdef_t * psp)
     {
         mo->momx += player->mo->momx;
         mo->momy += player->mo->momy;
-        mo->momz = 2 * FRACUNIT + ((player->lookdir) << (FRACBITS - 5));
+        mo->momz = 2 * FRACUNIT + (P_PlayerLookDir(player) << (FRACBITS - 5));
         if (linetarget)
         {
             P_SetTarget(&mo->special1.m, linetarget);

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -89,7 +89,7 @@ fixed_t P_PlayerSpeed(player_t* player)
 
 angle_t P_PlayerPitch(player_t* player)
 {
-  return player->mo->pitch - (angle_t)(player->lookdir * ANG1 / M_PI);
+  return dsda_FreeAim() ? player->mo->pitch : -(angle_t)(player->lookdir * ANG1 / M_PI);
 }
 
 //
@@ -334,23 +334,14 @@ void P_HandleExCmdLook(player_t* player)
   look = player->cmd.ex.look;
   if (look)
   {
-    if (raven)
+    if (look == XC_LOOK_RESET)
     {
-      player->lookdir += ANGLE_T_TO_LOOKDIR(look << 16);
-      if (player->lookdir > 90)
-        player->lookdir = 90;
-      if (player->lookdir < -110)
-        player->lookdir = -110;
+      player->mo->pitch = 0;
     }
     else
     {
-      if (look == XC_LOOK_RESET)
-        player->mo->pitch = 0;
-      else
-      {
-        player->mo->pitch += look << 16;
-        CheckPitch((signed int *) &player->mo->pitch);
-      }
+      player->mo->pitch += look << 16;
+      CheckPitch((signed int *) &player->mo->pitch);
     }
   }
 }

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -321,63 +321,46 @@ void P_CalcHeight (player_t* player)
 }
 
 //
-// P_SetPitch
-// Mouse Look Stuff
-//
-void P_SetPitch(player_t *player)
-{
-  mobj_t *mo = player->mo;
-
-  if (player == &players[consoleplayer])
-  {
-    if (!demoplayback)
-    {
-      if (dsda_MouseLook())
-      {
-        if (!mo->reactiontime && automap_off)
-        {
-          if (raven && !demorecording)
-          {
-            player->lookdir += ANGLE_T_TO_LOOKDIR(mlooky << 16);
-            if (player->lookdir > 90)
-              player->lookdir = 90;
-            if (player->lookdir < -110)
-              player->lookdir = -110;
-          }
-          else
-          {
-            mo->pitch += (mlooky << 16);
-            CheckPitch((signed int *)&mo->pitch);
-          }
-        }
-      }
-      else
-      {
-        mo->pitch = 0;
-      }
-    }
-    else
-    {
-      mo->pitch = 0;
-    }
-  }
-  else
-  {
-    mo->pitch = 0;
-  }
-}
-
-//
 // P_MovePlayer
 //
 // Adds momentum if the player is not in the air
 //
 // killough 10/98: simplified
 
+void P_HandleExCmdLook(player_t* player)
+{
+  int look;
+
+  look = player->cmd.ex.look;
+  if (look)
+  {
+    if (raven)
+    {
+      player->lookdir += ANGLE_T_TO_LOOKDIR(look << 16);
+      if (player->lookdir > 90)
+        player->lookdir = 90;
+      if (player->lookdir < -110)
+        player->lookdir = -110;
+    }
+    else
+    {
+      if (look == XC_LOOK_RESET)
+        player->mo->pitch = 0;
+      else
+      {
+        player->mo->pitch += look << 16;
+        CheckPitch((signed int *) &player->mo->pitch);
+      }
+    }
+  }
+}
+
 void P_MovePlayer (player_t* player)
 {
   ticcmd_t *cmd;
   mobj_t *mo;
+
+  P_HandleExCmdLook(player);
 
   if (raven) return Raven_P_MovePlayer(player);
 
@@ -736,8 +719,6 @@ void P_PlayerThink (player_t* player)
       }
     }
   }
-
-  P_SetPitch(player);
 
   P_CalcHeight (player); // Determines view height and bobbing
 

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -488,7 +488,7 @@ void P_DeathThink (player_t* player)
 
     if (dsda_FreeAim())
     {
-      const int delta = dsda_LookDirToPitch(6);
+      const int delta = dsda_LookDirToPitch(-6);
 
       if ((int) player->mo->pitch > 0)
       {
@@ -498,7 +498,8 @@ void P_DeathThink (player_t* player)
       {
          player->mo->pitch += delta;
       }
-      else if (abs((int) player->mo->pitch) < delta)
+
+      if (abs((int) player->mo->pitch) < delta)
       {
          player->mo->pitch = 0;
       }

--- a/prboom2/src/p_user.h
+++ b/prboom2/src/p_user.h
@@ -47,16 +47,6 @@ void P_Thrust(player_t *player, angle_t angle, fixed_t move);
 
 void P_SetPitch(player_t *player);
 
-typedef struct {
-  angle_t angle;
-  fixed_t slope;
-  fixed_t z_offset;
-} aim_t;
-
-fixed_t P_PlayerSlope(player_t* player);
-void P_PlayerAim(mobj_t* source, angle_t angle, aim_t* aim, uint64_t target_mask);
-int P_PlayerLookDir(player_t* player);
-
 // heretic
 
 int P_GetPlayerNum(player_t * player);

--- a/prboom2/src/p_user.h
+++ b/prboom2/src/p_user.h
@@ -47,6 +47,15 @@ void P_Thrust(player_t *player, angle_t angle, fixed_t move);
 
 void P_SetPitch(player_t *player);
 
+typedef struct {
+  angle_t angle;
+  fixed_t slope;
+  fixed_t z_offset;
+} aim_t;
+
+fixed_t P_PlayerSlope(player_t* player);
+void P_PlayerAim(mobj_t* source, angle_t angle, aim_t* aim, uint64_t target_mask);
+
 // heretic
 
 int P_GetPlayerNum(player_t * player);

--- a/prboom2/src/p_user.h
+++ b/prboom2/src/p_user.h
@@ -55,6 +55,7 @@ typedef struct {
 
 fixed_t P_PlayerSlope(player_t* player);
 void P_PlayerAim(mobj_t* source, angle_t angle, aim_t* aim, uint64_t target_mask);
+int P_PlayerLookDir(player_t* player);
 
 // heretic
 

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -43,6 +43,7 @@
 #include "i_capture.h"
 #include "e6y.h"
 
+#include "dsda/aim.h"
 #include "dsda/build.h"
 #include "dsda/configuration.h"
 #include "dsda/pause.h"
@@ -127,7 +128,7 @@ void R_InterpolateView(player_t *player, fixed_t frac)
 
       player->prev_viewz = player->viewz;
       player->prev_viewangle = player->mo->angle;
-      player->prev_viewpitch = P_PlayerPitch(player);
+      player->prev_viewpitch = dsda_PlayerPitch(player);
 
       P_ResetWalkcam();
     }
@@ -153,7 +154,7 @@ void R_InterpolateView(player_t *player, fixed_t frac)
     else
     {
       viewangle = player->prev_viewangle + FixedMul (frac, R_SmoothPlaying_Get(player) - player->prev_viewangle);
-      viewpitch = player->prev_viewpitch + FixedMul (frac, P_PlayerPitch(player) - player->prev_viewpitch);
+      viewpitch = player->prev_viewpitch + FixedMul (frac, dsda_PlayerPitch(player) - player->prev_viewpitch);
     }
   }
   else
@@ -178,7 +179,7 @@ void R_InterpolateView(player_t *player, fixed_t frac)
     else
     {
       viewangle = R_SmoothPlaying_Get(player);
-      viewpitch = P_PlayerPitch(player);
+      viewpitch = dsda_PlayerPitch(player);
     }
   }
 

--- a/prboom2/src/tables.h
+++ b/prboom2/src/tables.h
@@ -81,8 +81,9 @@ typedef unsigned angle_t;
 
 // lookdir range is -110 (down) to 90 (up)
 // pitch is -lookdir * ang1 / pi
-static const angle_t raven_angle_down_limit = (angle_t) (int) (110 * ANG1 / M_PI);
-static const angle_t raven_angle_up_limit = (angle_t) (int) (-90 * ANG1 / M_PI);
+// precomputed to avoid compiler-dependent floating point operation!
+static const angle_t raven_angle_down_limit = 0x18e61ea6; // (angle_t) (int) (110 * ANG1 / M_PI);
+static const angle_t raven_angle_up_limit   = 0xeba0cfa7; // (angle_t) (int) (-90 * ANG1 / M_PI);
 #define RAVEN_PITCH_UP_LIMIT ANGLE_T_TO_PITCH_F(raven_angle_up_limit)
 
 // Load trig tables if needed

--- a/prboom2/src/tables.h
+++ b/prboom2/src/tables.h
@@ -82,8 +82,8 @@ typedef unsigned angle_t;
 // lookdir range is -110 (down) to 90 (up)
 // pitch is -lookdir * ang1 / pi
 // precomputed to avoid compiler-dependent floating point operation!
-static const angle_t raven_angle_down_limit = 0x18e61ea6; // (angle_t) (int) (110 * ANG1 / M_PI);
-static const angle_t raven_angle_up_limit   = 0xeba0cfa7; // (angle_t) (int) (-90 * ANG1 / M_PI);
+static const angle_t raven_angle_down_limit = 0x18e70000; // (angle_t) (int) (110 * ANG1 / M_PI);
+static const angle_t raven_angle_up_limit   = 0xeba00000; // (angle_t) (int) (-90 * ANG1 / M_PI);
 #define RAVEN_PITCH_UP_LIMIT ANGLE_T_TO_PITCH_F(raven_angle_up_limit)
 
 // Load trig tables if needed

--- a/prboom2/src/tables.h
+++ b/prboom2/src/tables.h
@@ -70,6 +70,8 @@
 #define M_PI    3.14159265358979323846
 #endif
 
+#define FIXED_PI 205887
+
 #define SLOPERANGE 2048
 #define SLOPEBITS    11
 #define DBITS      (FRACBITS-SLOPEBITS)

--- a/prboom2/src/tables.h
+++ b/prboom2/src/tables.h
@@ -86,7 +86,6 @@ typedef unsigned angle_t;
 // precomputed to avoid compiler-dependent floating point operation!
 static const angle_t raven_angle_down_limit = 0x18e70000; // (angle_t) (int) (110 * ANG1 / M_PI);
 static const angle_t raven_angle_up_limit   = 0xeba00000; // (angle_t) (int) (-90 * ANG1 / M_PI);
-#define RAVEN_PITCH_UP_LIMIT ANGLE_T_TO_PITCH_F(raven_angle_up_limit)
 
 // Load trig tables if needed
 void R_LoadTrigTables(void);


### PR DESCRIPTION
This PR revises all the code related to free look for future MAPINFO-enabled maps. This includes projectile speeds when fired vertically, explosion damage calculations, rocket jump direction, etc. Behavior is distributed to 3 flags: free look, vertical explosion thrust, and 2d vs 3d explosions (i.e., infinite height or not).

Heretic vertical aiming is now uncapped as in doom.

Vertical aiming is now recorded in demos since it affects behavior.