### PR TITLE
allow shift+<key> when naming savegame

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5000,7 +5000,10 @@ dboolean M_Responder (event_t* ev) {
     }
     else if (ch > 0)
     {
-      ch = toupper(ch);
+      if (shiftdown && ch >= 32 && ch <= 127)
+        ch = shiftxform[ch];
+      else
+        ch = toupper(ch);
       if (ch >= 32 && ch <= 127 &&
           saveCharIndex < SAVESTRINGSIZE-1 &&
           M_StringWidth(savegamestrings[saveSlot]) < (SAVESTRINGSIZE-2)*8)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5000,14 +5000,14 @@ dboolean M_Responder (event_t* ev) {
     }
     else if (ch > 0)
     {
-      if (shiftdown && ch >= 32 && ch <= 127)
-        ch = shiftxform[ch];
-      else
-        ch = toupper(ch);
       if (ch >= 32 && ch <= 127 &&
           saveCharIndex < SAVESTRINGSIZE-1 &&
           M_StringWidth(savegamestrings[saveSlot]) < (SAVESTRINGSIZE-2)*8)
       {
+        if (shiftdown)
+          ch = shiftxform[ch];
+        else
+          ch = toupper(ch);
         savegamestrings[saveSlot][saveCharIndex++] = ch;
         savegamestrings[saveSlot][saveCharIndex] = 0;
       }


### PR DESCRIPTION
useful for symbols such as ()