### PR TITLE
Add macos artifact uploading

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -121,16 +121,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          rm /usr/local/bin/2to3
-          rm /usr/local/bin/2to3-3.12
-          rm /usr/local/bin/idle3
-          rm /usr/local/bin/idle3.12
-          rm /usr/local/bin/pydoc3
-          rm /usr/local/bin/pydoc3.12
-          rm /usr/local/bin/python3
-          rm /usr/local/bin/python3-config
-          rm /usr/local/bin/python3.12
-          rm /usr/local/bin/python3.12-config
+          brew install --overwrite python@3.12
           env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
             brew install \
               cmake \

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,52 +16,51 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {
-              name: "MSVC x64",
-              os: windows-latest,
-              build_type: "Release",
-              extra_options: "-A x64",
-              vcpkg_triplet: x64-windows,
-              shell: bash,
-            }
-          - {
-              name: "MSYS2 UCRT64",
-              os: windows-latest,
-              build_type: "Release",
-              extra_options: "-G Ninja",
-              package_name: "mingw_x64",
-              shell: "msys2 {0}",
-              msystem: ucrt64,
-              msys-env: mingw-w64-ucrt-x86_64,
-              artifact-path: build/*.zip,
-            }
-          - {
-              name: "Linux GCC",
-              os: ubuntu-latest,
-              build_type: "Release",
-              extra_options: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr",
-              package_name: "linux_gcc",
-              shell: bash,
-              artifact-path: build/*.appimage,
-            }
-          - {
-              name: "macOS arm64 Clang",
-              os: macos-latest,
-              build_type: "Release",
-              extra_options: "-G Ninja",
-              package_name: "mac_arm64",
-              shell: bash,
-              artifact-path: build/*.zip,
-            }
-          - {
-              name: "macOS x64 Clang",
-              os: macos-13,
-              build_type: "Release",
-              extra_options: "-G Ninja",
-              package_name: "mac_x64",
-              shell: bash,
-              artifact-path: build/*.zip,
-            }
+          - name: "MSVC x64"
+            os: windows-latest
+            build_type: "Release"
+            vcpkg_triplet: x64-windows
+            shell: pwsh
+            extra_options: >-
+              -A x64
+              -DCMAKE_TOOLCHAIN_FILE="${env:VCPKG_INSTALLATION_ROOT}\scripts\buildsystems\vcpkg.cmake"
+              -DVCPKG_TARGET_TRIPLET=x64-windows
+              
+          - name: "MSYS2 UCRT64"
+            os: windows-latest
+            build_type: "Release"
+            extra_options: "-G Ninja"
+            package_name: "mingw_x64"
+            shell: "msys2 {0}"
+            msystem: ucrt64
+            msys-env: mingw-w64-ucrt-x86_64
+            artifact-path: build/*.zip
+
+          - name: "Linux GCC"
+            os: ubuntu-latest
+            build_type: "Release"
+            extra_options: "-G Ninja -DCMAKE_INSTALL_PREFIX=/usr"
+            package_name: "linux_gcc"
+            shell: bash
+            artifact-path: build/*.appimage
+            
+          - name: "macOS arm64 Clang"
+            os: macos-latest,
+            build_type: "Release"
+            extra_options: "-G Ninja"
+            package_name: "mac_arm64"
+            shell: bash
+            artifact-path: build/*.zip
+            
+            
+          - name: "macOS x64 Clang"
+            os: macos-13
+            build_type: "Release"
+            extra_options: "-G Ninja"
+            package_name: "mac_x64"
+            shell: bash
+            artifact-path: build/*.zip
+            
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -45,11 +45,20 @@ jobs:
               artifact-path: build/*.appimage,
             }
           - {
-              name: "macOS Clang",
+              name: "macOS arm64 Clang",
               os: macos-latest,
               build_type: "Release",
               extra_options: "-G Ninja",
               package_name: "mac_arm64",
+              shell: bash,
+              artifact-path: build/*.zip,
+            }
+          - {
+              name: "macOS x64 Clang",
+              os: macos-13,
+              build_type: "Release",
+              extra_options: "-G Ninja",
+              package_name: "mac_x64",
               shell: bash,
               artifact-path: build/*.zip,
             }

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -49,6 +49,7 @@ jobs:
               os: macos-latest,
               build_type: "Release",
               extra_options: "-G Ninja",
+              package_name: "mac_arm64",
               shell: bash,
               artifact-path: build/*.zip,
             }

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -45,7 +45,7 @@ jobs:
             artifact-path: build/*.appimage
             
           - name: "macOS arm64 Clang"
-            os: macos-latest,
+            os: macos-latest
             build_type: "Release"
             extra_options: "-G Ninja"
             package_name: "mac_arm64"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -50,6 +50,7 @@ jobs:
               build_type: "Release",
               extra_options: "-G Ninja",
               shell: bash,
+              artifact-path: build/*.zip,
             }
 
     steps:
@@ -140,7 +141,8 @@ jobs:
               portmidi \
               sdl2 \
               sdl2_image \
-              sdl2_mixer
+              sdl2_mixer \
+              dylibbundler
 
       - name: Configure
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -138,6 +138,16 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
+          rm /usr/local/bin/2to3
+          rm /usr/local/bin/2to3-3.12
+          rm /usr/local/bin/idle3
+          rm /usr/local/bin/idle3.12
+          rm /usr/local/bin/pydoc3
+          rm /usr/local/bin/pydoc3.12
+          rm /usr/local/bin/python3
+          rm /usr/local/bin/python3-config
+          rm /usr/local/bin/python3.12
+          rm /usr/local/bin/python3.12-config
           env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
             brew install \
               cmake \

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -262,16 +262,23 @@ elseif(APPLE)
     set(CPACK_EXTERNAL_ENABLE_STAGING YES)
     set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
     set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake")
+    set(CPACK_SYSTEM_NAME "mac-${CMAKE_SYSTEM_PROCESSOR}")
+    set(CPACK_BUILD_DIR "${PROJECT_BINARY_DIR}")
 
     file(GENERATE
         OUTPUT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake"
         CONTENT [[
-            find_program(DYLIBBUNDLER_EXECUTABLE
-                NAMES dylibbundler)
+            set(CPACK_OUTPUT_DIR "${CPACK_BUILD_DIR}/${CPACK_PACKAGE_FILE_NAME}")
+            file(MAKE_DIRECTORY ${CPACK_OUTPUT_DIR})
 
+            find_program(DYLIBBUNDLER_EXECUTABLE NAMES dylibbundler)
             if(NOT DYLIBBUNDLER_EXECUTABLE)
                 message(FATAL_ERROR "Missing dylibbundler (brew install dylibbundler)")
             endif()
+
+            file(COPY_FILE
+                $<TARGET_FILE:dsda-doom>
+                ${CPACK_OUTPUT_DIR}/dsda-doom)
 
             execute_process(COMMAND
                 ${CMAKE_COMMAND} -E env
@@ -280,20 +287,22 @@ elseif(APPLE)
                 ${DYLIBBUNDLER_EXECUTABLE}
                 --bundle-deps
                 --create-dir
-                --fix-file $<TARGET_FILE:dsda-doom>
+                --fix-file ${CPACK_OUTPUT_DIR}/dsda-doom
                 --install-path @executable_path/libs
-                --dest-dir ${CPACK_PACKAGE_FILE_NAME}/libs
-                )
+                --dest-dir ${CPACK_OUTPUT_DIR}/libs)
 
-            execute_process(COMMAND cp $<TARGET_FILE:dsda-doom> ${CPACK_PACKAGE_FILE_NAME}/dsda-doom)
-            execute_process(COMMAND cp ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/games/doom/dsda-doom.wad ${CPACK_PACKAGE_FILE_NAME}/dsda-doom.wad)
-            execute_process(COMMAND cp ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/dsda-doom/COPYING ${CPACK_PACKAGE_FILE_NAME}/COPYING.txt)
+            file(COPY_FILE
+                ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/games/doom/dsda-doom.wad
+                ${CPACK_OUTPUT_DIR}/dsda-doom.wad)
+            file(COPY_FILE
+                ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/dsda-doom/COPYING
+                ${CPACK_OUTPUT_DIR}/COPYING.txt)
 
             file(CONFIGURE
-                OUTPUT ${CPACK_PACKAGE_FILE_NAME}/Quarantine.txt
+                OUTPUT ${CPACK_OUTPUT_DIR}/Quarantine.txt
                 CONTENT "If you are getting errors like 'libzip.5.5.dylib cant be opened because Apple cannot check it for malicious software.' Run the following command in the dsda-doom folder:\n\nxattr -dr com.apple.quarantine path/to/folder")
 
-            execute_process(COMMAND zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME})
+            execute_process(COMMAND zip -r ${CPACK_OUTPUT_DIR}.zip ${CPACK_OUTPUT_DIR})
             ]])
 endif()
 include(CPack)

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -261,7 +261,7 @@ elseif(APPLE)
     set(CPACK_GENERATOR External)
     set(CPACK_EXTERNAL_ENABLE_STAGING YES)
     set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake")
+    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/maczip-generate.cmake")
 
     file(GENERATE
         OUTPUT "${PROJECT_BINARY_DIR}/maczip-generate.cmake"

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -261,10 +261,10 @@ elseif(APPLE)
     set(CPACK_GENERATOR External)
     set(CPACK_EXTERNAL_ENABLE_STAGING YES)
     set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/maczip-generate.cmake")
+    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake")
 
     file(GENERATE
-        OUTPUT "${PROJECT_BINARY_DIR}/maczip-generate.cmake"
+        OUTPUT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake"
         CONTENT [[
             find_program(DYLIBBUNDLER_EXECUTABLE
                 NAMES dylibbundler)
@@ -288,6 +288,10 @@ elseif(APPLE)
             execute_process(COMMAND cp $<TARGET_FILE:dsda-doom> ${CPACK_PACKAGE_FILE_NAME}/dsda-doom)
             execute_process(COMMAND cp ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/games/doom/dsda-doom.wad ${CPACK_PACKAGE_FILE_NAME}/dsda-doom.wad)
             execute_process(COMMAND cp ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/dsda-doom/COPYING ${CPACK_PACKAGE_FILE_NAME}/COPYING.txt)
+
+            file(CONFIGURE
+                OUTPUT ${CPACK_PACKAGE_FILE_NAME}/Quarantine.txt
+                CONTENT "If you are getting errors like 'libzip.5.5.dylib cant be opened because Apple cannot check it for malicious software.' Run the following command in the dsda-doom folder:\n\nxattr -dr com.apple.quarantine path/to/folder")
 
             execute_process(COMMAND zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME})
             ]])

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -263,6 +263,7 @@ elseif(APPLE)
     set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
     set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake")
     set(CPACK_SYSTEM_NAME "mac-${CMAKE_SYSTEM_PROCESSOR}")
+    set(CPACK_SYSTEM_PROCESSOR "${CMAKE_SYSTEM_PROCESSOR}")
     set(CPACK_BUILD_DIR "${PROJECT_BINARY_DIR}")
 
     file(GENERATE
@@ -288,8 +289,8 @@ elseif(APPLE)
                 --bundle-deps
                 --create-dir
                 --fix-file ${CPACK_OUTPUT_DIR}/dsda-doom
-                --install-path @executable_path/libs
-                --dest-dir ${CPACK_OUTPUT_DIR}/libs)
+                --install-path @executable_path/libs_${CPACK_SYSTEM_PROCESSOR}
+                --dest-dir ${CPACK_OUTPUT_DIR}/libs_${CPACK_SYSTEM_PROCESSOR})
 
             file(COPY_FILE
                 ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/games/doom/dsda-doom.wad

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -286,12 +286,10 @@ elseif(APPLE)
                 )
 
             execute_process(COMMAND cp $<TARGET_FILE:dsda-doom> ${CPACK_PACKAGE_FILE_NAME}/dsda-doom)
-            execute_process(COMMAND cp dsda-doom.wad ${CPACK_PACKAGE_FILE_NAME}/dsda-doom.wad)
+            execute_process(COMMAND cp ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/games/doom/dsda-doom.wad ${CPACK_PACKAGE_FILE_NAME}/dsda-doom.wad)
+            execute_process(COMMAND cp ${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/doc/dsda-doom/COPYING ${CPACK_PACKAGE_FILE_NAME}/COPYING.txt)
 
-
-            execute_process(COMMAND
-                zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME}
-                )
+            execute_process(COMMAND zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME})
             ]])
 endif()
 include(CPack)

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -257,5 +257,41 @@ elseif(LINUX)
                 --icon-file=${CPACK_TEMPORARY_DIRECTORY}/${CPACK_PACKAGING_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps/dsda-doom.svg
                 --output=appimage)
             ]])
+elseif(APPLE)
+    set(CPACK_GENERATOR External)
+    set(CPACK_EXTERNAL_ENABLE_STAGING YES)
+    set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+    set(CPACK_EXTERNAL_PACKAGE_SCRIPT "${PROJECT_BINARY_DIR}/macbundle-generate.cmake")
+
+    file(GENERATE
+        OUTPUT "${PROJECT_BINARY_DIR}/maczip-generate.cmake"
+        CONTENT [[
+            find_program(DYLIBBUNDLER_EXECUTABLE
+                NAMES dylibbundler)
+
+            if(NOT DYLIBBUNDLER_EXECUTABLE)
+                message(FATAL_ERROR "Missing dylibbundler (brew install dylibbundler)")
+            endif()
+
+            execute_process(COMMAND
+                ${CMAKE_COMMAND} -E env
+                OUTPUT=${CPACK_PACKAGE_FILE_NAME}.zip
+                VERSION=$<IF:$<BOOL:${CPACK_PACKAGE_VERSION}>,${CPACK_PACKAGE_VERSION},0.1.0>
+                ${DYLIBBUNDLER_EXECUTABLE}
+                --bundle-deps
+                --create-dir
+                --fix-file $<TARGET_FILE:dsda-doom>
+                --install-path @executable_path/libs
+                --dest-dir ${CPACK_PACKAGE_FILE_NAME}/libs
+                )
+
+            execute_process(COMMAND cp $<TARGET_FILE:dsda-doom> ${CPACK_PACKAGE_FILE_NAME}/dsda-doom)
+            execute_process(COMMAND cp dsda-doom.wad ${CPACK_PACKAGE_FILE_NAME}/dsda-doom.wad)
+
+
+            execute_process(COMMAND
+                zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME}
+                )
+            ]])
 endif()
 include(CPack)

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -299,7 +299,7 @@ elseif(APPLE)
                 ${CPACK_OUTPUT_DIR}/COPYING.txt)
 
             file(CONFIGURE
-                OUTPUT ${CPACK_OUTPUT_DIR}/Quarantine.txt
+                OUTPUT ${CPACK_OUTPUT_DIR}/Troubleshooting.txt
                 CONTENT "If you are getting errors like 'libzip.5.5.dylib cant be opened because Apple cannot check it for malicious software.' Run the following command in the dsda-doom folder:\n\nxattr -dr com.apple.quarantine path/to/folder")
 
             execute_process(COMMAND zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME})

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -302,7 +302,7 @@ elseif(APPLE)
                 OUTPUT ${CPACK_OUTPUT_DIR}/Quarantine.txt
                 CONTENT "If you are getting errors like 'libzip.5.5.dylib cant be opened because Apple cannot check it for malicious software.' Run the following command in the dsda-doom folder:\n\nxattr -dr com.apple.quarantine path/to/folder")
 
-            execute_process(COMMAND zip -r ${CPACK_OUTPUT_DIR}.zip ${CPACK_OUTPUT_DIR})
+            execute_process(COMMAND zip -r ${CPACK_PACKAGE_FILE_NAME}.zip ${CPACK_PACKAGE_FILE_NAME})
             ]])
 endif()
 include(CPack)


### PR DESCRIPTION
https://github.com/Pedro-Beirao/dsda-doom/actions/runs/11133559533

Draft as Im not sure this is the best use of cpack.

I understand that cpack organizes the relevant files as if they were installed, but that isnt really what we need on macos.
Yeah we have App Bundles, but a source port that requires command line parameters on every run shouldnt be packaged that way.

___

Anyway, since we are not using an App Bundle, and the executable and dylibs are not being codesigned, the users will need to give permissions to every single dylib. So maybe we could include a txt file with a command to do it automatically (`xattr -dr com.apple.quarantine path/to/folder`)

Note: with the launcher, the users dont need to give perms like this

CC @rfomin 