### PR TITLE
Allow starting the window in a different display

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1226,8 +1226,8 @@ void I_UpdateVideoMode(void)
   int render_vsync;
   int integer_scaling;
   const char *sdl_video_window_pos;
-  int x = SDL_WINDOWPOS_CENTERED;
-  int y = SDL_WINDOWPOS_CENTERED;
+  int sdl_video_display_index;
+  int x, y;
   const dboolean novsync = dsda_Flag(dsda_arg_timedemo) ||
                            dsda_Flag(dsda_arg_fastdemo);
 
@@ -1235,6 +1235,7 @@ void I_UpdateVideoMode(void)
                          I_DesiredVideoMode() == VID_MODESW;
   render_vsync = dsda_IntConfig(dsda_config_render_vsync) && !novsync;
   sdl_video_window_pos = dsda_StringConfig(dsda_config_sdl_video_window_pos);
+  sdl_video_display_index = dsda_IntConfig(dsda_config_sdl_video_display_index);
   screen_multiply = dsda_IntConfig(dsda_config_render_screen_multiply);
   integer_scaling = dsda_IntConfig(dsda_config_integer_scaling);
 
@@ -1281,6 +1282,8 @@ void I_UpdateVideoMode(void)
     ACTUALHEIGHT = SCREENHEIGHT;
   }
 
+  x = SDL_WINDOWPOS_CENTERED_DISPLAY(sdl_video_display_index);
+  y = SDL_WINDOWPOS_CENTERED_DISPLAY(sdl_video_display_index);
   if (sdl_video_window_pos)
   {
     int nx, ny;
@@ -1288,11 +1291,6 @@ void I_UpdateVideoMode(void)
     {
       x = nx;
       y = ny;
-    }
-    else if (strcmp(sdl_video_window_pos, "center") == 0)
-    {
-      x = SDL_WINDOWPOS_CENTERED;
-      y = SDL_WINDOWPOS_CENTERED;
     }
   }
 

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1226,6 +1226,8 @@ void I_UpdateVideoMode(void)
   int render_vsync;
   int integer_scaling;
   const char *sdl_video_window_pos;
+  int x = SDL_WINDOWPOS_CENTERED;
+  int y = SDL_WINDOWPOS_CENTERED;
   const dboolean novsync = dsda_Flag(dsda_arg_timedemo) ||
                            dsda_Flag(dsda_arg_fastdemo);
 
@@ -1279,16 +1281,19 @@ void I_UpdateVideoMode(void)
     ACTUALHEIGHT = SCREENHEIGHT;
   }
 
-  if (desired_fullscreen)
+  if (sdl_video_window_pos)
   {
-    if (exclusive_fullscreen)
-      init_flags |= SDL_WINDOW_FULLSCREEN;
-    else
-      init_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
-  }
-  else
-  {
-    init_flags |= SDL_WINDOW_RESIZABLE;
+    int nx, ny;
+    if (sscanf(sdl_video_window_pos, "%d,%d", &nx, &ny) == 2)
+    {
+      x = nx;
+      y = ny;
+    }
+    else if (strcmp(sdl_video_window_pos, "center") == 0)
+    {
+      x = SDL_WINDOWPOS_CENTERED;
+      y = SDL_WINDOWPOS_CENTERED;
+    }
   }
 
   if (V_IsOpenGLMode())
@@ -1312,7 +1317,7 @@ void I_UpdateVideoMode(void)
 
     sdl_window = SDL_CreateWindow(
       PACKAGE_NAME " " PACKAGE_VERSION,
-      SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+      x, y,
       SCREENWIDTH * screen_multiply, ACTUALHEIGHT * screen_multiply,
       init_flags);
     sdl_glcontext = SDL_GL_CreateContext(sdl_window);
@@ -1327,7 +1332,7 @@ void I_UpdateVideoMode(void)
 
     sdl_window = SDL_CreateWindow(
       PACKAGE_NAME " " PACKAGE_VERSION,
-      SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+      x, y,
       SCREENWIDTH * screen_multiply, ACTUALHEIGHT * screen_multiply,
       init_flags);
     sdl_renderer = SDL_CreateRenderer(sdl_window, -1, flags);
@@ -1349,17 +1354,20 @@ void I_UpdateVideoMode(void)
     }
   }
 
-  if (sdl_video_window_pos)
+  // When creating the window, its not allowed to set a position in a different display
+  // This allows that
+  SDL_SetWindowPosition(sdl_window, x, y);
+
+  if (desired_fullscreen)
   {
-    int x, y;
-    if (sscanf(sdl_video_window_pos, "%d,%d", &x, &y) == 2)
-    {
-      SDL_SetWindowPosition(sdl_window, x, y);
-    }
-    if (strcmp(sdl_video_window_pos, "center") == 0)
-    {
-      SDL_SetWindowPosition(sdl_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-    }
+    if (exclusive_fullscreen)
+      SDL_SetWindowFullscreen(sdl_window, SDL_WINDOW_FULLSCREEN);
+    else
+      SDL_SetWindowFullscreen(sdl_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+  }
+  else
+  {
+    SDL_SetWindowResizable(sdl_window, SDL_TRUE);
   }
 
   // Workaround for SDL 2.0.14 alt-tab bug (taken from Doom Retro)

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1147,7 +1147,11 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_sdl_video_window_pos] = {
     "sdl_video_window_pos", dsda_config_sdl_video_window_pos,
-    CONF_STRING("center")
+    CONF_STRING("")
+  },
+  [dsda_config_sdl_video_display_index] = {
+    "sdl_video_display_index", dsda_config_sdl_video_display_index,
+    dsda_config_int, 0, 10, { 0 }, NULL, NOT_STRICT
   },
   [dsda_config_palette_ondamage] = {
     "palette_ondamage", dsda_config_palette_ondamage,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -258,6 +258,7 @@ typedef enum {
   dsda_config_usegamma,
   dsda_config_screenblocks,
   dsda_config_sdl_video_window_pos,
+  dsda_config_sdl_video_display_index,
   dsda_config_palette_ondamage,
   dsda_config_palette_onbonus,
   dsda_config_palette_onpowers,

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -151,6 +151,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_fps_limit),
   MIGRATED_SETTING(dsda_config_background_fps_limit),
   MIGRATED_SETTING(dsda_config_sdl_video_window_pos),
+  MIGRATED_SETTING(dsda_config_sdl_video_display_index),
   MIGRATED_SETTING(dsda_config_palette_ondamage),
   MIGRATED_SETTING(dsda_config_palette_onbonus),
   MIGRATED_SETTING(dsda_config_palette_onpowers),


### PR DESCRIPTION
- Fixes sdl_video_window_pos not working for fullscreen windows
   https://github.com/kraflab/dsda-doom/issues/580
   
- Adds sdl_video_display_index for starting the window in a different display
   Tbh, I always assumed this was already possible