### PR TITLE
Fix missing <string.h> include

### DIFF
--- a/prboom2/src/gl_opengl.c
+++ b/prboom2/src/gl_opengl.c
@@ -36,6 +36,7 @@
 #endif
 
 #include <stdio.h>
+#include <string.h>
 
 #include <SDL.h>
 #include "gl_opengl.h"


### PR DESCRIPTION
The OpenGL init code was calling `strstr()` to check for supported GL extensions, but it did not include `<string.h>`.