### PR TITLE
Revert "Release mouse" commits

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1556,6 +1556,11 @@ static dboolean MouseShouldBeGrabbed()
   if (!window_focused)
     return false;
 
+  // always grab the mouse when full screen (dont want to
+  // see the mouse pointer)
+  if (desired_fullscreen)
+    return true;
+
   // if we specify not to grab the mouse, never grab
   if (!mouse_enabled)
     return false;

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1575,8 +1575,7 @@ static dboolean MouseShouldBeGrabbed()
     return false;
 
   // only grab mouse when playing levels (but not demos)
-  return (gamestate == GS_LEVEL || gamestate == GS_INTERMISSION)
-          && !demoplayback && !advancedemo;
+  return !demoplayback;
 }
 
 // Update the value of window_focused when we get a focus event


### PR DESCRIPTION
From the discord, some people do not like the mouse to be visible in these scenarios (or ever), so lets revert this.
No need to match choco/woof when prboom never showed it.

Its not something interesting enough that it requires a toggle, but I might revise it if we get mouse controls on menu

Alternative would be to hide the mouse after 1 second of inactivity. If you think this is a good idea, we can go with it
https://github.com/Pedro-Beirao/dsda-doom/tree/hide-mouse