### PR TITLE
ENDOOM Features

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1266,7 +1266,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_show_endoom] = {
     "show_endoom", dsda_config_show_endoom,
-    dsda_config_int, 0, 1, { 0 }
+    dsda_config_int, 0, 2, { 0 }
   },
   [dsda_config_ansi_endoom] = {
     "ansi_endoom", dsda_config_ansi_endoom,

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1264,9 +1264,13 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "invert_analog_look", dsda_config_invert_analog_look,
     CONF_BOOL(0),
   },
+  [dsda_config_show_endoom] = {
+    "show_endoom", dsda_config_show_endoom,
+    dsda_config_int, 0, 1, { 0 }
+  },
   [dsda_config_ansi_endoom] = {
     "ansi_endoom", dsda_config_ansi_endoom,
-    dsda_config_int, 0, 2, { 0 }
+    dsda_config_int, 1, 2, { 1 }
   },
   [dsda_config_quit_sounds] = {
     "quit_sounds", dsda_config_quit_sounds,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -285,6 +285,7 @@ typedef enum {
   dsda_config_analog_look_acceleration,
   dsda_config_swap_analogs,
   dsda_config_invert_analog_look,
+  dsda_config_show_endoom,
   dsda_config_ansi_endoom,
   dsda_config_quit_sounds,
   dsda_config_announce_map,

--- a/prboom2/src/dsda/endoom.c
+++ b/prboom2/src/dsda/endoom.c
@@ -361,7 +361,7 @@ void dsda_CacheEndoom(void) {
       lump = W_CheckNumForName("ENDOOM");
   }
 
-  if (lump == LUMP_NOT_FOUND || W_LumpLength(lump) != 4000)
+  if (lump == LUMP_NOT_FOUND || W_LumpLength(lump) != 4000 || (show_endoom==2 && !W_PWADLumpNumExists(lump)))
     return;
 
   endoom = Z_Malloc(4000);

--- a/prboom2/src/dsda/endoom.c
+++ b/prboom2/src/dsda/endoom.c
@@ -20,6 +20,7 @@
 #include "windows.h"
 #endif
 
+#include "args.h"
 #include "doomdef.h"
 #include "doomtype.h"
 #include "lprintf.h"
@@ -344,8 +345,14 @@ static void RestoreOldMode(void) {
 void dsda_CacheEndoom(void) {
   int lump;
   int show_endoom = dsda_IntConfig(dsda_config_show_endoom);
+  dboolean demo_check  = dsda_Flag(dsda_arg_record) || dsda_Flag(dsda_arg_recordfromto)
+                      || dsda_Flag(dsda_arg_playdemo) || dsda_Flag(dsda_arg_timedemo)
+                      || dsda_Flag(dsda_arg_fastdemo);
 
   output_format = dsda_IntConfig(dsda_config_ansi_endoom);
+
+  if (demo_check)
+    return;
 
   if (show_endoom == 0)
     return;

--- a/prboom2/src/dsda/endoom.c
+++ b/prboom2/src/dsda/endoom.c
@@ -343,10 +343,11 @@ static void RestoreOldMode(void) {
 
 void dsda_CacheEndoom(void) {
   int lump;
+  int show_endoom = dsda_IntConfig(dsda_config_show_endoom);
 
   output_format = dsda_IntConfig(dsda_config_ansi_endoom);
 
-  if (!output_format)
+  if (show_endoom == 0)
     return;
 
   if (hexen)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3075,12 +3075,15 @@ setup_menu_t controller_settings[] = {
   FINAL_ENTRY
 };
 
+static const char* endoom_list[] = { "Off", "On", "PWAD only", NULL };
+
 setup_menu_t misc_settings[] = {
   { "Miscellaneous", S_SKIP | S_TITLE, m_null, G_X},
   { "Default skill level", S_CHOICE, m_conf, G_X, dsda_config_default_skill, 0, gen_skillstrings },
   { "Default compatibility level", S_CHOICE, m_conf, G_X, dsda_config_default_complevel, 0, &gen_compstrings[1] },
   { "Enable Cheat Code Entry", S_YESNO, m_conf, G_X, dsda_config_cheat_codes },
   { "Announce Map On Entry", S_YESNO, m_conf, G_X, dsda_config_announce_map },
+  { "Endoom Screen", S_CHOICE, m_conf, G_X, dsda_config_show_endoom, 0, endoom_list },
   EMPTY_LINE,
   { "Quality Of Life", S_SKIP | S_TITLE, m_null, G_X},
   { "Rewind Interval (s)", S_NUM, m_conf, G_X, dsda_config_auto_key_frame_interval },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -90,6 +90,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_demo_smoothturnsfactor),
   MIGRATED_SETTING(dsda_config_screenshot_dir),
   MIGRATED_SETTING(dsda_config_startup_delay_ms),
+  MIGRATED_SETTING(dsda_config_show_endoom),
   MIGRATED_SETTING(dsda_config_ansi_endoom),
   MIGRATED_SETTING(dsda_config_quit_sounds),
   MIGRATED_SETTING(dsda_config_announce_map),


### PR DESCRIPTION
I'm sure you knew this was coming eventually... This PR does not address the drawing of ENDOOM, but rather the behaviour of how it is treated.

Tweaks / Features:
- `ansi_endoom` is no longer tied as the on/off switch for showing the ENDOOM.
- `show_endoom` is now the on/off switch + has an option to only show PWAD ENDOOMs.
- Add an "ENDOOM" menu option
- Disable the ENDOOM if playing/recording a demo (I added this feature because I can't think of a single reason why speedrunners would want to see the ENDOOM when doing demos)