### PR TITLE
Minor OpenGL Dark Overlay Fix

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -850,7 +850,12 @@ void gld_FillBlock(int x, int y, int width, int height, int col)
 
 void gld_DrawShaded(int x, int y, int width, int height, int shade)
 {
-  color_rgb_t color = gld_LookupIndexedColor(playpal_black, V_IsAutomapLightmodeIndexed());
+  // This is more messy than I'd like. (I hate this, but this is my current fix for the menu overlay invert)
+  // The `col` fixes the menu overlay from inverting during `invul_cm`.
+  // The 'automap` boolean is to undo the `col` invert for the automap.
+  dboolean automap = V_IsAutomapLightmodeIndexed();
+  int col = invul_cm && !automap ? playpal_white : playpal_black;
+  color_rgb_t color = gld_LookupIndexedColor(col, V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed());
 
   glsl_PushNullShader();
 


### PR DESCRIPTION
I tried to get everything ready in the last big PR, but apparently I missed something.

During the last PR, I found and fixed an issue where the dark overlay would actually become inverted when the Invulnerability effect was on.

However my fix accidently made it so that the overlay ignored screen effects (red pain screen, yellow item screen). So this PR allows those effects to show on the overlay, just as it does on Software.

Let me know if there's a better way to simplify this code, because it seems a bit messier than I'd like, but this is the only way I could get it to not invert either the automap or menu overlay.