### PR TITLE
Weapon Alignment Fixes

### DIFF
--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1063,7 +1063,12 @@ static void R_DrawPSprite (pspdef_t *psp)
   {
     int weapon_attack_alignment = dsda_IntConfig(dsda_config_weapon_attack_alignment);
 
-    if (!dsda_WeaponBob())
+    // [crispy] don't align swiping weapons
+    const dboolean swiping_weapon = hexen && (viewplayer->pclass == PCLASS_FIGHTER ||
+                                             (viewplayer->pclass == PCLASS_CLERIC &&
+                                             viewplayer->readyweapon == wp_first));
+
+    if (!dsda_WeaponBob() && !(swiping_weapon && viewplayer->attackdown))
     {
       static fixed_t last_sy = 32 * FRACUNIT;
 
@@ -1086,7 +1091,7 @@ static void R_DrawPSprite (pspdef_t *psp)
 
       // [crispy] don't center vertically during lowering and raising states
       if (weapon_attack_alignment >= CENTERWEAPON_HORVER &&
-          psp->state->action != A_Lower && psp->state->action != A_Raise)
+          psp->state->action != A_Lower && psp->state->action != A_Raise && !swiping_weapon)
       {
           R_ApplyWeaponBob(NULL, false, &psp_sy, weapon_attack_alignment == CENTERWEAPON_BOB);
       }

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1061,21 +1061,7 @@ static void R_DrawPSprite (pspdef_t *psp)
   flip = (dboolean)(sprframe->flip & 1);
 
   {
-    weaponinfo_t *winfo;
-    int state;
-    int weapon_attack_alignment;
-
-    if (hexen)
-    {
-      winfo = &hexen_weaponinfo[viewplayer->readyweapon][viewplayer->pclass];
-    }
-    else
-    {
-      winfo = &weaponinfo[viewplayer->readyweapon];
-    }
-
-    state = viewplayer->psprites[ps_weapon].state - states;
-    weapon_attack_alignment = dsda_IntConfig(dsda_config_weapon_attack_alignment);
+    int weapon_attack_alignment = dsda_IntConfig(dsda_config_weapon_attack_alignment);
 
     if (!dsda_WeaponBob())
     {
@@ -1083,12 +1069,12 @@ static void R_DrawPSprite (pspdef_t *psp)
 
       psp_sx = FRACUNIT;
 
-      if (state != winfo->downstate && state != winfo->upstate)
+      if (psp->state->action != A_Lower && psp->state->action != A_Raise)
       {
         last_sy = psp->sy;
         psp_sy = 32 * FRACUNIT;
       }
-      else if (state == winfo->downstate)
+      else if (psp->state->action == A_Lower)
       {
         // We want to move smoothly from where we were
         psp_sy -= (last_sy - 32 * FRACUNIT);
@@ -1100,7 +1086,7 @@ static void R_DrawPSprite (pspdef_t *psp)
 
       // [crispy] don't center vertically during lowering and raising states
       if (weapon_attack_alignment >= CENTERWEAPON_HORVER &&
-          state != winfo->downstate && state != winfo->upstate)
+          psp->state->action != A_Lower && psp->state->action != A_Raise)
       {
           R_ApplyWeaponBob(NULL, false, &psp_sy, weapon_attack_alignment == CENTERWEAPON_BOB);
       }


### PR DESCRIPTION
So this took me a little while to figure out. Mostly because most of the original code here was taken from Crispy Doom, but obviously there was something wrong with some WADs when "centered" or "bobbing" was turned on for "Weapon Attack Alignment".

Essentially the issue was with the `A_Raise` and `A_Lower` state checking, in that it seemed that new custom weapons would seem to skip the `A_Raise` animation, or never play the `A_Lower` animation of death. (when the player is pressing down the fire button).

It seems the culprit was how the states were being checked (example: `state != winfo->downstate`). I think my best guess is that this works for vanilla weapons because it's checking the original states... but once custom dehacked is added in the mix, the states don't line up, and thus the code that allows `A_Raise` or `A_Lower` fails.

Examples you can check the behaviour in:
- [RUST](https://www.doomworld.com/forum/topic/144559) - the new chainsaw weapon will skip the `A_Raise` animation (before this fix)
- [200 Line Massacre](https://www.doomworld.com/idgames/levels/doom2/megawads/200lnm) - Upon death, the player weapon will stay on screen and never lower (before this fix)

I also added a fix for Hexen Melee Weapons from Crispy Hexen. This fixes melee weapons for both when weaponbob is disabled and when centered/bobbing alignment is turned on.

You can test the Hexen fix using the first weapon for the Fighter (see what happens after hitting an enemy 3 times)