### PR TITLE
Lineskip practice trails

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2747,7 +2747,9 @@ void AM_Drawer (dboolean minimap)
   }
 
   AM_drawMarks();
-  AM_drawTrail();
+
+  if (dsda_RevealAutomap() == 2)
+    AM_drawTrail();
 
   V_EndAutomapDraw();
 }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -844,6 +844,19 @@ void AM_clearMarks(void)
   markpointnum = 0;
 }
 
+//
+// AM_clearTrail()
+//
+// Sets the number of trails to 0, thereby clearing them from the display
+//
+// Passed nothing, returns nothing
+//
+void AM_clearTrail(void)
+{
+  trailpos = 0;
+  trailsize = 0;
+}
+
 void AM_InitParams(void)
 {
   map_blinking_locks = dsda_IntConfig(dsda_config_map_blinking_locks);

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -605,9 +605,16 @@ static void AM_updateTrail(void) {
 
     AM_GetMobjPosition(plr->mo, &pt, &angle);
 
-    last = (trailpos + (TRAIL_LENGTH - 1)) % TRAIL_LENGTH;
-    moved = trailpoints[last].x != pt.x ||
-            trailpoints[last].y != pt.y;
+    if (trailsize == 0)
+    {
+      moved = true;
+    }
+    else
+    {
+      last = (trailpos + (trailsize - 1)) % trailsize;
+      moved = trailpoints[last].x != pt.x ||
+              trailpoints[last].y != pt.y;
+    }
 
     if (moved) {
       trailpoints[trailpos].x = pt.x;

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2493,10 +2493,12 @@ static void AM_drawTrail() {
 
   for (i = 0; i < trailsize; i++) // killough 2/22/98: remove automap mark limit
   {
+    int pos = (i + trailpos) % trailsize;
+
     mpoint_t p;
 
-    p.x = trailpoints[i].x;
-    p.y = trailpoints[i].y;
+    p.x = trailpoints[pos].x;
+    p.y = trailpoints[pos].y;
 
     if (automap_rotate)
       AM_rotatePoint(&p);
@@ -2517,12 +2519,12 @@ static void AM_drawTrail() {
       mpoint_t e, f, g, h;
       mline_t line;
 
-      a.x = b.x = e.x = trailpoints[i].x - 65536;
-      c.x = d.x = f.x = trailpoints[i].x + 65536;
-      a.y = d.y = g.y = trailpoints[i].y - 65536;
-      b.y = c.y = h.y = trailpoints[i].y + 65536;
-      e.y = f.y = trailpoints[i].y;
-      g.x = h.x = trailpoints[i].x;
+      a.x = b.x = e.x = trailpoints[pos].x - 65536;
+      c.x = d.x = f.x = trailpoints[pos].x + 65536;
+      a.y = d.y = g.y = trailpoints[pos].y - 65536;
+      b.y = c.y = h.y = trailpoints[pos].y + 65536;
+      e.y = f.y = trailpoints[pos].y;
+      g.x = h.x = trailpoints[pos].x;
 
       if (automap_rotate)
       {

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2491,10 +2491,20 @@ static void AM_drawTrail() {
     p.x = trailpoints[i].x;
     p.y = trailpoints[i].y;
 
+    if (automap_rotate)
+      AM_rotatePoint(&p);
+    else
+      AM_SetMPointFloatValue(&p);
+
     p.x = CXMTOF(p.x);
     p.y = CYMTOF(p.y);
+    if (am_frame.precise)
+    {
+      p.fx = CXMTOF_F(p.fx);
+      p.fy = CYMTOF_F(p.fy);
+    }
 
-    if (p.y < f_y + f_h && p.y >= f_y)
+    if (p.x >= f_x && p.y >= f_y && p.x < f_x + f_w && p.y < f_y + f_h)
     {
       mpoint_t a, b, c, d;
       mpoint_t e, f, g, h;
@@ -2506,14 +2516,28 @@ static void AM_drawTrail() {
       b.y = c.y = h.y = trailpoints[i].y + 65536;
       e.y = f.y = trailpoints[i].y;
       g.x = h.x = trailpoints[i].x;
-      if (am_frame.precise)
+
+      if (automap_rotate)
       {
-        a.fx = b.fx = e.fx = a.x;
-        c.fx = d.fx = f.fx = c.x;
-        a.fy = d.fy = g.fy = a.y;
-        b.fy = c.fy = h.fy = b.y;
-        e.fy = f.fy = e.y;
-        g.fx = h.fx = g.x;
+        AM_rotatePoint(&a);
+        AM_rotatePoint(&b);
+        AM_rotatePoint(&c);
+        AM_rotatePoint(&d);
+        AM_rotatePoint(&e);
+        AM_rotatePoint(&f);
+        AM_rotatePoint(&g);
+        AM_rotatePoint(&h);
+      }
+      else
+      {
+        AM_SetMPointFloatValue(&a);
+        AM_SetMPointFloatValue(&b);
+        AM_SetMPointFloatValue(&c);
+        AM_SetMPointFloatValue(&d);
+        AM_SetMPointFloatValue(&e);
+        AM_SetMPointFloatValue(&f);
+        AM_SetMPointFloatValue(&g);
+        AM_SetMPointFloatValue(&h);
       }
 
       // Inner cross in dark gray

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -79,6 +79,7 @@ void AM_Start(dboolean full_automap);
 //jff 4/16/98 make externally available
 
 void AM_clearMarks(void);
+void AM_clearTrail(void);
 
 void AM_setMarkParams(int num);
 

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1047,6 +1047,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     dsda_config_int, 0, map_things_appearance_max - 1, { map_things_appearance_max - 1 },
     NULL, NOT_STRICT, AM_InitParams
   },
+  [dsda_config_map_trail] = {
+    "map_trail", dsda_config_map_trail,
+    CONF_BOOL(0)
+  },
   [dsda_config_videomode] = {
     "videomode", dsda_config_videomode,
     CONF_STRING("Software"), NULL, NOT_STRICT, M_ChangeVideoMode

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -233,6 +233,7 @@ typedef enum {
   dsda_config_map_textured_overlay_trans,
   dsda_config_map_lines_overlay_trans,
   dsda_config_map_things_appearance,
+  dsda_config_map_trail,
   dsda_config_videomode,
   dsda_config_screen_resolution,
   dsda_config_custom_resolution,

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2271,6 +2271,7 @@ void G_DoWorldDone (void)
   G_DoLoadLevel();
   gameaction = ga_nothing;
   AM_clearMarks();           //jff 4/12/98 clear any marks on the automap
+  AM_clearTrail();
   dsda_EvaluateSkipModeDoWorldDone();
 }
 
@@ -3065,6 +3066,7 @@ void G_InitNew(int skill, int episode, int map, dboolean prepare)
 
   //jff 4/16/98 force marks on automap cleared every new level start
   AM_clearMarks();
+  AM_clearTrail();
 
   dsda_InitSky();
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3949,7 +3949,6 @@ setup_menu_t helpstrings[] =  // HELP screen strings
   {"STRAFE RIGHT",S_SKIP|S_INPUT,m_null,KT_X3,0,dsda_input_straferight},
   {"STRAFE"      ,S_SKIP|S_INPUT,m_null,KT_X3,0,dsda_input_strafe},
   {"AUTORUN"     ,S_SKIP|S_INPUT,m_null,KT_X3,0,dsda_input_autorun},
-  {"180 TURN"    ,S_SKIP|S_INPUT,m_null,KT_X3,0,dsda_input_reverse},
   {"USE"         ,S_SKIP|S_INPUT,m_null,KT_X3,0,dsda_input_use},
   NEW_COLUMN,
   {"GAME"        ,S_SKIP|S_TITLE,m_null,KT_X2},

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2701,6 +2701,7 @@ setup_menu_t auto_settings1[] =  // 1st AutoMap Settings screen
   { "Enable textured display", S_YESNO, m_conf, AU_X, dsda_config_map_textured },
   { "Things appearance", S_CHOICE, m_conf, AU_X, dsda_config_map_things_appearance, 0, map_things_appearance_list },
   { "Show Minimap", S_YESNO, m_conf, AU_X, dsda_config_show_minimap },
+  { "Lineskip practice trails", S_YESNO, m_conf, AU_X, dsda_config_map_trail },
   EMPTY_LINE,
   { "Translucency percentage", S_SKIP | S_TITLE, m_null, AU_X},
   { "Textured automap", S_NUM, m_conf, AU_X, dsda_config_map_textured_trans },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -246,6 +246,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_map_textured_overlay_trans),
   MIGRATED_SETTING(dsda_config_map_lines_overlay_trans),
   MIGRATED_SETTING(dsda_config_map_things_appearance),
+  MIGRATED_SETTING(dsda_config_map_trail),
 
   SETTING_HEADING("Heads-up display settings"),
   MIGRATED_SETTING(dsda_config_hud_health_red),


### PR DESCRIPTION
A toggle is added to the 'automap' section of the options menu. (No key binding is added.)

When the full automap cheat is used, this feature shows a trail of the last 350 unique coordinates of the player on the map (at least 10 seconds of movement). This can greatly aid speedrunners in finding successful lineskip set-ups.

The image below shows a successful lineskip in MAP01, southwards, if that line had a trigger: one tic your center is still above the line, next tic your entire hitbox is below the line.

![image](https://github.com/kraflab/dsda-doom/assets/5273753/a633f6b9-9be5-481d-8c83-2015244c0300)

PS. I hope the "local player" implementation is correct in case of network play (I haven't tested this)