### PR TITLE
IDMUS cheat support UMAPINFO

### DIFF
--- a/prboom2/src/dsda/mapinfo.c
+++ b/prboom2/src/dsda/mapinfo.c
@@ -319,17 +319,17 @@ int dsda_MusicIndexToLumpNum(int music_index) {
   return lump;
 }
 
-void dsda_MapMusic(int* music_index, int* music_lump) {
-  if (dsda_DoomMapMusic(music_index, music_lump))
+void dsda_MapMusic(int* music_index, int* music_lump, int episode, int map) {
+  if (dsda_DoomMapMusic(music_index, music_lump, episode, map))
     return;
 
-  if (dsda_HexenMapMusic(music_index, music_lump))
+  if (dsda_HexenMapMusic(music_index, music_lump, episode, map))
     return;
 
-  if (dsda_UMapMusic(music_index, music_lump))
+  if (dsda_UMapMusic(music_index, music_lump, episode, map))
     return;
 
-  dsda_LegacyMapMusic(music_index, music_lump);
+  dsda_LegacyMapMusic(music_index, music_lump, episode, map);
 }
 
 void dsda_IntermissionMusic(int* music_index, int* music_lump) {

--- a/prboom2/src/dsda/mapinfo.h
+++ b/prboom2/src/dsda/mapinfo.h
@@ -80,7 +80,7 @@ void dsda_UpdateNextMapInfo(void);
 int dsda_ResolveCLEV(int* episode, int* map);
 int dsda_ResolveINIT(void);
 int dsda_MusicIndexToLumpNum(int music_index);
-void dsda_MapMusic(int* music_index, int* music_lump);
+void dsda_MapMusic(int* music_index, int* music_lump, int episode, int map);
 void dsda_IntermissionMusic(int* music_index, int* music_lump);
 void dsda_InterMusic(int* music_index, int* music_lump);
 void dsda_StartFinale(void);

--- a/prboom2/src/dsda/mapinfo/doom.c
+++ b/prboom2/src/dsda/mapinfo/doom.c
@@ -278,13 +278,22 @@ int dsda_DoomMusicIndexToLumpNum(int* lump, int music_index) {
   return false;
 }
 
-int dsda_DoomMapMusic(int* music_index, int* music_lump) {
+int dsda_DoomMapMusic(int* music_index, int* music_lump, int episode, int map) {
   int lump;
+  const doom_mapinfo_map_t* entry;
+  int level_num;
 
-  if (!current_map || !current_map->music)
+  if (gamemode == commercial)
+    level_num = map;
+  else
+    level_num = map + episode * 10;
+
+  entry = dsda_DoomMapEntry(level_num);
+
+  if (!entry || !entry->music)
     return false;
 
-  lump = W_CheckNumForName(current_map->music);
+  lump = W_CheckNumForName(entry->music);
 
   if (lump == LUMP_NOT_FOUND)
     return false;

--- a/prboom2/src/dsda/mapinfo/doom.h
+++ b/prboom2/src/dsda/mapinfo/doom.h
@@ -37,7 +37,7 @@ void dsda_DoomUpdateNextMapInfo(void);
 int dsda_DoomResolveCLEV(int* clev, int* episode, int* map);
 int dsda_DoomResolveINIT(int* init);
 int dsda_DoomMusicIndexToLumpNum(int* lump, int music_index);
-int dsda_DoomMapMusic(int* music_index, int* music_lump);
+int dsda_DoomMapMusic(int* music_index, int* music_lump, int episode, int map);
 int dsda_DoomIntermissionMusic(int* music_index, int* music_lump);
 int dsda_DoomInterMusic(int* music_index, int* music_lump);
 int dsda_DoomStartFinale(void);

--- a/prboom2/src/dsda/mapinfo/hexen.c
+++ b/prboom2/src/dsda/mapinfo/hexen.c
@@ -291,12 +291,12 @@ int dsda_HexenMusicIndexToLumpNum(int* lump, int music_index) {
   return true;
 }
 
-int dsda_HexenMapMusic(int* music_index, int* music_lump) {
+int dsda_HexenMapMusic(int* music_index, int* music_lump, int episode, int map) {
   if (!hexen)
     return false;
 
   *music_lump = -1;
-  *music_index = gamemap;
+  *music_index = map;
 
   return true;
 }

--- a/prboom2/src/dsda/mapinfo/hexen.h
+++ b/prboom2/src/dsda/mapinfo/hexen.h
@@ -37,7 +37,7 @@ void dsda_HexenUpdateNextMapInfo(void);
 int dsda_HexenResolveCLEV(int* clev, int* episode, int* map);
 int dsda_HexenResolveINIT(int* init);
 int dsda_HexenMusicIndexToLumpNum(int* lump, int music_index);
-int dsda_HexenMapMusic(int* music_index, int* music_lump);
+int dsda_HexenMapMusic(int* music_index, int* music_lump, int episode, int map);
 int dsda_HexenIntermissionMusic(int* music_index, int* music_lump);
 int dsda_HexenInterMusic(int* music_index, int* music_lump);
 int dsda_HexenStartFinale(void);

--- a/prboom2/src/dsda/mapinfo/legacy.c
+++ b/prboom2/src/dsda/mapinfo/legacy.c
@@ -357,14 +357,14 @@ static inline int WRAP(int i, int w)
   return i % w;
 }
 
-int dsda_LegacyMapMusic(int* music_index, int* music_lump) {
+int dsda_LegacyMapMusic(int* music_index, int* music_lump, int episode, int map) {
   *music_lump = -1;
 
   if (idmusnum != -1)
     *music_index = idmusnum; //jff 3/17/98 reload IDMUS music if not -1
   else {
     if (gamemode == commercial)
-      *music_index = mus_runnin + WRAP(gamemap - 1, DOOM_MUSINFO - mus_runnin);
+      *music_index = mus_runnin + WRAP(map - 1, DOOM_MUSINFO - mus_runnin);
     else {
       static const int spmus[] = {
         mus_e3m4,
@@ -380,13 +380,13 @@ int dsda_LegacyMapMusic(int* music_index, int* music_lump) {
 
       if (heretic)
         *music_index = heretic_mus_e1m1 +
-                       WRAP((gameepisode - 1) * 9 + gamemap - 1,
+                       WRAP((episode - 1) * 9 + map - 1,
                             HERETIC_NUMMUSIC - heretic_mus_e1m1);
-      else if (gameepisode < 4)
+      else if (episode < 4)
         *music_index = mus_e1m1 +
-                       WRAP((gameepisode - 1) * 9 + gamemap - 1, mus_runnin - mus_e1m1);
+                       WRAP((episode - 1) * 9 + map - 1, mus_runnin - mus_e1m1);
       else
-        *music_index = spmus[WRAP(gamemap - 1, 9)];
+        *music_index = spmus[WRAP(map - 1, 9)];
     }
   }
 

--- a/prboom2/src/dsda/mapinfo/legacy.h
+++ b/prboom2/src/dsda/mapinfo/legacy.h
@@ -37,7 +37,7 @@ void dsda_LegacyUpdateNextMapInfo(void);
 int dsda_LegacyResolveCLEV(int* clev, int* episode, int* map);
 int dsda_LegacyResolveINIT(int* init);
 int dsda_LegacyMusicIndexToLumpNum(int* lump, int music_index);
-int dsda_LegacyMapMusic(int* music_index, int* music_lump);
+int dsda_LegacyMapMusic(int* music_index, int* music_lump, int episode, int map);
 int dsda_LegacyIntermissionMusic(int* music_index, int* music_lump);
 int dsda_LegacyInterMusic(int* music_index, int* music_lump);
 int dsda_LegacyStartFinale(void);

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -170,16 +170,15 @@ int dsda_UMusicIndexToLumpNum(int* lump, int music_index) {
   return false;
 }
 
-int dsda_UMapMusic(int* music_index, int* music_lump) {
+int dsda_UMapMusic(int* music_index, int* music_lump, int episode, int map) {
   int lump;
+  struct MapEntry* entry = dsda_UMapEntry(episode, map);
+  int level_num;
 
-  if (!gamemapinfo)
+  if (!entry || !entry->music[0])
     return false;
 
-  if (!gamemapinfo->music[0])
-    return false;
-
-  lump = W_CheckNumForName(gamemapinfo->music);
+  lump = W_CheckNumForName(entry->music);
 
   if (lump == LUMP_NOT_FOUND)
     return false;

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -173,7 +173,6 @@ int dsda_UMusicIndexToLumpNum(int* lump, int music_index) {
 int dsda_UMapMusic(int* music_index, int* music_lump, int episode, int map) {
   int lump;
   struct MapEntry* entry = dsda_UMapEntry(episode, map);
-  int level_num;
 
   if (!entry || !entry->music[0])
     return false;

--- a/prboom2/src/dsda/mapinfo/u.h
+++ b/prboom2/src/dsda/mapinfo/u.h
@@ -37,7 +37,7 @@ void dsda_UUpdateNextMapInfo(void);
 int dsda_UResolveCLEV(int* clev, int* episode, int* map);
 int dsda_UResolveINIT(int* init);
 int dsda_UMusicIndexToLumpNum(int* lump, int music_index);
-int dsda_UMapMusic(int* music_index, int* music_lump);
+int dsda_UMapMusic(int* music_index, int* music_lump, int episode, int map);
 int dsda_UIntermissionMusic(int* music_index, int* music_lump);
 int dsda_UInterMusic(int* music_index, int* music_lump);
 int dsda_UStartFinale(void);

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -39,6 +39,7 @@
 #include "p_tick.h"
 #include "m_cheat.h"
 #include "s_sound.h"
+#include "s_advsound.h"
 #include "sounds.h"
 #include "dstrings.h"
 #include "r_main.h"
@@ -254,7 +255,8 @@ cheatseq_t cheat[] = {
 static void cheat_mus(buf)
 char buf[3];
 {
-  int musnum;
+  int musnum, muslump;
+  int epsd, map;
 
   //jff 3/20/98 note: this cheat allowed in netgame/demorecord
 
@@ -262,34 +264,35 @@ char buf[3];
   if (!isdigit(buf[0]) || !isdigit(buf[1]))
     return;
 
+  if (gamemode == commercial)
+  {
+    epsd = 1; //jff was 0, but espd is 1-based
+    map = (buf[0] - '0') * 10 + buf[1] - '0';
+  }
+  else
+  {
+    epsd = buf[0] - '1';
+    map = buf[1] - '1';
+  }
+
   dsda_AddMessage(s_STSTR_MUS);
 
-  if (gamemode == commercial)
-    {
-      musnum = mus_runnin + (buf[0]-'0')*10 + buf[1]-'0' - 1;
+  idmusnum = -1;
+  dsda_MapMusic(&musnum, &muslump, epsd, map);
+  idmusnum = musnum; //jff 3/17/98 remember idmus number for restore
 
-      //jff 4/11/98 prevent IDMUS00 in DOOMII and IDMUS36 or greater
-      if (musnum < mus_runnin ||  ((buf[0]-'0')*10 + buf[1]-'0') > 35)
-        dsda_AddMessage(s_STSTR_NOMUS);
-      else
-        {
-          S_ChangeMusic(musnum, 1);
-          idmusnum = musnum; //jff 3/17/98 remember idmus number for restore
-        }
-    }
+  if (muslump != -1)
+  {
+    S_ChangeMusInfoMusic(muslump, true);
+  }
+  else if (musnum != -1)
+  {
+    S_ChangeMusic(musnum, 1);
+  }
   else
-    {
-      musnum = mus_e1m1 + (buf[0]-'1')*9 + (buf[1]-'1');
-
-      //jff 4/11/98 prevent IDMUS0x IDMUSx0 in DOOMI and greater than introa
-      if (buf[0] < '1' || buf[1] < '1' || ((buf[0]-'1')*9 + buf[1]-'1') > 31)
-        dsda_AddMessage(s_STSTR_NOMUS);
-      else
-        {
-          S_ChangeMusic(musnum, 1);
-          idmusnum = musnum; //jff 3/17/98 remember idmus number for restore
-        }
-    }
+  {
+    dsda_AddMessage(s_STSTR_NOMUS);
+  }
 }
 
 // 'choppers' invulnerability & chainsaw

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -275,7 +275,7 @@ void S_Start(void)
   // start new music for the level
   mus_paused = 0;
 
-  dsda_MapMusic(&mnum, &muslump);
+  dsda_MapMusic(&mnum, &muslump, gameepisode, gamemap);
 
   if (muslump >= 0)
   {


### PR DESCRIPTION
Reported on discord. Fixes IDMUS only playing IWAD lumps

The dsda_*Music() functions were hardcoded to only use the current map, so I adapted dsda_MapMusic() to take any map.
Maybe we should do the same for the others, but I can't think of a reason we would need to call them with a map param.