### PR TITLE
Fallback to getpwuid() if $HOME is unset

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -91,6 +91,7 @@ check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
 check_symbol_exists(CreateFileMapping "windows.h" HAVE_CREATE_FILE_MAPPING)
 check_symbol_exists(strsignal "string.h" HAVE_STRSIGNAL)
 check_symbol_exists(mkstemp "stdlib.h" HAVE_MKSTEMP)
+check_symbol_exists(getpwuid "unistd.h;sys/types.h;pwd.h" HAVE_GETPWUID)
 
 include(CheckIncludeFile)
 

--- a/prboom2/cmake/config.h.cin
+++ b/prboom2/cmake/config.h.cin
@@ -14,6 +14,7 @@
 #cmakedefine HAVE_CREATE_FILE_MAPPING
 #cmakedefine HAVE_STRSIGNAL
 #cmakedefine HAVE_MKSTEMP
+#cmakedefine HAVE_GETPWUID
 
 #cmakedefine HAVE_SYS_WAIT_H
 #cmakedefine HAVE_UNISTD_H

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -56,6 +56,10 @@
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#ifdef HAVE_GETPWUID
+#include <sys/types.h>
+#include <pwd.h>
+#endif
 #endif
 
 #ifdef _MSC_VER
@@ -315,7 +319,13 @@ const char *I_ConfigDir(void)
     const char *home = M_getenv("HOME");
     if (!home)
     {
-      home = "/";
+#ifdef HAVE_GETPWUID
+      struct passwd *user_info = getpwuid(getuid());
+      if (user_info != NULL)
+        home = user_info->pw_dir;
+      else
+#endif
+        home = "/";
     }
 
     // First, try legacy directory.


### PR DESCRIPTION
Recently, commit 7621899c4025b4b4af811ed81ce0a08eca2b6a6e added some fallback code for the rare case when `$HOME` is unset. However, that code simply falls to using the root directory as the home. This PR makes the game use the `getpwuid()`[^0] function instead, which retrieves information about the user profile - including the home directory - from the OS.

One minor issue with this PR is that (at least on Fedora Linux) it causes some "duplicate definition" warnings:
```
prboom2/BUILD/config.h:18:9: warning: "HAVE_SYS_TYPES_H" redefined
   18 | #define HAVE_SYS_TYPES_H
      |         ^~~~~~~~~~~~~~~~
In file included from /usr/include/SDL2/SDL_config.h:58,
                 from /usr/include/SDL2/SDL_stdinc.h:31,
                 from /usr/include/SDL2/SDL_main.h:25,
                 from /usr/include/SDL2/SDL.h:32,
                 from prboom2/src/SDL/i_sound.c:43:
/usr/include/SDL2/SDL_config-x86_64.h:73:9: note: this is the location of the previous definition
```
There are a couple of different ways this could be solved:

1. Hide the `#cmakedefine` behind an `#ifdef`, so it only defines the symbol if not already present.

2. Move the "are all three headers present?" check to CMakeLists and then have only `#cmakedefine GETPWUID_FALLBACK` in the config file.

3. Probably something else I haven't considered.

Each has its pros and cons, so I thought it's best to discuss first.

[^0]: https://linux.die.net/man/3/getpwuid