### PR TITLE
Limit keys that can call the menu from the titlepic

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5086,32 +5086,6 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     return true;
   }
 
-  // Pop-up Main menu?
-  if ((!in_game && ch > -1) || ch == KEYD_ESCAPE || action == MENU_ESCAPE) // phares
-  {
-    M_StartControlPanel();
-    S_StartVoidSound(g_sfx_swtchn);
-    return true;
-  }
-
-  if (dsda_InputActivated(dsda_input_console))
-  {
-    if (dsda_OpenConsole())
-      S_StartVoidSound(g_sfx_swtchn);
-    return true;
-  }
-
-  {
-    int i;
-
-    for (i = 0; i < CONSOLE_SCRIPT_COUNT; ++i)
-      if (dsda_InputActivated(dsda_input_script_0 + i)) {
-        dsda_ExecuteConsoleScript(i);
-
-        return true;
-      }
-  }
-
   // Toggle gamma
   if (dsda_InputActivated(dsda_input_gamma))
   {
@@ -5125,22 +5099,20 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     return true;
   }
 
-  if (dsda_InputActivated(dsda_input_zoomout))
+  if (dsda_InputActivated(dsda_input_cycle_profile))
   {
-    if (automap_active)
-      return false;
-    M_SizeDisplay(0);
-    S_StartVoidSound(g_sfx_stnmov);
+    int value = dsda_CycleConfig(dsda_config_input_profile, true);
+    doom_printf("Input Profile %d", value);
+    S_StartVoidSound(g_sfx_swtchn);
     return true;
   }
 
-  if (dsda_InputActivated(dsda_input_zoomin))
-  {                                   // jff 2/23/98
-    if (automap_active)               // allow
-      return false;                   // key_hud==key_zoomin
-    M_SizeDisplay(1);                                             //  ^
-    S_StartVoidSound(g_sfx_stnmov);                              //  |
-    return true;                                                  // phares
+  if (dsda_InputActivated(dsda_input_cycle_palette))
+  {
+    dsda_CyclePlayPal();
+    doom_printf("Palette %s", dsda_PlayPalData()->lump_name);
+    S_StartVoidSound(g_sfx_swtchn);
+    return true;
   }
 
   //e6y
@@ -5169,6 +5141,51 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     doom_printf("Game Speed %d", value);
     // Don't eat the keypress in this case.
     // return true;
+  }
+
+  // Pop-up Main menu?
+  if (ch == KEYD_ESCAPE || action == MENU_ESCAPE ||
+      (!in_game && (ch == KEYD_ENTER || ch == KEYD_SPACEBAR || dsda_InputActivated(dsda_input_fire) || dsda_InputActivated(dsda_input_use)))) // phares
+  {
+    M_StartControlPanel();
+    S_StartVoidSound(g_sfx_swtchn);
+    return true;
+  }
+
+  if (dsda_InputActivated(dsda_input_console))
+  {
+    if (dsda_OpenConsole())
+      S_StartVoidSound(g_sfx_swtchn);
+    return true;
+  }
+
+  {
+    int i;
+
+    for (i = 0; i < CONSOLE_SCRIPT_COUNT; ++i)
+      if (dsda_InputActivated(dsda_input_script_0 + i)) {
+        dsda_ExecuteConsoleScript(i);
+
+        return true;
+      }
+  }
+
+  if (dsda_InputActivated(dsda_input_zoomout))
+  {
+    if (automap_active)
+      return false;
+    M_SizeDisplay(0);
+    S_StartVoidSound(g_sfx_stnmov);
+    return true;
+  }
+
+  if (dsda_InputActivated(dsda_input_zoomin))
+  {                                   // jff 2/23/98
+    if (automap_active)               // allow
+      return false;                   // key_hud==key_zoomin
+    M_SizeDisplay(1);                                             //  ^
+    S_StartVoidSound(g_sfx_stnmov);                              //  |
+    return true;                                                  // phares
   }
 
   if (dsda_InputActivated(dsda_input_nextlevel))
@@ -5234,22 +5251,6 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
   if (dsda_InputActivated(dsda_input_rewind))
   {
     if (!dsda_StrictMode()) dsda_RewindAutoKeyFrame();
-    return true;
-  }
-
-  if (dsda_InputActivated(dsda_input_cycle_profile))
-  {
-    int value = dsda_CycleConfig(dsda_config_input_profile, true);
-    doom_printf("Input Profile %d", value);
-    S_StartVoidSound(g_sfx_swtchn);
-    return true;
-  }
-
-  if (dsda_InputActivated(dsda_input_cycle_palette))
-  {
-    dsda_CyclePlayPal();
-    doom_printf("Palette %s", dsda_PlayPalData()->lump_name);
-    S_StartVoidSound(g_sfx_swtchn);
     return true;
   }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5145,7 +5145,8 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
 
   // Pop-up Main menu?
   if (ch == KEYD_ESCAPE || action == MENU_ESCAPE ||
-      (!in_game && (ch == KEYD_ENTER || ch == KEYD_SPACEBAR || dsda_InputActivated(dsda_input_fire) || dsda_InputActivated(dsda_input_use)))) // phares
+      (!in_game && (ch == KEYD_ENTER || ch == KEYD_SPACEBAR ||
+       dsda_InputActivated(dsda_input_fire) || dsda_InputActivated(dsda_input_use) || dsda_InputActivated(dsda_input_menu_enter)))) // phares
   {
     M_StartControlPanel();
     S_StartVoidSound(g_sfx_swtchn);


### PR DESCRIPTION
Having any key bring up the menu can cause problem if say, that key is used for speedup.
Instead of leaving it up to the user to not acidentaly press a sensitive key when trying to open the menu, lets just limit it to the keys that make the most sense.

This also reorganizes the order of some conditions to allow input to reach certain actions