### PR TITLE
Fix weapon sprite offset for irregular aspect ratios

### DIFF
--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1288,9 +1288,12 @@ void SetRatio(int width, int height)
   tallscreen = (ratio_scale < ratio_multiplier);
   if (tallscreen)
   {
+    float ratio_quotient = (float)ratio_multiplier/ratio_scale;
+    float ratio_percentage = (ratio_quotient - 1) * 100.0;
+    psprite_offset = (int)(ratio_percentage*FRACUNIT);
+
     lprintf(LO_DEBUG, "SetRatio: tallscreen aspect recognized; flipping multiplier\n");
     swap(&ratio_multiplier, &ratio_scale);
-    psprite_offset = (int)(6.5*FRACUNIT);
   }
   else
   {

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1285,19 +1285,15 @@ void SetRatio(int width, int height)
   ratio_scale *= 3;
   ReduceFraction(&ratio_multiplier, &ratio_scale);
 
+  float ratio_quotient = (float)ratio_multiplier/ratio_scale;
+  float ratio_percentage = (ratio_quotient - 1) * 100.0;
+  psprite_offset = MAX(0, (int)(ratio_percentage*FRACUNIT));
+
   tallscreen = (ratio_scale < ratio_multiplier);
   if (tallscreen)
   {
-    float ratio_quotient = (float)ratio_multiplier/ratio_scale;
-    float ratio_percentage = (ratio_quotient - 1) * 100.0;
-    psprite_offset = (int)(ratio_percentage*FRACUNIT);
-
     lprintf(LO_DEBUG, "SetRatio: tallscreen aspect recognized; flipping multiplier\n");
     swap(&ratio_multiplier, &ratio_scale);
-  }
-  else
-  {
-    psprite_offset = 0;
   }
   lprintf(LO_DEBUG, "SetRatio: multiplier %u/%u\n", ratio_multiplier, ratio_scale);
 

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1285,9 +1285,11 @@ void SetRatio(int width, int height)
   ratio_scale *= 3;
   ReduceFraction(&ratio_multiplier, &ratio_scale);
 
-  float ratio_quotient = (float)ratio_multiplier/ratio_scale;
-  float ratio_percentage = (ratio_quotient - 1) * 100.0;
-  psprite_offset = MAX(0, (int)(ratio_percentage*FRACUNIT));
+  {
+    float ratio_quotient = (float)ratio_multiplier/ratio_scale;
+    float ratio_percentage = (ratio_quotient - 1) * 100.0;
+    psprite_offset = MAX(0, (int)(ratio_percentage*FRACUNIT));
+  }
 
   tallscreen = (ratio_scale < ratio_multiplier);
   if (tallscreen)

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1285,15 +1285,19 @@ void SetRatio(int width, int height)
   ratio_scale *= 3;
   ReduceFraction(&ratio_multiplier, &ratio_scale);
 
-  float ratio_quotient = (float)ratio_multiplier/ratio_scale;
-  float ratio_percentage = (ratio_quotient - 1) * 100.0;
-  psprite_offset = MAX(0, (int)(ratio_percentage*FRACUNIT));
-
   tallscreen = (ratio_scale < ratio_multiplier);
   if (tallscreen)
   {
+    float ratio_quotient = (float)ratio_multiplier/ratio_scale;
+    float ratio_percentage = (ratio_quotient - 1) * 100.0;
+    psprite_offset = (int)(ratio_percentage*FRACUNIT);
+
     lprintf(LO_DEBUG, "SetRatio: tallscreen aspect recognized; flipping multiplier\n");
     swap(&ratio_multiplier, &ratio_scale);
+  }
+  else
+  {
+    psprite_offset = 0;
   }
   lprintf(LO_DEBUG, "SetRatio: multiplier %u/%u\n", ratio_multiplier, ratio_scale);
 

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1285,11 +1285,9 @@ void SetRatio(int width, int height)
   ratio_scale *= 3;
   ReduceFraction(&ratio_multiplier, &ratio_scale);
 
-  {
-    float ratio_quotient = (float)ratio_multiplier/ratio_scale;
-    float ratio_percentage = (ratio_quotient - 1) * 100.0;
-    psprite_offset = MAX(0, (int)(ratio_percentage*FRACUNIT));
-  }
+  float ratio_quotient = (float)ratio_multiplier/ratio_scale;
+  float ratio_percentage = (ratio_quotient - 1) * 100.0;
+  psprite_offset = MAX(0, (int)(ratio_percentage*FRACUNIT));
 
   tallscreen = (ratio_scale < ratio_multiplier);
   if (tallscreen)


### PR DESCRIPTION
When using a custom resolution with an aspect ratio not found in the settings, the weapon sprite is rendered away from the bottom of the window. This PR keeps the sprite in line with the bottom at any resolution.

Before (720x720):
![before](https://github.com/kraflab/dsda-doom/assets/38776151/e85e18db-2052-4cb3-9d49-18e0cf5c3d3a)

After (720x720):
![after](https://github.com/kraflab/dsda-doom/assets/38776151/02eeb418-fde8-4040-af46-adc68caa815e)
