### PR TITLE
Better TC game support + Autoload folders

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1450,7 +1450,10 @@ static const char *D_AutoLoadGameBase()
 {
   return hexen ? "hexen-all" :
          heretic ? "heretic-all" :
-         "doom-all";
+         chex ? "chex-all" :
+         freedoom ? "freedoom-all" :
+         !tc_game ? "doom-all":
+         NULL;
 }
 
 #define ALL_AUTOLOAD "all-all"
@@ -1467,11 +1470,14 @@ void D_AutoloadIWadDir()
   LoadZIPsAtPath(autoload_dir, source_auto_load, &autoload_deh_all_queue);
   Z_Free(autoload_dir);
 
-  // common auto-loaded files for the game
-  autoload_dir = GetAutoloadDir(D_AutoLoadGameBase(), true);
-  LoadWADsAtPath(autoload_dir, source_auto_load);
-  LoadZIPsAtPath(autoload_dir, source_auto_load, &autoload_deh_game_queue);
-  Z_Free(autoload_dir);
+  if (D_AutoLoadGameBase())
+  {
+    // common auto-loaded files for the game
+    autoload_dir = GetAutoloadDir(D_AutoLoadGameBase(), true);
+    LoadWADsAtPath(autoload_dir, source_auto_load);
+    LoadZIPsAtPath(autoload_dir, source_auto_load, &autoload_deh_game_queue);
+    Z_Free(autoload_dir);
+  }
 
   // auto-loaded files per IWAD
   autoload_dir = GetAutoloadDir(IWADBaseName(), true);
@@ -1510,11 +1516,14 @@ static void D_AutoloadDehIWadDir()
   D_ProcessDehAutoloadQueue(&autoload_deh_all_queue);
   Z_Free(autoload_dir);
 
-  // common auto-loaded files for the game
-  autoload_dir = GetAutoloadDir(D_AutoLoadGameBase(), true);
-  LoadDehackedFilesAtPath(autoload_dir, false, NULL);
-  D_ProcessDehAutoloadQueue(&autoload_deh_game_queue);
-  Z_Free(autoload_dir);
+  if (D_AutoLoadGameBase())
+  {
+    // common auto-loaded files for the game
+    autoload_dir = GetAutoloadDir(D_AutoLoadGameBase(), true);
+    LoadDehackedFilesAtPath(autoload_dir, false, NULL);
+    D_ProcessDehAutoloadQueue(&autoload_deh_game_queue);
+    Z_Free(autoload_dir);
+  }
 
   // auto-loaded files per IWAD
   autoload_dir = GetAutoloadDir(IWADBaseName(), true);

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -168,8 +168,9 @@ const char *const standard_iwads[]=
   "freedoom1.wad",
   "freedm.wad",
 
-  "hacx.wad",
   "chex.wad",
+
+  "hacx.wad",
   "rekkrsa.wad",
 
   "bfgdoom2.wad",
@@ -1028,7 +1029,7 @@ void AddIWAD(const char *iwad)
     case shareware:
       gamemission = doom;
       if (i>=8 && !strnicmp(iwad+i-8,"chex.wad",8))
-        gamemission = chex;
+        gamemission = tc_chex;
       break;
     case commercial:
       gamemission = doom2;
@@ -1039,7 +1040,7 @@ void AddIWAD(const char *iwad)
       else if (i>=12 && !strnicmp(iwad+i-12,"plutonia.wad",12))
         gamemission = pack_plut;
       else if (i>=8 && !strnicmp(iwad+i-8,"hacx.wad",8))
-        gamemission = hacx;
+        gamemission = tc_hacx;
       break;
     default:
       gamemission = none;
@@ -1605,7 +1606,7 @@ static void EvaluateDoomVerStr(void)
       case retail:
         switch (gamemission)
         {
-          case chex:
+          case tc_chex:
             doomverstr = "Chex(R) Quest";
             break;
           default:
@@ -1628,7 +1629,7 @@ static void EvaluateDoomVerStr(void)
           case pack_tnt:
             doomverstr = "Final DOOM - TNT: Evilution";
             break;
-          case hacx:
+          case tc_hacx:
             doomverstr = "HACX - Twitch 'n Kill";
             break;
           default:
@@ -1885,7 +1886,7 @@ static void D_DoomMainSetup(void)
         ProcessDehFile(NULL, D_dehout(), lump);
       }
     }
-    if (gamemission == chex)
+    if (gamemission == tc_chex)
     {
       int lump = W_CheckNumForName2("CHEXDEH", ns_prboom);
       if (lump != LUMP_NOT_FOUND)

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -169,6 +169,8 @@ const char *const standard_iwads[]=
   "freedm.wad",
 
   "chex.wad",
+  "chex3v.wad",
+  "chex3d2.wad",
 
   "hacx.wad",
   "rekkrsa.wad",
@@ -1036,6 +1038,8 @@ void AddIWAD(const char *iwad)
       gamemission = doom;
       if (i>=8 && !strnicmp(iwad+i-8,"chex.wad",8))
         gamemission = tc_chex;
+      else if (i>=10 && !strnicmp(iwad+i-10,"chex3v.wad",10))
+        gamemission = tc_chex3v;
       else if (i>=11 && !strnicmp(iwad+i-11,"rekkrsa.wad",11))
         gamemission = tc_rekkr;
       else if (i>=13 && !strnicmp(iwad+i-13,"freedoom1.wad",13))
@@ -1049,6 +1053,8 @@ void AddIWAD(const char *iwad)
         gamemission = pack_tnt;
       else if (i>=12 && !strnicmp(iwad+i-12,"plutonia.wad",12))
         gamemission = pack_plut;
+      else if (i>=11 && !strnicmp(iwad+i-11,"chex3d2.wad",11))
+        gamemission = tc_chex3v;
       else if (i>=8 && !strnicmp(iwad+i-8,"hacx.wad",8))
         gamemission = tc_hacx;
       else if ((i>=13 && !strnicmp(iwad+i-13,"freedoom2.wad",13))
@@ -1622,6 +1628,9 @@ static void EvaluateDoomVerStr(void)
           case tc_chex:
             doomverstr = "Chex(R) Quest";
             break;
+          case tc_chex3v:
+            doomverstr = "Chex(R) Quest 3: Vanilla Edition";
+            break;
           case tc_rekkr:
             doomverstr = "REKKR";
             break;
@@ -1647,6 +1656,9 @@ static void EvaluateDoomVerStr(void)
             break;
           case pack_tnt:
             doomverstr = "Final DOOM - TNT: Evilution";
+            break;
+          case tc_chex3v:
+            doomverstr = "Chex(R) Quest 3: Modding Edition";
             break;
           case tc_hacx:
             doomverstr = "HACX - Twitch 'n Kill";

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1069,12 +1069,8 @@ void AddIWAD(const char *iwad)
     //jff 9/3/98 use logical output routine
     lprintf(LO_WARN,"Unknown Game Version, may not work\n");
 
-  // Set up gamemission booleans
+  // Set up TC game logic
   tc_game = (gamemission > pack_nerve);
-  freedoom = (gamemission == tc_freedoom);
-  chex_exe = (gamemission == tc_chex);
-  chex = ((gamemission == tc_chex)
-       || (gamemission == tc_chex3v));
 
   D_AddFile(iwad,source_iwad);
 }
@@ -1458,8 +1454,9 @@ static const char *D_AutoLoadGameBase()
 {
   return hexen ? "hexen-all" :
          heretic ? "heretic-all" :
-         chex ? "chex-all" :
-         freedoom ? "freedoom-all" :
+         (gamemission == tc_chex ||
+         gamemission == tc_chex3v) ? "chex-all" :
+         (gamemission == tc_freedoom) ? "freedoom-all" :
          !tc_game ? "doom-all":
          NULL;
 }

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1068,6 +1068,14 @@ void AddIWAD(const char *iwad)
   if (gamemode == indetermined)
     //jff 9/3/98 use logical output routine
     lprintf(LO_WARN,"Unknown Game Version, may not work\n");
+
+  // Set up gamemission booleans
+  tc_game = (gamemission > pack_nerve);
+  freedoom = (gamemission == tc_freedoom);
+  chex_exe = (gamemission == tc_chex);
+  chex = ((gamemission == tc_chex)
+       || (gamemission == tc_chex3v));
+
   D_AddFile(iwad,source_iwad);
 }
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -613,6 +613,7 @@ static int  demosequence;         // killough 5/2/98: made static
 static int  pagetic;
 static const char *pagename; // CPhipps - const
 dboolean bfgedition = 0;
+dboolean freedm = 0;
 
 //
 // D_PageTicker
@@ -880,6 +881,7 @@ void CheckIWAD(const char *iwadname,GameMode_t *gmode,dboolean *hassec)
     int ud=0,rg=0,sw=0,cm=0,sc=0,hx=0;
     dboolean dmenupic = false;
     dboolean large_titlepic = false;
+    dboolean freedm_lmp = false;
     FILE* fp;
 
     // Identify IWAD correctly
@@ -944,6 +946,8 @@ void CheckIWAD(const char *iwadname,GameMode_t *gmode,dboolean *hassec)
             large_titlepic = true;
           if (!strncmp(fileinfo[length].name,"HACX",4))
             hx++;
+          if (!strncmp(fileinfo[length].name,"FREEDM",6))
+            freedm_lmp = true;
         }
         Z_Free(fileinfo);
 
@@ -957,6 +961,8 @@ void CheckIWAD(const char *iwadname,GameMode_t *gmode,dboolean *hassec)
     // unity iwad has dmenupic and a large titlepic
     if (dmenupic && !large_titlepic)
       bfgedition++;
+    if (freedm_lmp)
+      freedm++;
 
     // Determine game mode from levels present
     // Must be a full set for whichever mode is present
@@ -1030,6 +1036,10 @@ void AddIWAD(const char *iwad)
       gamemission = doom;
       if (i>=8 && !strnicmp(iwad+i-8,"chex.wad",8))
         gamemission = tc_chex;
+      else if (i>=11 && !strnicmp(iwad+i-11,"rekkrsa.wad",11))
+        gamemission = tc_rekkr;
+      else if (i>=13 && !strnicmp(iwad+i-13,"freedoom1.wad",13))
+        gamemission = tc_freedoom;
       break;
     case commercial:
       gamemission = doom2;
@@ -1041,6 +1051,9 @@ void AddIWAD(const char *iwad)
         gamemission = pack_plut;
       else if (i>=8 && !strnicmp(iwad+i-8,"hacx.wad",8))
         gamemission = tc_hacx;
+      else if ((i>=13 && !strnicmp(iwad+i-13,"freedoom2.wad",13))
+            || (i>=10 && !strnicmp(iwad+i-10,"freedm.wad",10)))
+        gamemission = tc_freedoom;
       break;
     default:
       gamemission = none;
@@ -1609,6 +1622,12 @@ static void EvaluateDoomVerStr(void)
           case tc_chex:
             doomverstr = "Chex(R) Quest";
             break;
+          case tc_rekkr:
+            doomverstr = "REKKR";
+            break;
+          case tc_freedoom:
+            doomverstr = "Freedoom Phase 1";
+            break;
           default:
             doomverstr = "The Ultimate DOOM";
             break;
@@ -1631,6 +1650,9 @@ static void EvaluateDoomVerStr(void)
             break;
           case tc_hacx:
             doomverstr = "HACX - Twitch 'n Kill";
+            break;
+          case tc_freedoom:
+            doomverstr = freedm ? "FreeDM" : "Freedoom Phase 2";
             break;
           default:
             doomverstr = "DOOM 2: Hell on Earth";

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -76,10 +76,14 @@ typedef enum {
   pack_tnt,     // TNT mission pack
   pack_plut,    // Plutonia pack
   pack_nerve,   // No Rest For The Living
-  hacx,         // HACX - Twitch 'n Kill
-  chex,         // Chex Quest
+  tc_hacx,      // HACX - Twitch 'n Kill
+  tc_chex,      // Chex Quest
+  tc_rekkr,     // REKKR
+  tc_freedoom,  // Freedoom
   none
 } GameMission_t;
+
+#define chex_exe  (gamemission == tc_chex)
 
 // Identify language to use, software localization.
 typedef enum {

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -85,9 +85,6 @@ typedef enum {
 } GameMission_t;
 
 extern dboolean tc_game;
-extern dboolean freedoom;
-extern dboolean chex_exe;
-extern dboolean chex;
 
 // Identify language to use, software localization.
 typedef enum {

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -84,11 +84,10 @@ typedef enum {
   none
 } GameMission_t;
 
-#define tc_game   !((gamemission == doom) || (gamemission == doom2) || (gamemission == pack_tnt) || (gamemission == pack_plut) || (gamemission == pack_nerve))
-
-#define chex      ((gamemission == tc_chex) || (gamemission == tc_chex3v))
-#define chex_exe  (gamemission == tc_chex)
-#define freedoom  (gamemission == tc_freedoom)
+extern dboolean tc_game;
+extern dboolean freedoom;
+extern dboolean chex_exe;
+extern dboolean chex;
 
 // Identify language to use, software localization.
 typedef enum {

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -84,7 +84,11 @@ typedef enum {
   none
 } GameMission_t;
 
+#define tc_game   !((gamemission == doom) || (gamemission == doom2) || (gamemission == pack_tnt) || (gamemission == pack_plut) || (gamemission == pack_nerve))
+
+#define chex      ((gamemission == tc_chex) || (gamemission == tc_chex3v))
 #define chex_exe  (gamemission == tc_chex)
+#define freedoom  (gamemission == tc_freedoom)
 
 // Identify language to use, software localization.
 typedef enum {

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -78,6 +78,7 @@ typedef enum {
   pack_nerve,   // No Rest For The Living
   tc_hacx,      // HACX - Twitch 'n Kill
   tc_chex,      // Chex Quest
+  tc_chex3v,    // Chex Quest 3: Vanilla/Modding Edition
   tc_rekkr,     // REKKR
   tc_freedoom,  // Freedoom
   none

--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -40,6 +40,11 @@
 GameMode_t gamemode = indetermined;
 GameMission_t   gamemission = doom;
 
+dboolean tc_game;
+dboolean freedoom;
+dboolean chex_exe;
+dboolean chex;
+
 // Language.
 Language_t   language = english;
 

--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -41,9 +41,6 @@ GameMode_t gamemode = indetermined;
 GameMission_t   gamemission = doom;
 
 dboolean tc_game;
-dboolean freedoom;
-dboolean chex_exe;
-dboolean chex;
 
 // Language.
 Language_t   language = english;

--- a/prboom2/src/dsda/episode.c
+++ b/prboom2/src/dsda/episode.c
@@ -50,7 +50,7 @@ void dsda_AddOriginalEpisodes(void) {
     dsda_AddEpisode("map01", "CLERIC", NULL, 'c', true);
     dsda_AddEpisode("map01", "MAGE", NULL, 'm', true);
   }
-  else if (gamemode != commercial && !chex_exe) {
+  else if (gamemode != commercial && gamemission != tc_chex) {
     dsda_AddEpisode("e1m1", NULL, "M_EPI1", 'k', true);
     dsda_AddEpisode("e2m1", NULL, "M_EPI2", 't', true);
     dsda_AddEpisode("e3m1", NULL, "M_EPI3", 'i', true);

--- a/prboom2/src/dsda/episode.c
+++ b/prboom2/src/dsda/episode.c
@@ -50,7 +50,7 @@ void dsda_AddOriginalEpisodes(void) {
     dsda_AddEpisode("map01", "CLERIC", NULL, 'c', true);
     dsda_AddEpisode("map01", "MAGE", NULL, 'm', true);
   }
-  else if (gamemode != commercial && gamemission != chex) {
+  else if (gamemode != commercial && !chex_exe) {
     dsda_AddEpisode("e1m1", NULL, "M_EPI1", 'k', true);
     dsda_AddEpisode("e2m1", NULL, "M_EPI2", 't', true);
     dsda_AddEpisode("e3m1", NULL, "M_EPI3", 'i', true);

--- a/prboom2/src/dsda/mapinfo/legacy.c
+++ b/prboom2/src/dsda/mapinfo/legacy.c
@@ -262,7 +262,7 @@ int dsda_LegacyPrevMap(int* episode, int* map) {
 int dsda_LegacyShowNextLocBehaviour(int* behaviour) {
   if (
     gamemode != commercial &&
-    (gamemap == 8 || (gamemission == chex && gamemap == 5))
+    (gamemap == 8 || (chex_exe && gamemap == 5))
   )
     *behaviour = WI_SHOW_NEXT_DONE;
   else
@@ -321,7 +321,7 @@ int dsda_LegacyResolveCLEV(int* clev, int* episode, int* map) {
   if (dsda_CannotCLEV(*episode, *map))
     *clev = false;
   else {
-    if (gamemission == chex)
+    if (chex_exe)
       *episode = 1;
 
     *clev = true;
@@ -470,7 +470,7 @@ int dsda_LegacyHUTitle(dsda_string_t* str) {
         case retail:
           // Chex.exe always uses the episode 1 level title
           // eg. E2M1 gives the title for E1M1
-          if (gamemission == chex && gamemap < 10)
+          if (chex_exe && gamemap < 10)
             dsda_StringCat(str, *mapnames[gamemap - 1]);
           else if (gameepisode < 6 && gamemap < 10)
             dsda_StringCat(str, *mapnames[(gameepisode - 1) * 9 + gamemap - 1]);
@@ -672,7 +672,7 @@ int dsda_LegacyPrepareFinale(int* result) {
     *result = WD_START_FINALE;
   else if (gamemap == 8)
     *result = WD_VICTORY;
-  else if (gamemap == 5 && gamemission == chex)
+  else if (gamemap == 5 && chex_exe)
     *result = WD_VICTORY;
 
   if (dsda_FinaleShortcut())

--- a/prboom2/src/dsda/mapinfo/legacy.c
+++ b/prboom2/src/dsda/mapinfo/legacy.c
@@ -262,7 +262,7 @@ int dsda_LegacyPrevMap(int* episode, int* map) {
 int dsda_LegacyShowNextLocBehaviour(int* behaviour) {
   if (
     gamemode != commercial &&
-    (gamemap == 8 || (chex_exe && gamemap == 5))
+    (gamemap == 8 || (gamemission == tc_chex && gamemap == 5))
   )
     *behaviour = WI_SHOW_NEXT_DONE;
   else
@@ -321,7 +321,7 @@ int dsda_LegacyResolveCLEV(int* clev, int* episode, int* map) {
   if (dsda_CannotCLEV(*episode, *map))
     *clev = false;
   else {
-    if (chex_exe)
+    if (gamemission == tc_chex)
       *episode = 1;
 
     *clev = true;
@@ -470,7 +470,7 @@ int dsda_LegacyHUTitle(dsda_string_t* str) {
         case retail:
           // Chex.exe always uses the episode 1 level title
           // eg. E2M1 gives the title for E1M1
-          if (chex_exe && gamemap < 10)
+          if (gamemission == tc_chex && gamemap < 10)
             dsda_StringCat(str, *mapnames[gamemap - 1]);
           else if (gameepisode < 6 && gamemap < 10)
             dsda_StringCat(str, *mapnames[(gameepisode - 1) * 9 + gamemap - 1]);
@@ -672,7 +672,7 @@ int dsda_LegacyPrepareFinale(int* result) {
     *result = WD_START_FINALE;
   else if (gamemap == 8)
     *result = WD_VICTORY;
-  else if (gamemap == 5 && chex_exe)
+  else if (gamemap == 5 && gamemission == tc_chex)
     *result = WD_VICTORY;
 
   if (dsda_FinaleShortcut())

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4166,7 +4166,7 @@ void M_DrawHelp (void)
 
   M_ChangeMenu(NULL, mnact_full);
 
-  if (W_PWADLumpNameExists(helplump))
+  if (W_PWADLumpNameExists(helplump) || tc_game)
   {
     V_ClearBorder();
     V_DrawNamePatch(0, 0, 0, helplump, CR_DEFAULT, VPT_STRETCH);
@@ -4230,7 +4230,7 @@ void M_DrawCredits(void)     // killough 10/98: credit screen
   const int PWADcredit = W_PWADLumpNameExists(credit);
 
   inhelpscreens = true;
-  if (PWADcredit)
+  if (PWADcredit || tc_game)
   {
     V_ClearBorder();
     V_DrawNamePatch(0, 0, 0, credit, CR_DEFAULT, VPT_STRETCH);

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -1170,7 +1170,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
     target->tics = 1;
 
   // In Chex Quest, monsters don't drop items.
-  if (chex_exe)
+  if (gamemission == tc_chex)
   {
     return;
   }

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -1170,7 +1170,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
     target->tics = 1;
 
   // In Chex Quest, monsters don't drop items.
-  if (gamemission == chex)
+  if (chex_exe)
   {
     return;
   }

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -764,7 +764,7 @@ static void ST_doPaletteStuff(void)
       // radiation suit palette is used to tint the screen green,
       // as though the player is being covered in goo by an
       // attacking flemoid.
-      if (gamemission == chex)
+      if (chex_exe)
       {
         palette = RADIATIONPAL;
       }

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -764,7 +764,7 @@ static void ST_doPaletteStuff(void)
       // radiation suit palette is used to tint the screen green,
       // as though the player is being covered in goo by an
       // attacking flemoid.
-      if (chex_exe)
+      if (gamemission == tc_chex)
       {
         palette = RADIATIONPAL;
       }

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -424,7 +424,7 @@ int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc
 			else if (!stricmp(parsed.mapname, "E2M8"))  strcpy(parsed.endpic, "VICTORY2");
 			else if (!stricmp(parsed.mapname, "E3M8"))  strcpy(parsed.endpic, "$BUNNY");
 			else if (!stricmp(parsed.mapname, "E4M8"))  strcpy(parsed.endpic, "ENDPIC");
-			else if (gamemission == chex && !stricmp(parsed.mapname, "E1M5"))  strcpy(parsed.endpic, "CREDIT");
+			else if (chex_exe && !stricmp(parsed.mapname, "E1M5"))  strcpy(parsed.endpic, "CREDIT");
 			else
 			{
 				int ep, map;

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -424,7 +424,7 @@ int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc
 			else if (!stricmp(parsed.mapname, "E2M8"))  strcpy(parsed.endpic, "VICTORY2");
 			else if (!stricmp(parsed.mapname, "E3M8"))  strcpy(parsed.endpic, "$BUNNY");
 			else if (!stricmp(parsed.mapname, "E4M8"))  strcpy(parsed.endpic, "ENDPIC");
-			else if (chex_exe && !stricmp(parsed.mapname, "E1M5"))  strcpy(parsed.endpic, "CREDIT");
+			else if (gamemission == tc_chex && !stricmp(parsed.mapname, "E1M5"))  strcpy(parsed.endpic, "CREDIT");
 			else
 			{
 				int ep, map;


### PR DESCRIPTION
This PR adds better TC game support for:
- Chex Quest (original DOS version)
- Chex Quest 3: Vanilla / Modding Edition
- REKKR
- Freedoom (Phase 1, Phase 2, FreeDM)

It also adds autoload folders for the above TCs.

I haven't added "REKKR: Sunken Land" here because the IWAD is badly formatted, and to get it to work in DSDA-Doom, it needs its own draft PR.