### PR TITLE
Create dsda-doom directory in $XDG_DATA_HOME or .local/share by default

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -295,8 +295,14 @@ const char *I_DoomExeDir(void)
   static char *base;
   if (!base)        // cache multiple requests
   {
-    char *home = M_getenv("HOME");
-    size_t len = strlen(home);
+    char *home;
+    size_t len;
+    // check if we're in Flatpak
+    if (access("/.flatpak-info", F_OK) == 0)
+      home = M_getenv("XDG_DATA_HOME");
+    else
+      home = M_getenv("HOME");
+    len = strlen(home);
 
     base = Z_Malloc(len + strlen(prboom_dir) + 1);
     strcpy(base, home);


### PR DESCRIPTION
This is the same PR as #461, but moved out of my main branch. The initial intent was to make it easier to create a Flatpak package, but this change probably should be done regardless as it's better practice to store application-specific data in a subdirectory in $XDG_DATA_HOME than storing it as a subdirectory in the home folder.

With these changes, the directory used to store DSDA-Doom's data will be $XDG_DATA_HOME/dsda-doom (or $HOME/.local/share/dsda-doom if $XDG_DATA_HOME is not set). However, to avoid breaking the application for existing users, $HOME/.dsda-doom is used if it exists.