### PR TITLE
Fix Chainsaw Vanilla Weapon Switch Behaviour

### DIFF
--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -303,6 +303,10 @@ int P_SwitchWeapon(player_t *player)
   newweapon = currentweapon;
   i = NUMWEAPONS + 1;   // killough 5/2/98
 
+  // Fix weapon switch logic in vanilla (example: chainsaw with ammo)
+  if (demo_compatibility)
+    currentweapon = newweapon = wp_nochange;
+
   // killough 2/8/98: follow preferences and fix BFG/SSG bugs
 
   do


### PR DESCRIPTION
So this is a vanilla demo-breaking issue... But it only affects Vanilla WADs with a custom dehacked weapon in the chainsaw slot that uses ammo.

The issue is in regards to the weapon switch behaviour when the weapon in the chainsaw slot uses ammo, and all other ammo types have been used up.

Currently in DSDA-Doom, if you run out of ammo and use up the ammo in the chainsaw slot, you will switch to the fist after trying to fire... This is incorrect, as in Vanilla it should be impossible to access the fist if the player has the chainsaw (berserk allows access to the fist... however it will never auto-switch to the fist when running out of ammo).

Test the same behaviour in DOS or Chocolate Doom, and you will see that holding the fire button, it will constantly try and switch to the chainsaw weapon, and never the fist.

The example WAD that can best showcase this behaviour is [RUST](https://www.doomworld.com/forum/topic/144559). Just warp to the first map, type IDCHOPPERS, and see the behavour.

_Note: It's worth noting that the Boom weapon switch behaviour is most likely correct, as Boom rewrote the weapon switch code. This is just a fix for vanilla complevels._