### PR TITLE
Fix music not automatically playing when using shareware iwad.

### DIFF
--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -3677,10 +3677,7 @@ void P_SetupLevel(int episode, int map, int playermask, int skill)
   lumpnum = W_GetNumForName(lumpname);
 
   // Must process musinfo to get default track before calling S_Start
-  if (gamemode != shareware)
-  {
-    S_ParseMusInfo(lumpname);
-  }
+  S_ParseMusInfo(lumpname);
 
   // Make sure all sounds are stopped before Z_FreeTag.
   S_Start();

--- a/prboom2/src/s_advsound.c
+++ b/prboom2/src/s_advsound.c
@@ -59,7 +59,7 @@ musinfo_t musinfo;
 //
 void S_ParseMusInfo(const char *mapid)
 {
-  if (W_LumpNameExists("MUSINFO"))
+  if (gamemode != shareware && W_LumpNameExists("MUSINFO"))
   {
     int num, lumpnum;
     int inMap = false;


### PR DESCRIPTION
Fix music not automatically playing when using a shareware iwad.

musinfo is not tested or parsed for shareware iwads, but the musinfo list was not set appropriately.

This meant that when later trying to playing the music, an attempt is made to play an invalid music lump, which fails.