### PR TITLE
Add "GAMEINFO" / Episode IWAD load support

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -57,6 +57,8 @@ set(COMMON_SRC
     dsda/font.h
     dsda/game_controller.c
     dsda/game_controller.h
+    dsda/gameinfo.cpp
+    dsda/gameinfo.h
     dsda/ghost.c
     dsda/ghost.h
     dsda/gl/render_scale.c

--- a/prboom2/src/d_main.h
+++ b/prboom2/src/d_main.h
@@ -67,6 +67,8 @@ void D_StartTitle(void);
 void D_DoomMain(void);
 void D_AddFile (const char *file, wad_source_t source);
 
+extern char* iwadlump;
+
 void AddIWAD(const char *iwad);
 
 extern const char *port_wad_file;

--- a/prboom2/src/dsda/gameinfo.cpp
+++ b/prboom2/src/dsda/gameinfo.cpp
@@ -1,0 +1,64 @@
+//
+// Copyright(C) 2025 by Andrik Powell
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  DSDA GAMEINFO
+//
+
+#include <string.h>
+
+extern "C" {
+#include "d_main.h"
+#include "w_wad.h"
+#include "lprintf.h"
+#include "z_zone.h"
+}
+
+#include "scanner.h"
+
+#include "gameinfo.h"
+    
+void dsda_ParseGameInfoLine(Scanner &scanner) {
+
+  if (!scanner.CheckString()) {
+    scanner.GetNextToken();
+    scanner.SkipLine();
+    return;
+  }
+
+  if (!stricmp(scanner.string, "IWAD")) {
+    scanner.MustGetToken('=');
+    scanner.MustGetString();
+
+    if (iwadlump)
+      Z_Free(iwadlump);
+
+    iwadlump = Z_Strdup(scanner.string);
+  }
+}
+
+void dsda_LoadGameInfo(void) {
+  int lump;
+
+  lump = W_CheckNumForName("GAMEINFO");
+
+  if (lump == LUMP_NOT_FOUND)
+    return;
+
+  Scanner scanner((const char*) W_LumpByNum(lump), W_LumpLength(lump));
+
+  scanner.SetErrorCallback(I_Error);
+
+  while (scanner.TokensLeft())
+    dsda_ParseGameInfoLine(scanner);
+}

--- a/prboom2/src/dsda/gameinfo.h
+++ b/prboom2/src/dsda/gameinfo.h
@@ -1,0 +1,31 @@
+//
+// Copyright(C) 2025 by Andrik Powell
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// DESCRIPTION:
+//  DSDA GAMEINFO
+//
+
+#ifndef __GAMEINFO__
+#define __GAMEINFO__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void dsda_LoadGameInfo(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/prboom2/src/dsda/zipfile.c
+++ b/prboom2/src/dsda/zipfile.c
@@ -130,6 +130,20 @@ const char* dsda_UnzipFile(const char *zipped_file_name) {
   return temporary_directory.string;
 }
 
+const char* dsda_ReadUnzippedFile(const char *zipped_file_name) {
+  dsda_string_t temporary_directory;
+  static unsigned int file_counter = 0;
+
+  dsda_StringPrintF(&temporary_directory, "%s/%u-%s", I_GetTempDir(), file_counter, dsda_BaseName(zipped_file_name));
+
+  temp_dirs = Z_Realloc(temp_dirs, (file_counter + 2) * sizeof(*temp_dirs));
+  temp_dirs[file_counter] = temporary_directory.string;
+  temp_dirs[file_counter + 1] = NULL;
+  file_counter++;
+
+  return temporary_directory.string;
+}
+
 void dsda_CleanZipTempDirs(void) {
   int i;
 

--- a/prboom2/src/dsda/zipfile.h
+++ b/prboom2/src/dsda/zipfile.h
@@ -19,6 +19,7 @@
 #define __DSDA_ZIPFILE__
 
 const char* dsda_UnzipFile(const char *zipped_file_name);
+const char* dsda_ReadUnzippedFile(const char *zipped_file_name);
 
 void dsda_CleanZipTempDirs(void);
 

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -65,6 +65,8 @@
 lumpinfo_t *lumpinfo;
 int        numlumps;         // killough
 
+int MainLumpCache = false;
+
 void ExtractFileBase (const char *path, char *dest)
 {
   const char *src = path + strlen(path) - 1;
@@ -160,7 +162,8 @@ static void W_AddFile(wadfile_info_t *wadfile)
   }
 
   //jff 8/3/98 use logical output routine
-  lprintf (LO_INFO," adding %s\n",wadfile->name);
+  if (MainLumpCache)
+    lprintf (LO_INFO," adding %s\n",wadfile->name);
   startlump = numlumps;
 
   // mark lumps from internal resource
@@ -496,7 +499,10 @@ void W_Init(void)
   }
 
   if (!numlumps)
+  {
+    if (!MainLumpCache) return;
     I_Error ("W_Init: No files found");
+  }
 
   //jff 1/23/98
   // get all the sprites and flats into one marked block each
@@ -637,4 +643,14 @@ void W_Shutdown(void)
       wadfiles[i].handle = -1;
     }
   }
+}
+
+void dsda_ResetInitLumpCache(void)
+{
+  W_Shutdown();
+
+  wadfiles = NULL;
+  numwadfiles = 0;
+  lumpinfo = NULL;
+  numlumps = 0;
 }

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -92,10 +92,13 @@ extern wadfile_info_t *wadfiles;
 
 extern size_t numwadfiles; // CPhipps - size of the wadfiles array
 
+extern int MainLumpCache;
+
 void W_Init(void); // CPhipps - uses the above array
 void W_InitCache(void);
 void W_DoneCache(void);
 void W_Shutdown(void);
+void dsda_ResetInitLumpCache(void);
 
 typedef enum
 {


### PR DESCRIPTION
So this is going to be a fun one...

This solution is pretty jank and probably not the best implementation... but it does work!

This is similar to the `GAMEINFO` lump that GZDoom uses that can specify an IWAD to load via a PWAD lump.

Essentially to search the PWADs for an "IWAD" lump, I needed to cache the lumps before choosing the IWAD. So what ends up happening is that I cache it once (as a sort of quick cache), read the IWAD lump and then clear the cache for the "Real" lump cache.

Currently the main thing I don't like is, I haven't been able to combine the zip functions together as one with the variable "MainLumpCache".

If you're wondering what this is useful for, it's so I can drag-and-drop a plutonia based wad on dsda-doom, and it can load `plutonia.wad` if it finds it in the directory. I have a clause that defaults to normal behaviour if the wad specified in the "IWAD" lump isn't found.