### PR TITLE
Fix linear sky calculation for wide sky textures

### DIFF
--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -426,10 +426,7 @@ static void R_InitTextureMapping (void)
 
       // [FG] linear horizontal sky scrolling
       angle = (0.5 - x / (double)viewwidth) * linearskyfactor;
-      if (angle >= 0)
-        linearskyangle[x] = angle;
-      else
-        linearskyangle[x] = ANG90 + angle;
+      linearskyangle[x] = (angle >= 0) ? angle : ANGLE_MAX + angle;
     }
 
   // Take out the fencepost cases from viewangletox.


### PR DESCRIPTION
For example [Ozonia 2 Ep1](https://www.doomworld.com/forum/topic/142512).