### PR TITLE
Prefer ~/Library/Application Support/dsda-doom as the data folder on macOS

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -323,12 +323,16 @@ const char *I_ConfigDir(void)
 
       Z_Free(base);
 
+#ifdef __APPLE__
+      base = dsda_ConcatDir(home, "Library/Application Support/dsda-doom");
+#else
       xdg_data_home = M_getenv("XDG_DATA_HOME");
       if (xdg_data_home)
         base = dsda_ConcatDir(xdg_data_home, "dsda-doom");
       else
         // $XDG_DATA_HOME should be $HOME/.local/share if not defined.
         base = dsda_ConcatDir(home, ".local/share/dsda-doom");
+#endif
     }
 
     M_MakeDir(base, true); // Make sure it exists


### PR DESCRIPTION
I was implementing support for the new data folders for the launcher when I noticed that https://github.com/kraflab/dsda-doom/commit/38fc904d32f434a8ead3d8c815753fa13e9cdb70 added support to folders that we do not use on mac

- XDG_DATA_HOME does not exist
- ~/.local/share is not conventionally used. Only some apps that start with linux support might use this same path for mac (Citra for example, although I might have an old version)

So, on mac the "correct" folder is "~/Library/Application Support"