### PR TITLE
Fix black space on low res opengl statusbar

### DIFF
--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -66,10 +66,10 @@ void dsda_GLSetRenderViewportParams() {
   }
 
   gl_scale_x = (float)gl_viewport_width / (float)SCREENWIDTH;
-  gl_scale_y = (float)gl_viewport_height / (float)ACTUALHEIGHT;
+  gl_scale_y = (float)gl_viewport_height / (float)SCREENHEIGHT;
 
   // elim - This will be zero if no statusbar is being drawn
-  gl_statusbar_height = (int)(gl_scale_y * (float)ST_SCALED_HEIGHT) * R_PartialView();
+  gl_statusbar_height = (int)(gl_scale_y * (float)ST_SCALED_HEIGHT + 1) * R_PartialView();
 
   gl_scene_width = gl_viewport_width;
   gl_scene_height = gl_viewport_height - gl_statusbar_height;


### PR DESCRIPTION
Because of float -> int conversion (I think),  that +1 is needed to not get a sliver of a black line