### PR TITLE
Small OpenGL fixes

### DIFF
--- a/prboom2/src/gl_intern.h
+++ b/prboom2/src/gl_intern.h
@@ -39,8 +39,6 @@
 
 #define MAXCOORD (32767.0f / MAP_COEFF)
 
-#define SMALLDELTA 0.001f
-
 typedef enum
 {
   GLDT_UNREGISTERED,

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1286,14 +1286,14 @@ void gld_AddWall(seg_t *seg)
 
     if (frontsector->ceilingpic==skyflatnum)
     {
-      wall.ytop=MAXCOORD;
+      wall.ytop=MAXCOORD*2; // Simply using MAXCOORD would result in HOM when the floor is at a height close to the limit
       wall.ybottom=(float)frontsector->ceilingheight/MAP_SCALE;
       gld_AddSkyTexture(&wall, frontsector->ceilingsky, frontsector->ceilingsky, SKY_CEILING);
     }
     if (frontsector->floorpic==skyflatnum)
     {
       wall.ytop=(float)frontsector->floorheight/MAP_SCALE;
-      wall.ybottom=-MAXCOORD;
+      wall.ybottom=-MAXCOORD*2;  // Simply using MAXCOORD would result in HOM when the ceiling is at a height close to the limit
       gld_AddSkyTexture(&wall, frontsector->floorsky, frontsector->floorsky, SKY_FLOOR);
     }
     temptex=gld_RegisterTexture(texturetranslation[seg->sidedef->midtexture], true, false, true, false);
@@ -1366,7 +1366,7 @@ void gld_AddWall(seg_t *seg)
     wall.yscale = (float) seg->sidedef->scaley_top / FRACUNIT;
     if (frontsector->ceilingpic==skyflatnum)// || backsector->ceilingpic==skyflatnum)
     {
-      wall.ytop= MAXCOORD;
+      wall.ytop= MAXCOORD*2;
       if (
           // e6y
           // There is no more HOM in the starting area on Memento Mori map29 and on map30.
@@ -1600,7 +1600,7 @@ bottomtexture:
     wall.yscale = (float) seg->sidedef->scaley_bottom / FRACUNIT;
     if (frontsector->floorpic==skyflatnum)
     {
-      wall.ybottom=-MAXCOORD;
+      wall.ybottom=-MAXCOORD*2;
       if (
           (backsector->ceilingheight==backsector->floorheight) &&
           (backsector->floorpic==skyflatnum)

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1175,8 +1175,8 @@ static void gld_DrawWall(GLWall *wall)
 static void gld_CalculateWallY(GLWall *wall, float *lineheight,
                                fixed_t floor_height, fixed_t ceiling_height)
 {
-  wall->ytop = (float) ceiling_height / (float) MAP_SCALE + SMALLDELTA;
-  wall->ybottom = (float) floor_height / (float) MAP_SCALE - SMALLDELTA;
+  wall->ytop = (float) ceiling_height / (float) MAP_SCALE;
+  wall->ybottom = (float) floor_height / (float) MAP_SCALE;
   *lineheight = (float) fabs((float) (ceiling_height - floor_height) / FRACUNIT);
 }
 
@@ -1431,8 +1431,8 @@ void gld_AddWall(seg_t *seg)
           !(backsector->flags & NULL_SECTOR) &&
           backsector->floorheight < backsector->ceilingheight)
         {
-          wall.ytop=((float)(ceiling_height)/(float)MAP_SCALE)+SMALLDELTA;
-          wall.ybottom=((float)(floor_height)/(float)MAP_SCALE)-SMALLDELTA;
+          wall.ytop=((float)(ceiling_height)/(float)MAP_SCALE);
+          wall.ybottom=((float)(floor_height)/(float)MAP_SCALE);
           if (wall.ybottom >= zCamera)
           {
             wall.flag=GLDWF_TOPFLUD;
@@ -1637,8 +1637,8 @@ bottomtexture:
         !(backsector->flags & NULL_SECTOR) &&
         backsector->floorheight < backsector->ceilingheight)
       {
-        wall.ytop=((float)(ceiling_height)/(float)MAP_SCALE)+SMALLDELTA;
-        wall.ybottom=((float)(floor_height)/(float)MAP_SCALE)-SMALLDELTA;
+        wall.ytop=((float)(ceiling_height)/(float)MAP_SCALE);
+        wall.ybottom=((float)(floor_height)/(float)MAP_SCALE);
         if (wall.ytop <= zCamera)
         {
           wall.flag = GLDWF_BOTFLUD;

--- a/prboom2/src/gl_vertex.c
+++ b/prboom2/src/gl_vertex.c
@@ -211,9 +211,9 @@ void gld_RecalcVertexHeights(const vertex_t *v)
     for(j = 0; j < 2; j++)
     {
       if (j == 0)
-        height = (float)vi->sectors[i]->ceilingheight/MAP_SCALE+SMALLDELTA;
+        height = (float)vi->sectors[i]->ceilingheight/MAP_SCALE;
       else
-        height = (float)vi->sectors[i]->floorheight/MAP_SCALE-SMALLDELTA;
+        height = (float)vi->sectors[i]->floorheight/MAP_SCALE;
 
       for(k = 0; k < vi->numheights; k++)
       {


### PR DESCRIPTION
- When a flat of height close to the map height limits has a Skytexture, it would result in HOM

- Remove SMALLDELTA
It caused walls to be rendered a fraction of a unit off. 
This had already been done in https://github.com/kraflab/dsda-doom/commit/948c28a354bf0f94fa95650bec46fbf1141a41f4,  but was reverted in https://github.com/kraflab/dsda-doom/commit/8ed83163272e9c8ac57585e2b4934e777cf598e2.  I tried all sorts of maps,  but couldnt replicate the mentioned "dots on seams between flats and walls",  so I assume that its a bug of the past.

