### PR TITLE
Implement dark overlay for menus and automap

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -1005,6 +1005,18 @@ dboolean AM_Responder
 {
   static int bigstate=0;
 
+  if (dsda_InputActivated(dsda_input_map_overlay) && (automap_input || dsda_ShowMinimap()))
+  {
+    dsda_CycleConfig(dsda_config_automap_overlay, true);
+    dsda_AddMessage(automap_overlay == 0 ? s_AMSTR_OVERLAYOFF :
+                    automap_overlay == 1 ? s_AMSTR_OVERLAYON :
+                    "Overlay Mode Dark");
+    AM_SetPosition();
+    AM_activateNewScale();
+
+    return true;
+  }
+
   if (!automap_input)
   {
     if (dsda_InputActivated(dsda_input_map))
@@ -1143,17 +1155,6 @@ dboolean AM_Responder
   {
     dsda_ToggleConfig(dsda_config_automap_rotate, true);
     dsda_AddMessage(automap_rotate ? s_AMSTR_ROTATEON : s_AMSTR_ROTATEOFF);
-
-    return true;
-  }
-  else if (dsda_InputActivated(dsda_input_map_overlay))
-  {
-    dsda_CycleConfig(dsda_config_automap_overlay, true);
-    dsda_AddMessage(automap_overlay == 0 ? s_AMSTR_OVERLAYOFF :
-                    automap_overlay == 1 ? s_AMSTR_OVERLAYON :
-                    "Overlay Mode Dark");
-    AM_SetPosition();
-    AM_activateNewScale();
 
     return true;
   }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -57,6 +57,7 @@
 #include "m_misc.h"
 #include "m_bbox.h"
 #include "d_main.h"
+#include "m_menu.h"
 
 #include "dsda/id_list.h"
 #include "dsda/input.h"
@@ -616,7 +617,7 @@ void AM_SetPosition(void)
     f_x = f_y = 0;
     f_w = SCREENWIDTH;
 
-    if (automap_overlay)
+    if (automap_overlay > 0)
     {
       f_h = viewheight;
     }
@@ -1147,7 +1148,10 @@ dboolean AM_Responder
   }
   else if (dsda_InputActivated(dsda_input_map_overlay))
   {
-    dsda_ToggleConfig(dsda_config_automap_overlay, true);
+    dsda_CycleConfig(dsda_config_automap_overlay, true);
+    dsda_AddMessage(automap_overlay == 0 ? s_AMSTR_OVERLAYOFF :
+                    automap_overlay == 1 ? s_AMSTR_OVERLAYON :
+                    "Overlay Mode Dark");
     AM_SetPosition();
     AM_activateNewScale();
 
@@ -2769,6 +2773,9 @@ void AM_Drawer (dboolean minimap)
   if (!automap_active && !minimap)
     return;
 
+  if (automap_active && automap_overlay == 2 && minimap)
+    return;
+
   V_BeginAutomapDraw();
 
   if (automap_follow)
@@ -2792,6 +2799,8 @@ void AM_Drawer (dboolean minimap)
 
   if (!automap_overlay) // cph - If not overlay mode, clear background for the automap
     V_FillRect(FB, f_x, f_y, f_w, f_h, (byte)mapcolor_p->back); //jff 1/5/98 background default color
+  if (automap_overlay == 2 && !M_MenuIsShaded())
+    V_DrawShaded(FB, f_x, f_y, f_w, f_h, FULLSHADE);
 
   if (map_textured)
   {

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -198,6 +198,7 @@ extern int automap_grid;
 
 #define automap_on (automap_active && !automap_overlay)
 #define automap_off (!automap_active && automap_overlay > 0)
+#define automap_stbar (automap_active && R_StatusBarVisible())
 #define automap_input (automap_active)
 #define automap_hud (automap_active && !automap_overlay)
 

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -197,7 +197,7 @@ extern int automap_follow;
 extern int automap_grid;
 
 #define automap_on (automap_active && !automap_overlay)
-#define automap_off (!automap_on)
+#define automap_off (!automap_active && automap_overlay > 0)
 #define automap_input (automap_active)
 #define automap_hud (automap_active && !automap_overlay)
 

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1042,7 +1042,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_automap_overlay] = {
     "automap_overlay", dsda_config_automap_overlay,
-    CONF_BOOL(0), &automap_overlay
+    dsda_config_int, 0, 2, { 0 }, &automap_overlay
   },
   [dsda_config_automap_rotate] = {
     "automap_rotate", dsda_config_automap_rotate,

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -231,7 +231,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_menu_background] = {
     "menu_background", dsda_config_menu_background,
-    CONF_BOOL(1)
+    dsda_config_int, 0, 2, { 1 }
   },
   [dsda_config_process_priority] = {
     "process_priority", dsda_config_process_priority,

--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -659,7 +659,7 @@ static void dsda_UpdateComponents(exhud_component_t* update_components) {
 }
 
 void dsda_UpdateExHud(void) {
-  if (automap_on) {
+  if (automap_stbar) {
     if (containers[hud_map].loaded)
       dsda_UpdateComponents(containers[hud_map].components);
 
@@ -689,7 +689,7 @@ int global_patch_top_offset;
 void dsda_DrawExHud(void) {
   global_patch_top_offset = M_ConsoleOpen() ? dsda_ConsoleHeight() : 0;
 
-  if (automap_on) {
+  if (automap_stbar) {
     if (containers[hud_map].loaded)
       dsda_DrawComponents(containers[hud_map].components);
   }

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -282,7 +282,7 @@ void gld_MapDrawSubsectors(player_t *plr, int fx, int fy, fixed_t mx, fixed_t my
   float coord_scale;
   GLTexture *gltexture;
 
-  alpha = (float)(automap_overlay ? map_textured_overlay_trans : map_textured_trans) / 100.0f;
+  alpha = (float)((automap_overlay > 0) ? map_textured_overlay_trans : map_textured_trans) / 100.0f;
   if (alpha == 0)
     return;
 
@@ -714,7 +714,7 @@ void gld_DrawLine_f(float x0, float y0, float x1, float y1, int BaseColor)
   unsigned char a;
   map_line_t *line;
 
-  a = (automap_overlay ? map_lines_overlay_trans * 255 / 100 : 255);
+  a = ((automap_overlay == 1) ? map_lines_overlay_trans * 255 / 100 : 255);
   if (a == 0)
     return;
 

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -848,6 +848,31 @@ void gld_FillBlock(int x, int y, int width, int height, int col)
   glsl_PopNullShader();
 }
 
+void gld_DrawShaded(int x, int y, int width, int height, int shade)
+{
+  color_rgb_t color = gld_LookupIndexedColor(playpal_black, V_IsAutomapLightmodeIndexed());
+
+  glsl_PushNullShader();
+
+  gld_EnableTexture2D(GL_TEXTURE0_ARB, false);
+
+  glColor4f((float)color.r/255.0f,
+            (float)color.g/255.0f,
+            (float)color.b/255.0f,
+            (float)shade/30);
+
+  glBegin(GL_TRIANGLE_STRIP);
+    glVertex2i( x, y );
+    glVertex2i( x, y+height );
+    glVertex2i( x+width, y );
+    glVertex2i( x+width, y+height );
+  glEnd();
+  glColor4f(1.0f,1.0f,1.0f,1.0f);
+  gld_EnableTexture2D(GL_TEXTURE0_ARB, true);
+
+  glsl_PopNullShader();
+}
+
 void gld_SetPalette(int palette)
 {
   static int last_palette = 0;

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -92,6 +92,7 @@ void gld_DrawLine(int x0, int y0, int x1, int y1, int BaseColor);
 void gld_DrawLine_f(float x0, float y0, float x1, float y1, int BaseColor);
 void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel);
 void gld_FillBlock(int x, int y, int width, int height, int col);
+void gld_DrawShaded(int x, int y, int width, int height, int shade);
 void gld_SetPalette(int palette);
 unsigned char *gld_ReadScreen(void);
 

--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -18,6 +18,7 @@
 
 #include "doomstat.h"
 #include "m_cheat.h"
+#include "m_menu.h"
 #include "m_random.h"
 #include "v_video.h"
 #include "r_main.h"
@@ -537,7 +538,7 @@ static int oldpieces = -1;
 
 void SB_Drawer(dboolean statusbaron, dboolean refresh, dboolean fullmenu)
 {
-    if (refresh || fullmenu || V_IsOpenGLMode()) SB_state = -1;
+    if (refresh || fullmenu || fadeBG() || V_IsOpenGLMode()) SB_state = -1;
 
     if (!statusbaron)
     {

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -47,6 +47,7 @@
 #include "p_tick.h"
 #include "p_map.h"
 #include "sc_man.h"
+#include "m_menu.h"
 #include "m_misc.h"
 #include "r_main.h"
 #include "lprintf.h"
@@ -364,7 +365,7 @@ void HU_Start(void)
 void HU_Drawer(void)
 {
   // don't draw anything if there's a fullscreen menu up
-  if (menuactive == mnact_full)
+  if (menuactive == mnact_full && !M_MenuIsShaded())
     return;
 
   V_BeginUIDraw();

--- a/prboom2/src/m_menu.h
+++ b/prboom2/src/m_menu.h
@@ -49,6 +49,10 @@
 
 dboolean M_Responder (event_t *ev);
 
+dboolean fadeBG(void);
+dboolean M_MenuIsShaded(void);
+#define FULLSHADE 20
+
 // Called by main loop,
 // only used for menu (skull cursor) animation.
 

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -44,6 +44,7 @@
 #include "r_main.h"
 #include "am_map.h"
 #include "m_cheat.h"
+#include "m_menu.h"
 #include "s_sound.h"
 #include "sounds.h"
 #include "dstrings.h"
@@ -893,7 +894,7 @@ void ST_Refresh(void)
 void ST_Drawer(dboolean refresh)
 {
   dboolean statusbaron = R_StatusBarVisible();
-  dboolean fullmenu = (menuactive == mnact_full);
+  dboolean fullmenu = (menuactive == mnact_full) && !M_MenuIsShaded();
 
   V_BeginUIDraw();
 
@@ -913,7 +914,7 @@ void ST_Drawer(dboolean refresh)
   ST_doPaletteStuff();  // Do red-/gold-shifts from damage/items
 
   if (statusbaron) {
-    if (st_firsttime || (V_IsOpenGLMode()))
+    if (st_firsttime || (V_IsOpenGLMode() || fadeBG()))
     {
       /* If just after ST_Start(), refresh all */
       st_firsttime = false;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -615,6 +615,34 @@ static void V_DrawMemPatch(int x, int y, int scrn, const rpatch_t *patch,
   }
 }
 
+
+//
+// FUNC_V_DrawShaded
+//
+// Adapted from Woof.
+//
+// This uses a dark colormap to create
+// a dark faded background under menus.
+//
+static void FUNC_V_DrawShaded(int scrn, int x, int y, int width, int height, int shade)
+{
+  extern const lighttable_t **colormaps;
+  byte* dest;
+  int ix, iy;
+
+  for (iy = y; iy < y + height; ++iy)
+  {
+    dest = screens[scrn].data + screens[scrn].pitch * iy + x;
+
+    for (ix = x; ix < x + width; ++ix)
+    {
+      *dest = colormaps[scrn][shade * 256 + dest[scrn]];
+      dest++;
+    }
+  }
+}
+
+
 // CPhipps - some simple, useful wrappers for that function, for drawing patches from wads
 
 // CPhipps - GNU C only suppresses generating a copy of a function if it is
@@ -742,6 +770,10 @@ static void WRAP_gld_DrawLine(fline_t* fl, int color)
 {
   gld_DrawLine_f(fl->a.fx, fl->a.fy, fl->b.fx, fl->b.fy, color);
 }
+static void WRAP_gld_DrawShaded(int scrn, int x, int y, int width, int height, int shade)
+{
+  gld_DrawShaded(x, y, width, height, shade);
+}
 
 static void NULL_BeginUIDraw(void) {}
 static void NULL_EndUIDraw(void) {}
@@ -758,6 +790,7 @@ static void NULL_PlotPixel(int scrn, int x, int y, byte color) {}
 static void NULL_PlotPixelWu(int scrn, int x, int y, byte color, int weight) {}
 static void NULL_DrawLine(fline_t* fl, int color) {}
 static void NULL_DrawLineWu(fline_t* fl, int color) {}
+static void NULL_DrawShaded(int scrn, int x, int y, int width, int height, int shade) {}
 
 static video_mode_t current_videomode = VID_MODESW;
 
@@ -776,6 +809,7 @@ V_PlotPixel_f V_PlotPixel = NULL_PlotPixel;
 V_PlotPixelWu_f V_PlotPixelWu = NULL_PlotPixelWu;
 V_DrawLine_f V_DrawLine = NULL_DrawLine;
 V_DrawLineWu_f V_DrawLineWu = NULL_DrawLineWu;
+V_DrawShaded_f V_DrawShaded = NULL_DrawShaded;
 
 //
 // V_InitMode
@@ -799,6 +833,7 @@ void V_InitMode(video_mode_t mode) {
       V_PlotPixelWu = V_PlotPixelWu8;
       V_DrawLine = WRAP_V_DrawLine;
       V_DrawLineWu = WRAP_V_DrawLineWu;
+      V_DrawShaded = FUNC_V_DrawShaded;
       current_videomode = VID_MODESW;
       break;
     case VID_MODEGL:
@@ -818,6 +853,7 @@ void V_InitMode(video_mode_t mode) {
       V_PlotPixelWu = V_PlotPixelWuGL;
       V_DrawLine = WRAP_gld_DrawLine;
       V_DrawLineWu = WRAP_gld_DrawLine;
+      V_DrawShaded = WRAP_gld_DrawShaded;
       current_videomode = VID_MODEGL;
       break;
   }

--- a/prboom2/src/v_video.h
+++ b/prboom2/src/v_video.h
@@ -223,6 +223,9 @@ extern V_FillPatch_f V_FillPatch;
 typedef void (*V_DrawBackground_f)(const char* flatname, int scrn);
 extern V_DrawBackground_f V_DrawBackground;
 
+typedef void (*V_DrawShaded_f)(int scrn, int x, int y, int width, int height, int shade);
+extern V_DrawShaded_f V_DrawShaded;
+
 // CPhipps - function to set the palette to palette number pal.
 void V_TouchPalette(void);
 void V_SetPalette(int pal);


### PR DESCRIPTION
This PR adds the dark overlay that Woof has.

I've implemented it via `V_DrawShaded` which gets directed to two different functions depending on OpenGL or Software (this is how most render functions currently work in DSDA Doom)

The `V_DrawShaded` function includes a gradual fade option (`dboolean animate`) that's used in Nyan Doom, although I've set it to false in both instances that it's used here to match Woof's implementation.

The automap now has 3 overlay settings in the same way Woof does: "No Overlay", "Overlay 1" (what DSDA already had), and "Overlay dark" which adds a translucent background. The dark overlay is also compatible with the DSDA Doom Minimap.

~The final commit here is probably the most controversial, but I wanted to bring it up here. It's because of this commit that implementing the dark overlay was actually harder to get working for DSDA Doom compared to Nyan Doom. In order for Nyan Doom to support overlapping HUD icons and statusbar animations, I have the statusbar always refresh in Software just as it does in OpenGL. In my testing I haven't run into issues or slowdown by doing this, and it fixes many statusbar bleed issues with PWADs such as "Pirate Doom II" and "200 Line Christmas".~