### PR TITLE
Statusbar Fixes

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2411,8 +2411,6 @@ void G_AfterLoad(void)
   if (setsizeneeded)
     R_ExecuteSetViewSize ();
 
-  R_FillBackScreen ();
-
   BorderNeedRefresh = true;
   ST_Start();
 }

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -500,11 +500,13 @@ static void R_InitLightTables (void)
 // The change will take effect next refresh.
 //
 
+extern dboolean BorderNeedRefresh;
 dboolean setsizeneeded;
 static int setblocks;
 
 void R_SetViewSize(void)
 {
+  BorderNeedRefresh = true;
   setsizeneeded = true;
   setblocks = dsda_IntConfig(dsda_config_screenblocks);
 }


### PR DESCRIPTION
This PR fixes two issues I found.

1) First commit "refresh stbar when changing view size" fixes a bug that was found in the DSDA-Doom discord, when running using `-noautoload` and resizing the screensize to remove the statusbar and bring it back. When brought back, grnrock would show on top of the status bar background.

I fixed this by calling for a statusbar refresh when changing the viewsize. This is only a software issue, as OpenGL always refreshes the statusbar background.

There may be a later discussion on this, as in Nyan Doom I've set software to always refresh the statusbar. The reasoning for this is that it fixes a couple bugs with a few wads and certain elements bleeding into the background (Pirate Doom II mugshot bleeding into the background), but also due to the animated statusbar functionality (or berserk/armour indicators) requiring a constant refresh. Currently OpenGL always refreshes the stbar, and I'm wondering if there's a reason we don't just do that in software as well. Funny enough, to get the dark overlay to work with the statusbar, we always have to refresh it anyway.

2) Second commit fixes a bug during the load of a map and the wipe screen. When reloading a map (and the status bar is filling the width of the screen), grnrock is drawn in the main screens[0]. I think this is a fix in case the stbar background ends up not being refreshed (see fix 1, with grnrock in place of stbar background), or perhaps a very weird stbar size? I'm not quite sure. What I do know is that when the screen is "taken", the grnrock shows on top of the statusbar.

Since the grnrock is drawn later anyway, I dropped drawing it during `G_AfterLoad`, and so the screen "taken" by the screenwipe shows the stbar as intended.

Note that this is a fix for both OpenGL and software.

Apparently I saw some code that mentions that grnrock can change per level? But I don't even know if DSDA-Doom currently has that functionality, and so I haven't tested that yet.