### PR TITLE
Add missing <math.h> include

### DIFF
--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -25,6 +25,8 @@
 #include "r_main.h"
 #include "st_stuff.h"
 
+#include <math.h>
+
 int gl_window_width;
 int gl_window_height;
 int gl_viewport_width;


### PR DESCRIPTION
`prboom2/src/dsda/gl/render_scale.c` is calling `ceilf()`, but does not include the necessary header.