### PR TITLE
Add a new thinker thread for teleports

### DIFF
--- a/prboom2/src/p_telept.c
+++ b/prboom2/src/p_telept.c
@@ -145,7 +145,7 @@ static mobj_t* P_TeleportDestination(short thing_id, int tag)
   FIND_SECTORS(id_p, tag)
   {
     register thinker_t* th = NULL;
-    while ((th = P_NextThinker(th,th_misc)) != NULL)
+    while ((th = P_NextThinker(th,th_teleport)) != NULL)
       if (th->function == P_MobjThinker) {
         register mobj_t* m = (mobj_t*)th;
         if (m->type == MT_TELEPORTMAN  &&

--- a/prboom2/src/p_tick.c
+++ b/prboom2/src/p_tick.c
@@ -90,14 +90,23 @@ void P_UpdateThinker(thinker_t *thinker)
   register thinker_t *th;
   // find the class the thinker belongs to
 
-  int class =
-    thinker->function == P_RemoveThinkerDelayed ? th_delete :
-    thinker->function == P_MobjThinker &&
-    ((mobj_t *) thinker)->health > 0 &&
-    (((mobj_t *) thinker)->flags & MF_COUNTKILL ||
-     ((mobj_t *) thinker)->type == MT_SKULL) ?
-    ((mobj_t *) thinker)->flags & MF_FRIEND ?
-    th_friends : th_enemies : th_misc;
+  int class;
+  if (thinker->function == P_RemoveThinkerDelayed)
+    class = th_delete;
+  else if (thinker->function != P_MobjThinker)
+    class = th_misc;
+  else {
+    register mobj_t* m = (mobj_t*)thinker;
+    if (m->type == MT_TELEPORTMAN)
+      class = th_teleport;
+    else if (m->health > 0 && (m->flags & MF_COUNTKILL || m->type == MT_SKULL))
+      if (m->flags & MF_FRIEND)
+        class = th_friends;
+      else
+        class = th_enemies;
+    else
+      class = th_misc;
+  }
 
   {
     /* Remove from current thread, if in one */

--- a/prboom2/src/p_tick.h
+++ b/prboom2/src/p_tick.h
@@ -59,6 +59,7 @@ typedef enum {
   th_misc,
   th_friends,
   th_enemies,
+  th_teleport,
   NUMTHCLASS,
   th_all = NUMTHCLASS, /* For P_NextThinker, indicates "any class" */
 } th_class;


### PR DESCRIPTION
This fixes the extreme lag in Oversaturation when thousands of zombies try to teleport in, and the th_misc class thinker list is around 60000 elements long.

Bofu correctrly voices his concern about desyncs. I think, if the teleport destinations in the list can be guaranteed to be in the same order, there should be no desyncs.