### PR TITLE
Midi volume fixes

### DIFF
--- a/prboom2/src/MUSIC/flplayer.c
+++ b/prboom2/src/MUSIC/flplayer.c
@@ -576,6 +576,7 @@ static void fl_render (void *vdest, unsigned length)
             {
               fluid_synth_cc (f_syn, i, 123, 0); // ALL NOTES OFF
               fluid_synth_cc (f_syn, i, 121, 0); // RESET ALL CONTROLLERS
+              fluid_synth_cc (f_syn, i, 7, 100); // reset volume
             }
             continue;
           }

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -651,6 +651,7 @@ static void pm_render (void *vdest, unsigned bufflen)
               {
                 writeevent (when, 0xB0, i, 0x7B, 0x00); // all notes off
                 writeevent (when, 0xB0, i, 0x79, 0x00); // reset all controllers
+                write_volume (when, i, DEFAULT_VOLUME); // reset volume
               }
               continue;
             }

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -67,7 +67,6 @@ const music_player_t pm_player =
 
 #else // HAVE_LIBPORTMIDI
 
-#include <math.h>
 #include <portmidi.h>
 #include <porttime.h>
 #include <stdio.h>
@@ -394,7 +393,7 @@ static void pm_setvolume (int v)
     return;
 
   pm_volume = v;
-  volume_scale = sqrtf((float)pm_volume / 15);
+  volume_scale = pm_volume / 15.0f;
   update_volume();
 }
 


### PR DESCRIPTION
1. Some midis neglect to set an initial volume, causing issues when the song loops (e.g. 1994TU.wad map17, drums fade out forever). Vanilla Doom and the OPL emulator reset midi volume at the end of each song loop, so this change does the same for Fluidsynth and Portmidi.

2. Users continue to report that the volume curve is too loud, so I'm reverting an old change I made. I already did this for Woof and will probably do the same for other ports.