### PR TITLE
Fix potential hang after restoring keyframe due to invalid blocklist pointers.

### DIFF
--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -1610,6 +1610,10 @@ void P_UnArchiveThinkers(void) {
 
           mobj->state = states + (intptr_t) mobj->state;
 
+          // Wipe blocklist pointers. They will be restored correctly later in P_UnArchiveBlockLinks.
+          mobj->bprev = NULL;
+          mobj->bnext = NULL;
+
           if (mobj->player)
             (mobj->player = &players[(size_t) mobj->player - 1]) -> mo = mobj;
 
@@ -1632,6 +1636,10 @@ void P_UnArchiveThinkers(void) {
             mobj->tranmap = NULL;
 
           P_SetThingPosition (mobj);
+
+          // Wipe blocklist pointers again as P_SetThingPosition may have changed them.
+          mobj->bprev = NULL;
+          mobj->bnext = NULL;
 
           // killough 2/28/98:
           // Fix for falling down into a wall after savegame loaded:


### PR DESCRIPTION
Fix potential hang after restoring keyframe due to invalid blocklist pointers.

When restoring a keyframe, the blockmap is not cleared and blocklist pointers are modified during P_UnArchiveThinkers. The blockmap is then restored in UnArchiveBlockLinks, but this can leave blocklist pointers in an invalid state.

This can then lead to a hang later when the blocklist is iterated and may get stuck in an infinite loop.

The hang is fairly easy to reproduce using Legacy of Rust when Vassago are present after using keyframe restore.

I chose to simply wipe the blocklist pointers during restoring as this avoids adding extra functions or modifying much existing code. It's basically brute-forcing it.