### PR TITLE
Add -track_reality and reset tracking in casual play

### DIFF
--- a/prboom2/src/dsda.c
+++ b/prboom2/src/dsda.c
@@ -555,11 +555,12 @@ static void dsda_ResetTracking(void) {
 }
 
 void dsda_WatchDeferredInitNew(int skill, int episode, int map) {
+  dsda_ResetTracking();
+  
   if (!demorecording) return;
 
   ++dsda_session_attempts;
 
-  dsda_ResetTracking();
   dsda_QueueQuickstart();
 
   dsda_ResetRevealMap();

--- a/prboom2/src/dsda.c
+++ b/prboom2/src/dsda.c
@@ -47,6 +47,7 @@
 // command-line toggles
 int dsda_track_pacifist;
 int dsda_track_100k;
+int dsda_track_reality;
 
 int dsda_last_leveltime;
 int dsda_last_gamemap;
@@ -152,6 +153,7 @@ void dsda_ReadCommandLine(void) {
 
   dsda_track_pacifist = dsda_Flag(dsda_arg_track_pacifist);
   dsda_track_100k = dsda_Flag(dsda_arg_track_100k);
+  dsda_track_reality = dsda_Flag(dsda_arg_track_reality);
   dsda_analysis = dsda_Flag(dsda_arg_analysis);
   dsda_time_keys = dsda_SimpleIntArg(dsda_arg_time_keys);
   dsda_time_use = dsda_SimpleIntArg(dsda_arg_time_use);
@@ -207,6 +209,17 @@ void dsda_DisplayNotifications(void) {
 
     dsda_100k_note_shown = true;
     dsda_DisplayNotification("100K achieved!");
+  }
+
+  if (!dsda_reality && !dsda_almost_reality_note_shown) {
+    if (!dsda_almost_reality && !dsda_almost_reality_note_shown) {
+      dsda_almost_reality_note_shown = true;
+      dsda_DisplayNotification("Not reality / almost reality!");
+    }
+    else if (!dsda_reality_note_shown) {
+      dsda_reality_note_shown = true;
+      dsda_DisplayNotification("Almost reality!");
+    }
   }
 }
 
@@ -537,6 +550,8 @@ static void dsda_ResetTracking(void) {
   dsda_ResetAnalysis();
 
   dsda_pacifist_note_shown = false;
+  dsda_reality_note_shown = false;
+  dsda_almost_reality_note_shown = false;
 }
 
 void dsda_WatchDeferredInitNew(int skill, int episode, int map) {

--- a/prboom2/src/dsda/analysis.c
+++ b/prboom2/src/dsda/analysis.c
@@ -51,6 +51,8 @@ int dsda_kills_on_map = 0;
 dboolean dsda_100k_on_map = false;
 dboolean dsda_100k_note_shown = false;
 dboolean dsda_pacifist_note_shown = false;
+dboolean dsda_reality_note_shown = false;
+dboolean dsda_almost_reality_note_shown = false;
 
 void dsda_ResetAnalysis(void) {
   dsda_pacifist = true;

--- a/prboom2/src/dsda/analysis.h
+++ b/prboom2/src/dsda/analysis.h
@@ -47,6 +47,8 @@ extern int dsda_kills_on_map;
 extern dboolean dsda_100k_on_map;
 extern dboolean dsda_100k_note_shown;
 extern dboolean dsda_pacifist_note_shown;
+extern dboolean dsda_reality_note_shown;
+extern dboolean dsda_almost_reality_note_shown;
 
 void dsda_ResetAnalysis(void);
 void dsda_WriteAnalysis(void);

--- a/prboom2/src/dsda/args.c
+++ b/prboom2/src/dsda/args.c
@@ -268,6 +268,11 @@ static arg_config_t arg_config[dsda_arg_count] = {
     "tracks when 100% kills is reached",
     arg_null,
   },
+  [dsda_arg_track_reality] = {
+    "-track_reality", NULL, NULL,
+    "tracks reality and almost reality categories restrictions",
+    arg_null,
+  },
   [dsda_arg_time_keys] = {
     "-time_keys", NULL, "105",
     "announces the time when keys are picked up",

--- a/prboom2/src/dsda/args.h
+++ b/prboom2/src/dsda/args.h
@@ -64,6 +64,7 @@ typedef enum {
   dsda_arg_skiptic,
   dsda_arg_track_pacifist,
   dsda_arg_track_100k,
+  dsda_arg_track_reality,
   dsda_arg_time_keys,
   dsda_arg_time_use,
   dsda_arg_time_secrets,


### PR DESCRIPTION
Suggested in the discord. Tracks whether reality and/or almost reality have been broken.

Also noticed that -track_* parameters were not persisting beetween resets/new games without recording demos, so they get reset properly now.