### PR TITLE
Fix weapon being visible at the start of the level

### DIFF
--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1231,18 +1231,22 @@ static void R_DrawPSprite (pspdef_t *psp)
     psp_inter.x1_prev = vis->x1;
     psp_inter.texturemid_prev = vis->texturemid;
 
-    if (lump == psp_inter.lump)
+    // Do not interpolate on the first tic of the level
+    if (leveltime > 1)
     {
-      int deltax = vis->x2 - vis->x1;
-      vis->x1 = psp_inter.x1 + FixedMul (tic_vars.frac, (vis->x1 - psp_inter.x1));
-      vis->x2 = vis->x1 + deltax;
-      vis->texturemid = psp_inter.texturemid + FixedMul (tic_vars.frac, (vis->texturemid - psp_inter.texturemid));
-    }
-    else
-    {
-      psp_inter.x1 = vis->x1;
-      psp_inter.texturemid = vis->texturemid;
-      psp_inter.lump=lump;
+      if (lump == psp_inter.lump)
+      {
+        int deltax = vis->x2 - vis->x1;
+        vis->x1 = psp_inter.x1 + FixedMul (tic_vars.frac, (vis->x1 - psp_inter.x1));
+        vis->x2 = vis->x1 + deltax;
+        vis->texturemid = psp_inter.texturemid + FixedMul (tic_vars.frac, (vis->texturemid - psp_inter.texturemid));
+      }
+      else
+      {
+        psp_inter.x1 = vis->x1;
+        psp_inter.texturemid = vis->texturemid;
+        psp_inter.lump=lump;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/kraflab/dsda-doom/issues/559.

Fix taken from: https://github.com/fabiangreffrath/woof/commit/bf9a63b0900cb31d62c9188a5e952defdd6efa91