### PR TITLE
Reintroduce complevel check for Ultimate Doom Episode 4

### DIFF
--- a/prboom2/src/dsda/episode.c
+++ b/prboom2/src/dsda/episode.c
@@ -55,7 +55,7 @@ void dsda_AddOriginalEpisodes(void) {
     dsda_AddEpisode("e2m1", NULL, "M_EPI2", 't', true);
     dsda_AddEpisode("e3m1", NULL, "M_EPI3", 'i', true);
 
-    if (gamemode == retail)
+    if (gamemode == retail && compatibility_level >= ultdoom_compatibility)
       dsda_AddEpisode("e4m1", NULL, "M_EPI4", 't', true);
   }
 }


### PR DESCRIPTION
It looks like kraflab may have accidentally introduced a regression when they refactored the episode handler in 874ff9525a775ca5bdfda526396fd4bb18b636fc. Traditionally, Thy Flesh Consumed could only be selected in complevel 3 and when an Ultimate Doom IWAD is being used, but from that point forward the complevel check was dropped and only a `gamemode == retail` check remained. This patch simply reintroduces the complevel check.

It's safe to say that this isn't going to impact too many people, but it technically restores the correct, pre-0.27.0 behavior. :)