### PR TITLE
Fix "Show Alive Monsters" Bug (When switching from OpenGL to Software)

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5278,15 +5278,20 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     }
   }
 
-  if (V_IsOpenGLMode())
+  if (dsda_InputActivated(dsda_input_showalive) && !dsda_StrictMode())
   {
-    if (dsda_InputActivated(dsda_input_showalive) && !dsda_StrictMode())
+    if (V_IsOpenGLMode())
     {
       const char* const show_alive_message[3] = { "off", "(mode 1) on", "(mode 2) on" };
       int show_alive = dsda_CycleConfig(dsda_config_show_alive_monsters, false);
 
       if (show_alive >= 0 && show_alive < 3)
         doom_printf("Show Alive Monsters %s", show_alive_message[show_alive]);
+    }
+    else
+    {
+      dsda_UpdateIntConfig(dsda_config_show_alive_monsters,0,false);
+      doom_printf("Action Only Supported in OpenGL");
     }
   }
 

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -930,7 +930,7 @@ void R_AddSprites(subsector_t* subsec, int lightlevel)
 
   // Handle all things in sector.
 
-  if (dsda_ShowAliveMonsters())
+  if (dsda_ShowAliveMonsters() && V_IsOpenGLMode())
   {
     if (dsda_ShowAliveMonsters() == 1)
     {


### PR DESCRIPTION
- Fully disable option in Software (since it's OpenGL only)
- Fixed a bug when switching from OpenGL to Software with "Show Alive Monsters" active (it no longer makes monsters / items invisible in Software)
- Added an "Action Only Supported in OpenGL" message when attempting to use feature in Software (This also resets the option to off)