### PR TITLE
Fix crash when adding or removing NOBLOCKMAP and NOSECTOR flags

### DIFF
--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -55,7 +55,7 @@ complevel_t compatibility_level;
 // it's required for demos recorded in "demo compatibility" mode by boom201 for example
 int demover;
 
-int comp[MBF_COMP_TOTAL];    // killough 10/98
+int comp[COMP_TOTAL];    // killough 10/98
 int default_comperr[COMPERR_NUM];
 
 int demo_insurance;        // killough 1/16/98

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -114,7 +114,9 @@ enum {
   comp_friendlyspawn,
   comp_voodooscroller,
   comp_reservedlineflag,
+  comp_blockmapflags,
 
+  COMP_TOTAL,          // actual number of comp options
   MBF_COMP_TOTAL = 32  // limit in MBF format
 };
 
@@ -126,7 +128,7 @@ enum {
   COMPERR_NUM
 };
 
-extern int comp[MBF_COMP_TOTAL];
+extern int comp[COMP_TOTAL];
 extern int default_comperr[COMPERR_NUM];
 
 // -------------------------------------------

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -100,6 +100,7 @@ static const dsda_options_t default_mbf_options = {
   // .comp_friendlyspawn = 1,
   // .comp_voodooscroller = 1,
   // .comp_reservedlineflag = 1,
+  // .comp_blockmapflags = 0,
 };
 
 static const dsda_options_t default_latest_options = {
@@ -148,6 +149,7 @@ static const dsda_options_t default_latest_options = {
   .comp_friendlyspawn = 1,
   .comp_voodooscroller = 0,
   .comp_reservedlineflag = 1,
+  .comp_blockmapflags = 0,
 };
 
 static dsda_options_t mbf_options;
@@ -198,6 +200,7 @@ static dsda_option_t option_list[] = {
   { "comp_friendlyspawn", &mbf_options.comp_friendlyspawn, 0, 1 },
   { "comp_voodooscroller", &mbf_options.comp_voodooscroller, 0, 1 },
   { "comp_reservedlineflag", &mbf_options.comp_reservedlineflag, 0, 1 },
+  { "comp_blockmapflags", &mbf_options.comp_blockmapflags, 0, 1 },
 
   { "mapcolor_back", NULL, 0, 255, dsda_config_mapcolor_back },
   { "mapcolor_grid", NULL, 0, 255, dsda_config_mapcolor_grid },
@@ -327,7 +330,7 @@ const dsda_options_t* dsda_Options(void) {
   return dsda_MBFOptions();
 }
 
-#define MBF21_COMP_TOTAL 25
+#define MBF21_COMP_TOTAL 26
 
 static int mbf21_comp_translation[MBF21_COMP_TOTAL] = {
   comp_telefrag,
@@ -355,6 +358,7 @@ static int mbf21_comp_translation[MBF21_COMP_TOTAL] = {
   comp_friendlyspawn,
   comp_voodooscroller,
   comp_reservedlineflag,
+  comp_blockmapflags,
 };
 
 // killough 5/2/98: number of bytes reserved for saving options
@@ -457,6 +461,10 @@ const byte *dsda_ReadOptions21(const byte *demo_p) {
   // comp_reservedlineflag
   if (count < 25)
     comp[mbf21_comp_translation[24]] = 0;
+
+  // comp_blockmapflags
+  if(count < 26)
+    comp[mbf21_comp_translation[25]] = 1;
 
   G_Compatibility();
 

--- a/prboom2/src/dsda/options.h
+++ b/prboom2/src/dsda/options.h
@@ -62,6 +62,7 @@ typedef struct dsda_options {
   int comp_friendlyspawn;
   int comp_voodooscroller;
   int comp_reservedlineflag;
+  int comp_blockmapflags;
 } dsda_options_t;
 
 void dsda_ParseOptionsLump(void);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2670,11 +2670,13 @@ void G_Compatibility(void)
     // comp_voodooscroller - Voodoo dolls on slow scrollers move too slowly
     { mbf21_compatibility, mbf21_compatibility },
     // comp_reservedlineflag - ML_RESERVED clears extended flags
+    { mbf21_compatibility, mbf21_compatibility },
+    // comp_blockmapflags - adding/removing NOBLOCKMAP or NOSECTOR flags does not update blockmap
     { mbf21_compatibility, mbf21_compatibility }
   };
   unsigned int i;
 
-  if (sizeof(levels)/sizeof(*levels) != MBF_COMP_TOTAL)
+  if (sizeof(levels)/sizeof(*levels) != COMP_TOTAL)
     I_Error("G_Compatibility: consistency error");
 
   for (i = 0; i < sizeof(levels)/sizeof(*levels); i++)
@@ -2808,6 +2810,7 @@ void G_ReloadDefaults(void)
     comp[comp_friendlyspawn] = options->comp_friendlyspawn;
     comp[comp_voodooscroller] = options->comp_voodooscroller;
     comp[comp_reservedlineflag] = options->comp_reservedlineflag;
+    comp[comp_blockmapflags] = options->comp_blockmapflags;
   }
 
   G_Compatibility();

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2693,6 +2693,7 @@ void G_Compatibility(void)
     comp[comp_ouchface] = 0;
     comp[comp_maxhealth] = 0;
     comp[comp_translucency] = 0;
+    comp[comp_blockmapflags] = 0;
   }
 
   e6y_G_Compatibility();//e6y

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3618,8 +3618,9 @@ void A_AddFlags(mobj_t* actor)
 
   // unlink/relink the thing from the blockmap if
   // the NOBLOCKMAP or NOSECTOR flags are added
-  const bool updateBlockmap = ((flags & MF_NOBLOCKMAP) && !(actor->flags & MF_NOBLOCKMAP))
-                           || ((flags & MF_NOSECTOR) && !(actor->flags & MF_NOSECTOR));
+  const bool updateBlockmap = !comp[comp_blockmapflags]
+                           && (((flags & MF_NOBLOCKMAP) && !(actor->flags & MF_NOBLOCKMAP))
+                            || ((flags & MF_NOSECTOR) && !(actor->flags & MF_NOSECTOR)));
 
   if (updateBlockmap)
     P_UnsetThingPosition(actor);
@@ -3649,8 +3650,9 @@ void A_RemoveFlags(mobj_t* actor)
 
   // unlink/relink the thing from the blockmap if
   // the NOBLOCKMAP or NOSECTOR flags are removed
-  const bool updateBlockmap = ((flags & MF_NOBLOCKMAP) && (actor->flags & MF_NOBLOCKMAP))
-                           || ((flags & MF_NOSECTOR) && (actor->flags & MF_NOSECTOR));
+  const bool updateBlockmap = !comp[comp_blockmapflags]
+                           && (((flags & MF_NOBLOCKMAP) && (actor->flags & MF_NOBLOCKMAP))
+                            || ((flags & MF_NOSECTOR) && (actor->flags & MF_NOSECTOR)));
 
   if (updateBlockmap)
     P_UnsetThingPosition(actor);

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3616,8 +3616,19 @@ void A_AddFlags(mobj_t* actor)
   flags  = actor->state->args[0];
   flags2 = actor->state->args[1];
 
+  // unlink/relink the thing from the blockmap if
+  // the NOBLOCKMAP or NOSECTOR flags are added
+  const bool updateBlockmap = ((flags & MF_NOBLOCKMAP) && !(actor->flags & MF_NOBLOCKMAP))
+                           || ((flags & MF_NOSECTOR) && !(actor->flags & MF_NOSECTOR));
+
+  if (updateBlockmap)
+    P_UnsetThingPosition(actor);
+
   actor->flags  |= flags;
   actor->flags2 |= flags2;
+
+  if (updateBlockmap)
+    P_SetThingPosition(actor);
 }
 
 //
@@ -3636,8 +3647,19 @@ void A_RemoveFlags(mobj_t* actor)
   flags  = actor->state->args[0];
   flags2 = actor->state->args[1];
 
+  // unlink/relink the thing from the blockmap if
+  // the NOBLOCKMAP or NOSECTOR flags are removed
+  const bool updateBlockmap = ((flags & MF_NOBLOCKMAP) && (actor->flags & MF_NOBLOCKMAP))
+                           || ((flags & MF_NOSECTOR) && (actor->flags & MF_NOSECTOR));
+
+  if (updateBlockmap)
+    P_UnsetThingPosition(actor);
+
   actor->flags  &= ~flags;
   actor->flags2 &= ~flags2;
+
+  if (updateBlockmap)
+    P_SetThingPosition(actor);
 }
 
 


### PR DESCRIPTION
If MBF21's A_AddFlags or A_RemoveFlags is used to add or set the NOBLOCKMAP or NOSECTOR flags, the game can crash due to a dangling actor pointer. This can occasionally be seen with Legacy of Rust (id1.wad)'s Vassago fireballs when they impact a wal -- it's luck of the draw whether it decides to crash, since it's invalid memory shenanigans, but either way it's buggy. :P

This PR fixes the crash, and adds a new `comp_blockmapflags` option (not settable via OPTIONS lump since it's strictly a bugfix) that re-enables the buggy behavior for any demos that were recorded before the fix. Attached a quick demo (requires id1.wad) recorded on the release build, just as a demo of the comp functionality.

[comp_blockmapflags.lmp.zip](https://github.com/user-attachments/files/16703312/comp_blockmapflags.lmp.zip)

Lemme know if this all looks kosher and I'll make a PR to the MBF21 repo documenting the new comp option (sort of a minor implementation detail in a way, since it's not user-settable, but the docs oughta be accurate ;).