### PR TITLE
Expand features bit array size to 128

### DIFF
--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -449,7 +449,7 @@ void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, byte* demo, size_
 
   MD5Update(&md5, demo, demo_size);
 
-  MD5Update(&md5, features, 8 * FEATURES_PARTS);
+  MD5Update(&md5, features, FEATURE_SLOTS);
 
   MD5Final(cksum->bytes, &md5);
 
@@ -457,7 +457,7 @@ void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, byte* demo, size_
 }
 
 void dsda_GetDemoRecordingCheckSum(dsda_cksum_t* cksum) {
-  byte features[8 * FEATURES_PARTS];
+  byte features[FEATURE_SLOTS];
 
   dsda_CopyFeatures(features);
 

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -449,7 +449,7 @@ void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, byte* demo, size_
 
   MD5Update(&md5, demo, demo_size);
 
-  MD5Update(&md5, features, FEATURE_SIZE);
+  MD5Update(&md5, features, 8 * FEATURES_PARTS);
 
   MD5Final(cksum->bytes, &md5);
 
@@ -457,7 +457,7 @@ void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, byte* demo, size_
 }
 
 void dsda_GetDemoRecordingCheckSum(dsda_cksum_t* cksum) {
-  byte features[FEATURE_SIZE];
+  byte features[8 * FEATURES_PARTS];
 
   dsda_CopyFeatures(features);
 

--- a/prboom2/src/dsda/exdemo.c
+++ b/prboom2/src/dsda/exdemo.c
@@ -406,9 +406,9 @@ static void DemoEx_GetFeatures(const wadinfo_t* header) {
   int ftext_end = 0;
 
   exdemo.is_signed = 0;
-  FOR_FEATURE_SLOT
+  for (int f = 0; f < FEATURE_SLOTS; f++) {
     exdemo.features[f] = 0;
-  END_FEATURE_SLOT
+  }
 
   str = DemoEx_LumpAsString(DEMOEX_FEATURE_LUMPNAME, header);
   if (!str)
@@ -423,12 +423,12 @@ static void DemoEx_GetFeatures(const wadinfo_t* header) {
       strcat(padded_ftext, "0");
     strcat(padded_ftext, ftext);
 
-    FOR_FEATURE_SLOT
+    for (int f = 0; f < FEATURE_SLOTS; f++) {
       char current_text[3];
       strncpy(current_text, padded_ftext + f * 2, 2);
       current_text[2] = '\0';
       exdemo.features[FEATURE_SLOTS - f - 1] = strtol(current_text, NULL, 16);
-    END_FEATURE_SLOT
+    }
 
     dsda_GetDemoCheckSum(&cksum, exdemo.features, exdemo.demo, exdemo.demo_size);
 
@@ -462,10 +462,10 @@ static void DemoEx_AddFeatures(wadtbl_t* wadtbl) {
   strcpy(buffer, description);
   strcat(buffer, "\n0x");
 
-  FOR_FEATURE_SLOT
+  for (int f = 0; f < FEATURE_SLOTS; f++) {
     snprintf(current_feature, 3, "%02" PRIx8, features[FEATURE_SLOTS - f - 1]);
     strncat(buffer, current_feature, 2);
-  END_FEATURE_SLOT
+  }
 
   strcat(buffer, "-");
   strcat(buffer, cksum.string);

--- a/prboom2/src/dsda/features.c
+++ b/prboom2/src/dsda/features.c
@@ -80,15 +80,15 @@ byte *dsda_UsedFeatures(void) {
 }
 
 void dsda_MergeFeatures(byte *source) {
-  FOR_FEATURE_SLOT
+  for (int f = 0; f < FEATURE_SLOTS; f++) {
     used_features[f] |= source[f];
-  END_FEATURE_SLOT
+  }
 }
 
 void dsda_CopyFeatures(byte* result) {
-  FOR_FEATURE_SLOT
+  for (int f = 0; f < FEATURE_SLOTS; f++) {
     result[f] = used_features[f];
-  END_FEATURE_SLOT
+  }
 }
 
 char* dsda_DescribeFeatures(void) {
@@ -98,18 +98,16 @@ char* dsda_DescribeFeatures(void) {
 
   dsda_InitString(&description, NULL);
 
-  FOR_FEATURE_SLOT
-    for (i = 0; i < 8; i++) {
-      if (BITTEST(used_features, i + f * 8) && feature_names[i + f * 8]) {
-        if (first)
-          first = false;
-        else
-          dsda_StringCat(&description, ", ");
+  for (int i = 0; i < FEATURE_SIZE; i++) {
+    if (BITTEST(used_features, i) && feature_names[i]) {
+      if (first)
+        first = false;
+      else
+        dsda_StringCat(&description, ", ");
 
-        dsda_StringCat(&description, feature_names[i + f * 8]);
-      }
+      dsda_StringCat(&description, feature_names[i]);
     }
-  END_FEATURE_SLOT
+  }
 
   if (!description.string)
     dsda_StringCat(&description, "Tachyeres pteneres");

--- a/prboom2/src/dsda/features.h
+++ b/prboom2/src/dsda/features.h
@@ -86,12 +86,16 @@ typedef enum {
   // 63
 } dsda_feature_flag_t;
 
-#define FEATURE_SIZE 8
+// Size of the uint64 array of features
+#define FEATURES_PARTS 2
+
+#define FOR_FEATURES_PART for (int f = 0; f < FEATURES_PARTS; f++) {
+#define END_FEATURES_PART }
 
 void dsda_TrackFeature(int feature);
 void dsda_ResetFeatures(void);
-uint64_t dsda_UsedFeatures(void);
-void dsda_MergeFeatures(uint64_t source);
+uint64_t *dsda_UsedFeatures(void);
+void dsda_MergeFeatures(uint64_t *source);
 void dsda_CopyFeatures(byte* result);
-void dsda_CopyFeatures2(byte* result, uint64_t source);
+void dsda_CopyFeatures2(byte* result, uint64_t *source);
 char* dsda_DescribeFeatures(void);

--- a/prboom2/src/dsda/features.h
+++ b/prboom2/src/dsda/features.h
@@ -96,8 +96,6 @@ typedef enum {
 #define FEATURE_SIZE 128
 #define FEATURE_SLOTS BITNSLOTS(FEATURE_SIZE)
 
-#define FOR_FEATURE_SLOT for (int f = 0; f < FEATURE_SLOTS; f++) {
-#define END_FEATURE_SLOT }
 
 void dsda_TrackFeature(int feature);
 void dsda_ResetFeatures(void);

--- a/prboom2/src/dsda/features.h
+++ b/prboom2/src/dsda/features.h
@@ -86,16 +86,22 @@ typedef enum {
   // 63
 } dsda_feature_flag_t;
 
-// Size of the uint64 array of features
-#define FEATURES_PARTS 2
+#define BITMASK(b) (1 << ((b) % 8))
+#define BITSLOT(b) ((b) / 8)
+#define BITSET(a, b) ((a)[BITSLOT(b)] |= BITMASK(b))
+#define BITCLEAR(a, b) ((a)[BITSLOT(b)] &= ~BITMASK(b))
+#define BITTEST(a, b) ((a)[BITSLOT(b)] & BITMASK(b))
+#define BITNSLOTS(nb) ((nb + 8 - 1) / 8)
 
-#define FOR_FEATURES_PART for (int f = 0; f < FEATURES_PARTS; f++) {
-#define END_FEATURES_PART }
+#define FEATURE_SIZE 128
+#define FEATURE_SLOTS BITNSLOTS(FEATURE_SIZE)
+
+#define FOR_FEATURE_SLOT for (int f = 0; f < FEATURE_SLOTS; f++) {
+#define END_FEATURE_SLOT }
 
 void dsda_TrackFeature(int feature);
 void dsda_ResetFeatures(void);
-uint64_t *dsda_UsedFeatures(void);
-void dsda_MergeFeatures(uint64_t *source);
+byte *dsda_UsedFeatures(void);
+void dsda_MergeFeatures(byte *source);
 void dsda_CopyFeatures(byte* result);
-void dsda_CopyFeatures2(byte* result, uint64_t *source);
 char* dsda_DescribeFeatures(void);

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -46,13 +46,13 @@ static void dsda_ArchiveInternal(void) {
   P_SAVE_X(dsda_max_kill_requirement);
   P_SAVE_X(player_damage_last_tic);
 
-  FOR_FEATURES_PART
+  FOR_FEATURE_SLOT
     P_SAVE_X(dsda_UsedFeatures()[f]);
-  END_FEATURES_PART
+  END_FEATURE_SLOT
 }
 
 static void dsda_UnArchiveInternal(void) {
-  uint64_t features[FEATURES_PARTS];
+  byte features[FEATURE_SLOTS];
 
   P_LOAD_X(dsda_max_kill_requirement);
   P_LOAD_X(player_damage_last_tic);

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -43,17 +43,16 @@ extern int dsda_max_kill_requirement;
 extern int player_damage_last_tic;
 
 static void dsda_ArchiveInternal(void) {
-  uint64_t features;
-
   P_SAVE_X(dsda_max_kill_requirement);
   P_SAVE_X(player_damage_last_tic);
 
-  features = dsda_UsedFeatures();
-  P_SAVE_X(features);
+  FOR_FEATURES_PART
+    P_SAVE_X(dsda_UsedFeatures()[f]);
+  END_FEATURES_PART
 }
 
 static void dsda_UnArchiveInternal(void) {
-  uint64_t features;
+  uint64_t features[FEATURES_PARTS];
 
   P_LOAD_X(dsda_max_kill_requirement);
   P_LOAD_X(player_damage_last_tic);

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -46,9 +46,9 @@ static void dsda_ArchiveInternal(void) {
   P_SAVE_X(dsda_max_kill_requirement);
   P_SAVE_X(player_damage_last_tic);
 
-  FOR_FEATURE_SLOT
+  for (int f = 0; f < FEATURE_SLOTS; f++) {
     P_SAVE_X(dsda_UsedFeatures()[f]);
-  END_FEATURE_SLOT
+  }
 }
 
 static void dsda_UnArchiveInternal(void) {

--- a/prboom2/src/p_saveg.h
+++ b/prboom2/src/p_saveg.h
@@ -36,7 +36,7 @@
 
 #include "doomtype.h"
 
-#define SAVEVERSION 5
+#define SAVEVERSION 6
 
 /* Persistent storage/archiving.
  * These are the load / save game routines. */


### PR DESCRIPTION
With https://github.com/kraflab/dsda-doom/pull/586, we are introducing 2 new features that need to be tracked. This will exceed the array size of 64, so we need to increase it to 128.

There is no unit128 in 32-bit targets, so this PR uses an array of uint64. It can easily be increased in the future as well.