### PR TITLE
Fix z-fighting on bottom texture with skytexture

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -1603,7 +1603,8 @@ bottomtexture:
       wall.ybottom=-MAXCOORD*2;
       if (
           (backsector->ceilingheight==backsector->floorheight) &&
-          (backsector->floorpic==skyflatnum)
+          (backsector->floorpic==skyflatnum) &&
+          (bottomtexture == NO_TEXTURE)
          )
       {
         wall.ytop=(float)backsector->floorheight/MAP_SCALE;


### PR DESCRIPTION
If the sector height is 0 and the floor is a skytexture,  then in the bottom texture a sky hack would be drawn
I cant seem to figure out why this if statement exists in the first place


This change prevents the sky from being drawn if a bottom texture is already there
So this shouldnt break anything