### PR TITLE
Add "Auto Switch Weapon on Pickup" option

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -996,6 +996,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "dsda_switch_when_ammo_runs_out", dsda_config_switch_when_ammo_runs_out,
     CONF_BOOL(1)
   },
+  [dsda_config_switch_weapon_on_pickup] = {
+    "dsda_switch_weapon_on_pickup", dsda_config_switch_weapon_on_pickup,
+    CONF_BOOL(1), NULL, STRICT_INT(1)
+  },
   [dsda_config_viewbob] = {
     "dsda_viewbob", dsda_config_viewbob,
     CONF_BOOL(1)

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -220,6 +220,7 @@ typedef enum {
   dsda_config_parallel_sfx_window,
   dsda_config_movement_toggle_sfx,
   dsda_config_switch_when_ammo_runs_out,
+  dsda_config_switch_weapon_on_pickup,
   dsda_config_viewbob,
   dsda_config_weaponbob,
   dsda_config_quake_intensity,

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3087,6 +3087,7 @@ setup_menu_t misc_settings[] = {
   { "Skip Quit Prompt", S_YESNO, m_conf, G_X, dsda_config_skip_quit_prompt },
   { "Death Use Action", S_CHOICE, m_conf, G_X, dsda_config_death_use_action, 0, death_use_strings },
   { "Boom Weapon Auto Switch", S_YESNO, m_conf, G_X, dsda_config_switch_when_ammo_runs_out },
+  { "Auto Switch Weapon on Pickup", S_YESNO, m_conf, G_X, dsda_config_switch_weapon_on_pickup },
   { "Parallel Same-Sound Limit", S_NUM, m_conf, G_X, dsda_config_parallel_sfx_limit },
   { "Parallel Same-Sound Window", S_NUM, m_conf, G_X, dsda_config_parallel_sfx_window },
   { "Play SFX For Movement Toggles", S_YESNO, m_conf, G_X, dsda_config_movement_toggle_sfx },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -311,6 +311,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_parallel_sfx_window),
   MIGRATED_SETTING(dsda_config_movement_toggle_sfx),
   MIGRATED_SETTING(dsda_config_switch_when_ammo_runs_out),
+  MIGRATED_SETTING(dsda_config_switch_weapon_on_pickup),
   MIGRATED_SETTING(dsda_config_viewbob),
   MIGRATED_SETTING(dsda_config_weaponbob),
   MIGRATED_SETTING(dsda_config_quake_intensity),

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -108,7 +108,21 @@ static weapontype_t GetAmmoChange[] = {
     wp_mace
 };
 
-#define autoswitch (allow_incompatibility && !deathmatch && !netgame ? dsda_IntConfig(dsda_config_switch_weapon_on_pickup) : true)
+//
+// P_AutoSwitchWeapon
+// Autoswitches player to a weapon,
+// Based on config and other conditions.
+//
+
+static void P_AutoSwitchWeapon(player_t *player, weapontype_t weapon)
+{
+  int autoswitch_config = dsda_IntConfig(dsda_config_switch_weapon_on_pickup);
+  int autoswitch = ((allow_incompatibility && !deathmatch && !netgame) ? autoswitch_config : true);
+
+  if (!autoswitch) return;
+
+  player->pendingweapon = weapon;
+}
 
 //
 // P_GiveAmmo
@@ -136,8 +150,7 @@ static dboolean P_GiveAmmoAutoSwitch(player_t *player, ammotype_t ammo, int olda
         weaponinfo[i].ammopershot <= player->ammo[ammo]
       )
       {
-        if (autoswitch)
-          player->pendingweapon = i;
+        P_AutoSwitchWeapon(player, i);
         break;
       }
     }
@@ -190,47 +203,43 @@ static dboolean P_GiveAmmo(player_t *player, ammotype_t ammo, int num)
     {
         if (player->weaponowned[GetAmmoChange[ammo]])
         {
-            if (autoswitch)
-              player->pendingweapon = GetAmmoChange[ammo];
+              P_AutoSwitchWeapon(player, GetAmmoChange[ammo]);
         }
     }
 
     return true;
   }
 
-  if (autoswitch)
-  {
-    switch (ammo)
-      {
-      case am_clip:
-        if (player->readyweapon == wp_fist) {
-          if (player->weaponowned[wp_chaingun])
-            player->pendingweapon = wp_chaingun;
-          else
-            player->pendingweapon = wp_pistol;
-        }
-        break;
-
-      case am_shell:
-        if (player->readyweapon == wp_fist || player->readyweapon == wp_pistol)
-          if (player->weaponowned[wp_shotgun])
-            player->pendingweapon = wp_shotgun;
-        break;
-
-        case am_cell:
-          if (player->readyweapon == wp_fist || player->readyweapon == wp_pistol)
-            if (player->weaponowned[wp_plasma])
-              player->pendingweapon = wp_plasma;
-          break;
-
-        case am_misl:
-          if (player->readyweapon == wp_fist)
-            if (player->weaponowned[wp_missile])
-              player->pendingweapon = wp_missile;
-      default:
-        break;
+  switch (ammo)
+    {
+    case am_clip:
+      if (player->readyweapon == wp_fist) {
+        if (player->weaponowned[wp_chaingun])
+          P_AutoSwitchWeapon(player, wp_chaingun);
+        else
+          P_AutoSwitchWeapon(player, wp_pistol);
       }
-  }
+      break;
+
+    case am_shell:
+      if (player->readyweapon == wp_fist || player->readyweapon == wp_pistol)
+        if (player->weaponowned[wp_shotgun])
+          P_AutoSwitchWeapon(player, wp_shotgun);
+      break;
+
+      case am_cell:
+        if (player->readyweapon == wp_fist || player->readyweapon == wp_pistol)
+          if (player->weaponowned[wp_plasma])
+            P_AutoSwitchWeapon(player, wp_plasma);
+        break;
+
+      case am_misl:
+        if (player->readyweapon == wp_fist)
+          if (player->weaponowned[wp_missile])
+            P_AutoSwitchWeapon(player, wp_missile);
+    default:
+      break;
+    }
   return true;
 }
 
@@ -256,8 +265,7 @@ dboolean P_GiveWeapon(player_t *player, weapontype_t weapon, dboolean dropped)
       player->weaponowned[weapon] = true;
 
       P_GiveAmmo(player, weaponinfo[weapon].ammo, deathmatch ? 5 : 2);
-      if (autoswitch)
-        player->pendingweapon = weapon;
+      P_AutoSwitchWeapon(player, weapon);
       /* cph 20028/10 - for old-school DM addicts, allow old behavior
        * where only consoleplayer's pickup sounds are heard */
       // displayplayer, not consoleplayer, for viewing multiplayer demos
@@ -283,8 +291,7 @@ dboolean P_GiveWeapon(player_t *player, weapontype_t weapon, dboolean dropped)
     {
       gaveweapon = true;
       player->weaponowned[weapon] = true;
-      if (autoswitch)
-        player->pendingweapon = weapon;
+      P_AutoSwitchWeapon(player, weapon);
     }
   return gaveweapon || gaveammo;
 }
@@ -636,8 +643,7 @@ void P_TouchSpecialThing(mobj_t *special, mobj_t *toucher)
         return;
       dsda_AddPlayerMessage(s_GOTBERSERK, player);
       if (player->readyweapon != wp_fist)
-        if (autoswitch)
-          player->pendingweapon = wp_fist;
+        P_AutoSwitchWeapon(player, wp_fist);
       sound = sfx_getpow;
       break;
 
@@ -2307,8 +2313,7 @@ dboolean Heretic_P_GiveWeapon(player_t * player, weapontype_t weapon)
         player->bonuscount += BONUSADD;
         player->weaponowned[weapon] = true;
         P_GiveAmmo(player, wpnlev1info[weapon].ammo, GetWeaponAmmo[weapon]);
-        if (autoswitch)
-          player->pendingweapon = weapon;
+        P_AutoSwitchWeapon(player, weapon);
         if (player == &players[consoleplayer])
         {
             S_StartVoidSound(heretic_sfx_wpnup);
@@ -2327,8 +2332,7 @@ dboolean Heretic_P_GiveWeapon(player_t * player, weapontype_t weapon)
         player->weaponowned[weapon] = true;
         if (WeaponValue[weapon] > WeaponValue[player->readyweapon])
         {                       // Only switch to more powerful weapons
-            if (autoswitch)
-              player->pendingweapon = weapon;
+            P_AutoSwitchWeapon(player, weapon);
         }
     }
     return (gaveWeapon || gaveAmmo);
@@ -2854,8 +2858,7 @@ void TryPickupWeapon(player_t * player, pclass_t weaponClass,
         {
             P_GiveMana(player, MANA_2, 25);
         }
-        if (autoswitch)
-          player->pendingweapon = weaponType;
+        P_AutoSwitchWeapon(player, weaponType);
         remove = false;
     }
     else
@@ -2878,8 +2881,7 @@ void TryPickupWeapon(player_t * player, pclass_t weaponClass,
             player->weaponowned[weaponType] = true;
             if (weaponType > player->readyweapon)
             {                   // Only switch to more powerful weapons
-                if (autoswitch)
-                  player->pendingweapon = weaponType;
+                P_AutoSwitchWeapon(player, weaponType);
             }
         }
         if (!(gaveWeapon || gaveMana))
@@ -3015,8 +3017,7 @@ static void TryPickupWeaponPiece(player_t * player, pclass_t matchClass,
         {
             gaveWeapon = true;
             player->weaponowned[wp_fourth] = true;
-            if (autoswitch)
-              player->pendingweapon = wp_fourth;
+            P_AutoSwitchWeapon(player, wp_fourth);
         }
     }
 


### PR DESCRIPTION
Took a stab at implementing an Auto Switch option asked for in (#511).

It's a rather simple casual only setting that's disabled in strict mode, demo recording/playing, netgame, and deathmatch.

Let me know if there's better precedent when it comes to netgame / deathmatch compat for options.