### PR TITLE
More window improvements

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1223,7 +1223,6 @@ void I_UpdateVideoMode(void)
 {
   int init_flags = SDL_WINDOW_ALLOW_HIGHDPI;
   int screen_multiply;
-  int actualheight;
   int render_vsync;
   int integer_scaling;
   const char *sdl_video_window_pos;
@@ -1273,11 +1272,11 @@ void I_UpdateVideoMode(void)
   // [FG] aspect ratio correction for the canonical video modes
   if (SCREENHEIGHT == 200 || SCREENHEIGHT == 400)
   {
-    actualheight = 6*SCREENHEIGHT/5;
+    ACTUALHEIGHT = 6*SCREENHEIGHT/5;
   }
   else
   {
-    actualheight = SCREENHEIGHT;
+    ACTUALHEIGHT = SCREENHEIGHT;
   }
 
   if (desired_fullscreen)
@@ -1314,10 +1313,10 @@ void I_UpdateVideoMode(void)
     sdl_window = SDL_CreateWindow(
       PACKAGE_NAME " " PACKAGE_VERSION,
       SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-      SCREENWIDTH * screen_multiply, actualheight * screen_multiply,
+      SCREENWIDTH * screen_multiply, ACTUALHEIGHT * screen_multiply,
       init_flags);
     sdl_glcontext = SDL_GL_CreateContext(sdl_window);
-    SDL_SetWindowMinimumSize(sdl_window, SCREENWIDTH, actualheight);
+    SDL_SetWindowMinimumSize(sdl_window, SCREENWIDTH, ACTUALHEIGHT);
   }
   else
   {
@@ -1329,12 +1328,12 @@ void I_UpdateVideoMode(void)
     sdl_window = SDL_CreateWindow(
       PACKAGE_NAME " " PACKAGE_VERSION,
       SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
-      SCREENWIDTH * screen_multiply, actualheight * screen_multiply,
+      SCREENWIDTH * screen_multiply, ACTUALHEIGHT * screen_multiply,
       init_flags);
     sdl_renderer = SDL_CreateRenderer(sdl_window, -1, flags);
 
-    SDL_SetWindowMinimumSize(sdl_window, SCREENWIDTH, actualheight);
-    SDL_RenderSetLogicalSize(sdl_renderer, SCREENWIDTH, actualheight);
+    SDL_SetWindowMinimumSize(sdl_window, SCREENWIDTH, ACTUALHEIGHT);
+    SDL_RenderSetLogicalSize(sdl_renderer, SCREENWIDTH, ACTUALHEIGHT);
 
     // [FG] force integer scales
     SDL_RenderSetIntegerScale(sdl_renderer, integer_scaling);

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1290,12 +1290,6 @@ void I_UpdateVideoMode(void)
   else
   {
     init_flags |= SDL_WINDOW_RESIZABLE;
-
-    // [FG] make sure initial window size is always >= 640x480
-    while (screen_multiply*SCREENWIDTH < 640 || screen_multiply*actualheight < 480)
-    {
-      screen_multiply++;
-    }
   }
 
   if (V_IsOpenGLMode())

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1076,16 +1076,16 @@ void I_InitScreenResolution(void)
 
   desired_fullscreen = dsda_IntConfig(dsda_config_use_fullscreen);
 
-  if (dsda_Flag(dsda_arg_fullscreen))
-    desired_fullscreen = 1;
-
-  if (dsda_Flag(dsda_arg_window))
-    desired_fullscreen = 0;
-
   if (init)
   {
     //e6y: ability to change screen resolution from GUI
     I_FillScreenResolutionsList();
+
+    if (dsda_Flag(dsda_arg_fullscreen))
+    desired_fullscreen = 1;
+
+    if (dsda_Flag(dsda_arg_window))
+      desired_fullscreen = 0;
 
     // Video stuff
     arg = dsda_Arg(dsda_arg_width);

--- a/prboom2/src/doomdef.c
+++ b/prboom2/src/doomdef.c
@@ -41,6 +41,7 @@
 // proff 08/17/98: Changed for high-res
 int SCREENWIDTH=320;
 int SCREENHEIGHT=200;
+int ACTUALHEIGHT=240;
 int SCREENPITCH=320;
 
 // e6y: wide-res

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -109,6 +109,10 @@ typedef enum {
 // SCREENWIDTH and SCREENHEIGHT define the visible size
 extern int SCREENWIDTH;
 extern int SCREENHEIGHT;
+// ACTUALHEIGHT is the actual height of the resolution
+// If the resolution is 200p or 400p, aspect ratio correction
+// should be applied, making this value 240 or 480
+extern int ACTUALHEIGHT;
 // SCREENPITCH is the size of one line in the buffer and
 // can be bigger than the SCREENWIDTH depending on the size
 // of one pixel (8, 16 or 32 bit) and the padding at the

--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -48,7 +48,7 @@ void dsda_GLGetSDLWindowSize(SDL_Window* sdl_window) {
 void dsda_GLSetRenderViewportParams() {
   float viewport_aspect;
 
-  viewport_aspect = (float)SCREENWIDTH / (float)SCREENHEIGHT;
+  viewport_aspect = (float)SCREENWIDTH / (float)ACTUALHEIGHT;
 
   // Black bars on left and right of viewport
   if ((int)(gl_window_height * viewport_aspect) < gl_window_width) {
@@ -66,7 +66,7 @@ void dsda_GLSetRenderViewportParams() {
   }
 
   gl_scale_x = (float)gl_viewport_width / (float)SCREENWIDTH;
-  gl_scale_y = (float)gl_viewport_height / (float)SCREENHEIGHT;
+  gl_scale_y = (float)gl_viewport_height / (float)ACTUALHEIGHT;
 
   // elim - This will be zero if no statusbar is being drawn
   gl_statusbar_height = (int)(gl_scale_y * (float)ST_SCALED_HEIGHT) * R_PartialView();


### PR DESCRIPTION
- Allow < 640x480 windows https://github.com/kraflab/dsda-doom/issues/531
- Add low res aspect ratio correction on OpenGL
   On software 200p and 400p, the image is stretched to match 240p and 480p. This makes OpenGL follow it
   I meantioned before that I thought this behaviour should be removed instead, but Ive changed my opinions as I explored the issue more
- Allow setting desired_fullscreen in the menu, even if -window or -fullscreen
   If you had one of these params on, the desired_fullscreen menu option would not work
   Unlike these other params, -geom already allowed the menu option to work
   This is useful for the launcher, as it uses these params on every launch