### PR TITLE
Raven RawScreen Aspect Fix

### DIFF
--- a/prboom2/src/dsda/stretch.c
+++ b/prboom2/src/dsda/stretch.c
@@ -158,7 +158,7 @@ void dsda_ResetExTextOffsets(void) {
 static void InitStretchParam(stretch_param_t* offsets, int stretch, enum patch_translation_e flags) {
   memset(offsets, 0, sizeof(*offsets));
 
-  switch (stretch) {
+  switch (stretch_hud(stretch)) {
     case patch_stretch_not_adjusted:
       if (flags == VPT_ALIGN_WIDE) {
         offsets->video = &video_stretch;
@@ -271,10 +271,7 @@ void dsda_EvaluatePatchScale(void) {
       SCREENHEIGHT < 200 || WIDE_SCREENHEIGHT < 200)
     render_stretch_hud = patch_stretch_fit_to_width;
 
-  if (raven && render_stretch_hud == 0)
-    render_stretch_hud++;
-
-  switch (render_stretch_hud) {
+  switch (stretch_hud(render_stretch_hud)) {
     case patch_stretch_not_adjusted:
       wide_offset2x = SCREENWIDTH - patches_scalex * 320;
       wide_offset2y = SCREENHEIGHT - patches_scaley * 200;

--- a/prboom2/src/dsda/stretch.h
+++ b/prboom2/src/dsda/stretch.h
@@ -51,6 +51,10 @@ typedef enum
   patch_stretch_max
 } patch_stretch_t;
 
+// Raven HUD breaks in "patch_stretch_not_adjusted",
+// so let's use "patch_stretch_doom_format" settings
+#define stretch_hud(a) ((raven && (a) == patch_stretch_not_adjusted) ? patch_stretch_doom_format : (a))
+
 extern int wide_offsetx;
 extern int wide_offset2x;
 extern int wide_offsety;

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -403,7 +403,7 @@ void ST_SetScaledWidth(void)
   if (width == 0)
       width = ST_WIDTH;
 
-  switch (render_stretch_hud)
+  switch (stretch_hud(render_stretch_hud))
   {
     case patch_stretch_not_adjusted:
       ST_SCALED_WIDTH  = width * patches_scalex;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1417,7 +1417,7 @@ void V_DrawRawScreen(const char *lump_name)
 void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y_offset, int dest_y_limit)
 {
   int i, j;
-  float x_factor, y_factor;
+  float x_factor = 0, y_factor = 0;
   int x_offset, y_offset;
   const byte* raw;
 
@@ -1440,11 +1440,24 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
     }
   }
 
-  x_factor = (float)SCREENWIDTH / 320;
-  y_factor = (float)SCREENHEIGHT / 200;
-
-  if (y_factor < x_factor)
-    x_factor = y_factor;
+  switch (render_stretch_hud) {
+    case patch_stretch_not_adjusted:
+      x_factor = (float)SCREENWIDTH / 320;
+      y_factor = (float)SCREENHEIGHT / 200;
+      if (y_factor < x_factor)
+        x_factor = y_factor;
+      break;
+    case patch_stretch_doom_format:
+      x_factor = (float)WIDE_SCREENWIDTH / 320;
+      y_factor = (float)WIDE_SCREENHEIGHT / 200;
+      if (y_factor < x_factor)
+        x_factor = y_factor;
+      break;
+    case patch_stretch_fit_to_width:
+      x_factor = (float)SCREENWIDTH / 320;
+      y_factor = (float)SCREENHEIGHT / 200;
+      break;
+  }
 
   x_offset = (int)((SCREENWIDTH - (x_factor * 320)) / 2);
   y_offset = (int)((dest_y_offset * y_factor) - (source_offset * y_factor / 320));


### PR DESCRIPTION
So a thing that's bothered me for quite a while is that the "RawScreen"s that Raven uses have only been rendered using the "Not Adjusted" stretch setting... regardless of the stretch settings.

This PR fixes that and the issue mentioned here (#467). They are both related to the same issue in different ways. The problem with the specific issue, was that the "RawScreen" under "Fit to Width" was supposed to fit to width (imagine that), but code was set to prevent that.

Now the "RawScreen"s will look as they should for all three settings: "Not Adjusted", "Doom Format", and "Fit to Width". I will mention that the "RawScreen" code seems a bit WIP, so eventually there may be a better way to approach this further down the line.

One of the reasons the format was previously forced was probably due to the Raven Statusbar not being rendered properly under "Not Adjusted"... But the "RawScreen"s don't have that issue.

I haven't been able to fix the Raven Statusbar for "Not Adjusted", so I have it using the "Doom Format" stretch settings (just as DSDA Doom currently does).