### PR TITLE
Allow macOS and Linux to find files in the executable directory

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -236,7 +236,7 @@ void I_SwitchToWindow(HWND hwnd)
   }
 }
 
-const char *I_DoomDir(void)
+const char *I_ConfigDir(void)
 {
   return I_ExeDir();
 }
@@ -289,7 +289,7 @@ const char* I_GetTempDir(void)
 
 #elif defined(AMIGA)
 
-const char *I_DoomDir(void)
+const char *I_ConfigDir(void)
 {
   return "PROGDIR:";
 }
@@ -310,7 +310,7 @@ const char* I_GetTempDir(void)
 // cph 2006/07/23 - give prboom+ its own dir
 static const char prboom_dir[] = {"/.dsda-doom"}; // Mead rem extra slash 8/21/03
 
-const char *I_DoomDir(void)
+const char *I_ConfigDir(void)
 {
   static char *base;
   if (!base)        // cache multiple requests
@@ -416,7 +416,7 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
   } search0[] = {
     {NULL, NULL, NULL, I_ExeDir}, // executable directory
 #ifndef _WIN32
-    {NULL, NULL, NULL, I_DoomDir}, // config and autoload directory. on windows, this is the same as I_ExeDir
+    {NULL, NULL, NULL, I_ConfigDir}, // config and autoload directory. on windows, this is the same as I_ExeDir
 #endif
     {NULL}, // current working directory
     {NULL, NULL, "DOOMWADDIR"}, // run-time $DOOMWADDIR

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -236,7 +236,12 @@ void I_SwitchToWindow(HWND hwnd)
   }
 }
 
-const char *I_DoomExeDir(void)
+const char *I_DoomDir(void)
+{
+  return I_ExeDir();
+}
+
+const char *I_ExeDir(void)
 {
   extern char **dsda_argv;
 
@@ -284,7 +289,12 @@ const char* I_GetTempDir(void)
 
 #elif defined(AMIGA)
 
-const char *I_DoomExeDir(void)
+const char *I_DoomDir(void)
+{
+  return "PROGDIR:";
+}
+
+const char *I_ExeDir(void)
 {
   return "PROGDIR:";
 }
@@ -300,7 +310,7 @@ const char* I_GetTempDir(void)
 // cph 2006/07/23 - give prboom+ its own dir
 static const char prboom_dir[] = {"/.dsda-doom"}; // Mead rem extra slash 8/21/03
 
-const char *I_DoomExeDir(void)
+const char *I_DoomDir(void)
 {
   static char *base;
   if (!base)        // cache multiple requests
@@ -315,6 +325,32 @@ const char *I_DoomExeDir(void)
     strcat(base, prboom_dir);
     M_MakeDir(base, true); // Make sure it exists
   }
+  return base;
+}
+
+const char *I_ExeDir(void)
+{
+  extern char **dsda_argv;
+
+  static const char current_dir_dummy[] = {"."}; // proff - rem extra slash 8/21/03
+  static char *base;
+  if (!base)        // cache multiple requests
+    {
+      size_t len = strlen(*dsda_argv);
+      char *p = (base = (char*)Z_Malloc(len+1)) + len - 1;
+      strcpy(base,*dsda_argv);
+      while (p > base && *p!='/' && *p!='\\')
+        *p--=0;
+      if (*p=='/' || *p=='\\')
+        *p--=0;
+      if (strlen(base) < 2 || !M_WriteAccess(base))
+      {
+        Z_Free(base);
+        base = (char*)Z_Malloc(1024);
+        if (!M_getcwd(base, 1024) || !M_WriteAccess(base))
+          strcpy(base, current_dir_dummy);
+      }
+    }
   return base;
 }
 
@@ -376,9 +412,12 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
     const char *dir; // directory
     const char *sub; // subdirectory
     const char *env; // environment variable
-    const char *(*func)(void); // for I_DoomExeDir
+    const char *(*func)(void); // for functions that return the directory
   } search0[] = {
-    {NULL, NULL, NULL, I_DoomExeDir}, // config directory
+    {NULL, NULL, NULL, I_ExeDir}, // executable directory
+#ifndef _WIN32
+    {NULL, NULL, NULL, I_DoomDir}, // config and autoload directory. on windows, this is the same as I_ExeDir
+#endif
     {NULL}, // current working directory
     {NULL, NULL, "DOOMWADDIR"}, // run-time $DOOMWADDIR
     {DOOMWADDIR}, // build-time configured DOOMWADDIR

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -245,7 +245,6 @@ const char *I_ExeDir(void)
 {
   extern char **dsda_argv;
 
-  static const char current_dir_dummy[] = {"."}; // proff - rem extra slash 8/21/03
   static char *base;
   if (!base)        // cache multiple requests
     {
@@ -261,7 +260,7 @@ const char *I_ExeDir(void)
         Z_Free(base);
         base = (char*)Z_Malloc(1024);
         if (!M_getcwd(base, 1024) || !M_WriteAccess(base))
-          strcpy(base, current_dir_dummy);
+          strcpy(base, ".");
       }
     }
   return base;
@@ -332,7 +331,6 @@ const char *I_ExeDir(void)
 {
   extern char **dsda_argv;
 
-  static const char current_dir_dummy[] = {"."}; // proff - rem extra slash 8/21/03
   static char *base;
   if (!base)        // cache multiple requests
     {
@@ -348,7 +346,7 @@ const char *I_ExeDir(void)
         Z_Free(base);
         base = (char*)Z_Malloc(1024);
         if (!M_getcwd(base, 1024) || !M_WriteAccess(base))
-          strcpy(base, current_dir_dummy);
+          strcpy(base, ".");
       }
     }
   return base;

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1218,10 +1218,10 @@ static char *GetAutoloadDir(const char *iwadname, dboolean createdir)
 
     if (autoload_path == NULL)
     {
-        const char* doomdir = I_DoomDir();
-        len = snprintf(NULL, 0, "%s/autoload", doomdir);
+        const char* configdir = I_ConfigDir();
+        len = snprintf(NULL, 0, "%s/autoload", configdir);
         autoload_path = Z_Malloc(len+1);
-        snprintf(autoload_path, len+1, "%s/autoload", doomdir);
+        snprintf(autoload_path, len+1, "%s/autoload", configdir);
     }
 
     M_MakeDir(autoload_path, false);

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1218,10 +1218,10 @@ static char *GetAutoloadDir(const char *iwadname, dboolean createdir)
 
     if (autoload_path == NULL)
     {
-        const char* exedir = I_DoomExeDir();
-        len = snprintf(NULL, 0, "%s/autoload", exedir);
+        const char* doomdir = I_DoomDir();
+        len = snprintf(NULL, 0, "%s/autoload", doomdir);
         autoload_path = Z_Malloc(len+1);
-        snprintf(autoload_path, len+1, "%s/autoload", exedir);
+        snprintf(autoload_path, len+1, "%s/autoload", doomdir);
     }
 
     M_MakeDir(autoload_path, false);

--- a/prboom2/src/dsda/data_organizer.c
+++ b/prboom2/src/dsda/data_organizer.c
@@ -68,7 +68,7 @@ char* dsda_DetectDirectory(const char* env_key, int arg_id) {
   default_directory = M_getenv(env_key);
 
   if (!default_directory)
-    default_directory = I_DoomExeDir();
+    default_directory = I_DoomDir();
 
   arg = dsda_Arg(arg_id);
   if (arg->found) {

--- a/prboom2/src/dsda/data_organizer.c
+++ b/prboom2/src/dsda/data_organizer.c
@@ -68,7 +68,7 @@ char* dsda_DetectDirectory(const char* env_key, int arg_id) {
   default_directory = M_getenv(env_key);
 
   if (!default_directory)
-    default_directory = I_DoomDir();
+    default_directory = I_ConfigDir();
 
   arg = dsda_Arg(arg_id);
   if (arg->found) {

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -767,7 +767,7 @@ int GetFullPath(const char* FileName, const char* ext, char *Buffer, size_t Buff
       strcpy(dir, M_getenv("DOOMWADDIR"));
       break;
     case 2:
-      strcpy(dir, I_DoomDir());
+      strcpy(dir, I_ConfigDir());
       break;
     }
 

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -767,7 +767,7 @@ int GetFullPath(const char* FileName, const char* ext, char *Buffer, size_t Buff
       strcpy(dir, M_getenv("DOOMWADDIR"));
       break;
     case 2:
-      strcpy(dir, I_DoomExeDir());
+      strcpy(dir, I_DoomDir());
       break;
     }
 

--- a/prboom2/src/i_system.h
+++ b/prboom2/src/i_system.h
@@ -76,7 +76,8 @@ void I_SwitchToWindow(HWND hwnd);
 // e6y
 const char* I_GetTempDir(void);
 
-const char *I_DoomExeDir(void); // killough 2/16/98: path to executable's dir
+const char *I_ExeDir(void); // killough 2/16/98: path to executable's dir
+const char *I_DoomDir(void); // path to config and autoload dir
 
 dboolean HasTrailingSlash(const char* dn);
 char* I_RequireFile(const char* wfname, const char* ext);

--- a/prboom2/src/i_system.h
+++ b/prboom2/src/i_system.h
@@ -77,7 +77,7 @@ void I_SwitchToWindow(HWND hwnd);
 const char* I_GetTempDir(void);
 
 const char *I_ExeDir(void); // killough 2/16/98: path to executable's dir
-const char *I_DoomDir(void); // path to config and autoload dir
+const char *I_ConfigDir(void); // path to config and autoload dir
 
 dboolean HasTrailingSlash(const char* dn);
 char* I_RequireFile(const char* wfname, const char* ext);

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -691,10 +691,10 @@ void M_LoadDefaults (void)
   }
   else
   {
-    const char* exedir = I_DoomExeDir();
-    int len = snprintf(NULL, 0, "%s/dsda-doom.cfg", exedir);
+    const char* doomdir = I_DoomDir();
+    int len = snprintf(NULL, 0, "%s/dsda-doom.cfg", doomdir);
     defaultfile = Z_Malloc(len + 1);
-    snprintf(defaultfile, len + 1, "%s/dsda-doom.cfg", exedir);
+    snprintf(defaultfile, len + 1, "%s/dsda-doom.cfg", doomdir);
   }
 
   lprintf(LO_DEBUG, " default file: %s\n", defaultfile);
@@ -889,7 +889,7 @@ void M_ScreenShot(void)
     shot_dir = M_CheckWritableDir(dsda_StringConfig(dsda_config_screenshot_dir));
   if (!shot_dir)
 #ifdef _WIN32
-    shot_dir = M_CheckWritableDir(I_DoomExeDir());
+    shot_dir = M_CheckWritableDir(I_DoomDir());
 #else
     shot_dir = (M_WriteAccess(SCREENSHOT_DIR) ? SCREENSHOT_DIR : NULL);
 #endif

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -691,10 +691,10 @@ void M_LoadDefaults (void)
   }
   else
   {
-    const char* doomdir = I_DoomDir();
-    int len = snprintf(NULL, 0, "%s/dsda-doom.cfg", doomdir);
+    const char* configdir = I_ConfigDir();
+    int len = snprintf(NULL, 0, "%s/dsda-doom.cfg", configdir);
     defaultfile = Z_Malloc(len + 1);
-    snprintf(defaultfile, len + 1, "%s/dsda-doom.cfg", doomdir);
+    snprintf(defaultfile, len + 1, "%s/dsda-doom.cfg", configdir);
   }
 
   lprintf(LO_DEBUG, " default file: %s\n", defaultfile);
@@ -889,7 +889,7 @@ void M_ScreenShot(void)
     shot_dir = M_CheckWritableDir(dsda_StringConfig(dsda_config_screenshot_dir));
   if (!shot_dir)
 #ifdef _WIN32
-    shot_dir = M_CheckWritableDir(I_DoomDir());
+    shot_dir = M_CheckWritableDir(I_ConfigDir());
 #else
     shot_dir = (M_WriteAccess(SCREENSHOT_DIR) ? SCREENSHOT_DIR : NULL);
 #endif


### PR DESCRIPTION
Ive been meaning to make this PR for like a year :P

This is most useful for finding dsda-doom.wad. When installing/updating, you would need to copy dsda-doom.wad to some folder that dsda searched (~/.dsda-doom for example). This sucked, so adding the executable directory to the search path is pretty helpful.

Will create merge conflicts in PR https://github.com/kraflab/dsda-doom/pull/491