### PR TITLE
Add Back "Classic Zoom Levels"

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -617,15 +617,22 @@ void AM_SetPosition(void)
 {
   if (automap_active)
   {
-    f_x = f_y = 0;
-    f_w = SCREENWIDTH;
-
     if (automap_overlay > 0)
     {
-      f_h = viewheight;
+      f_x = 0;
+      f_y = 0;
+      f_w = SCREENWIDTH;
+      f_h = SCREENHEIGHT;
+
+      f_x = viewwindowx + f_x * viewwidth / SCREENWIDTH;
+      f_y = viewwindowy + f_y * viewheight / SCREENHEIGHT;
+      f_w = f_w * viewwidth / SCREENWIDTH;
+      f_h = f_h * viewheight / SCREENHEIGHT;
     }
     else
     {
+      f_x = f_y = 0;
+      f_w = SCREENWIDTH;
       f_h = SCREENHEIGHT - ST_SCALED_HEIGHT;
     }
   }

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -340,6 +340,7 @@ static void D_DrawPause(void)
 }
 
 static dboolean must_fill_back_screen;
+extern dboolean ScreenSize_Interpolate;
 
 void D_MustFillBackScreen(void)
 {
@@ -486,6 +487,10 @@ void D_Display (fixed_t frac)
     DSDA_REMOVE_CONTEXT(sf_status_bar);
 
     BorderNeedRefresh = false;
+
+    // Interpolate weapon only when not changing screensize
+    ScreenSize_Interpolate = true;
+
     if (V_IsSoftwareMode())
       R_DrawViewBorder();
 

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1144,7 +1144,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_screenblocks] = {
     "screenblocks", dsda_config_screenblocks,
-    dsda_config_int, 10, 11, { 10 }, NULL, CONF_FEATURE | NOT_STRICT, R_SetViewSize
+    dsda_config_int, 3, 11, { 10 }, NULL, CONF_FEATURE | NOT_STRICT, R_SetViewSize
   },
   [dsda_config_sdl_video_window_pos] = {
     "sdl_video_window_pos", dsda_config_sdl_video_window_pos,

--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -36,6 +36,8 @@ int gl_viewport_y;
 int gl_statusbar_height;
 int gl_scene_width;
 int gl_scene_height;
+int gl_scene_offset_x;
+int gl_scene_offset_y;
 float gl_scale_x;
 float gl_scale_y;
 int gl_letterbox_clear_required = 0;
@@ -73,8 +75,11 @@ void dsda_GLSetRenderViewportParams() {
   // elim - This will be zero if no statusbar is being drawn
   gl_statusbar_height = (int)ceilf(gl_scale_y * (float)ST_SCALED_HEIGHT) * R_PartialView();
 
-  gl_scene_width = gl_viewport_width;
-  gl_scene_height = gl_viewport_height - gl_statusbar_height;
+  gl_scene_offset_x = (int)(viewwindowx * gl_scale_x);
+  gl_scene_offset_y = (int)(viewwindowy * gl_scale_y);
+
+  gl_scene_width = gl_viewport_width - (gl_scene_offset_x * 2);
+  gl_scene_height = gl_viewport_height - gl_statusbar_height - (gl_scene_offset_y * 2);
 
   // elim - If the viewport's x or y coordinate is indented from the window, we need to call glClear
   //        each frame to prevent artifacts smearing on undrawn framebuffer area
@@ -94,8 +99,8 @@ void dsda_GLSetRenderViewportScissor() {
 }
 
 void dsda_GLSetRenderSceneScissor() {
-  glScissor(gl_viewport_x,
-            gl_viewport_y + gl_statusbar_height,
+  glScissor(gl_viewport_x + gl_scene_offset_x,
+            gl_viewport_y + gl_statusbar_height + gl_scene_offset_y,
             gl_scene_width, gl_scene_height);
 }
 
@@ -115,7 +120,7 @@ void dsda_GLUpdateStatusBarVisible() {
   current_visible = R_PartialView();
 
   if (saved_visible != current_visible) {
-    gl_statusbar_height = (int)(gl_scale_y * (float)ST_SCALED_HEIGHT) * R_PartialView();
+    gl_scene_height = gl_viewport_height - gl_statusbar_height - (gl_scene_offset_y * 2);
     gl_scene_height = gl_viewport_height - gl_statusbar_height;
   }
 }

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -784,9 +784,9 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // More precise weapon drawing:
   // Shotgun from DSV3_War looks correctly now. Especially during movement.
   // There is no more line of graphics under certain weapons.
-  x1 = vis->x1;
+  x1 = viewwindowx + vis->x1;
   x2 = roundf(x1 + gltexture->realtexwidth * pspritexscale_f);
-  y1 = roundf(viewheight / 2.0 - vis->texturemid * pspriteyscale_f / FRACUNIT);
+  y1 = roundf(viewwindowy + centery - (int)(((float)vis->texturemid / (float)FRACUNIT) * pspriteyscale_f));
   y2 = roundf(y1 + gltexture->realtexheight * pspriteyscale_f);
   // e6y: don't do the gamma table correction on the lighting
   light = (float)lightlevel / 255.0f;
@@ -1008,7 +1008,7 @@ void gld_StartDrawScene(void)
   gld_SetPalette(-1);
 
   glViewport(viewport[0], viewport[1], viewport[2], viewport[3]);
-  glScissor(0, SCREENHEIGHT - viewheight, viewwidth, viewheight);
+  glScissor(viewwindowx, SCREENHEIGHT - (viewheight + viewwindowy), viewwidth, viewheight);
   glEnable(GL_SCISSOR_TEST);
   // Player coordinates
   xCamera=-(float)viewx/MAP_SCALE;

--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -206,7 +206,8 @@ void SB_Start(void)
 //---------------------------------------------------------------------------
 
 extern patchnum_t stbarbg;
-extern patchnum_t brdr_b;
+extern patchnum_t brdr_t, brdr_b, brdr_l, brdr_r;
+extern patchnum_t brdr_tl, brdr_tr, brdr_bl, brdr_br;
 
 void SB_Init(void)
 {
@@ -238,7 +239,14 @@ void SB_Init(void)
     sb_full_inv_gem_xr = 269;
 
     // magic globals that ends up in the background
+    R_SetPatchNum(&brdr_t, "bordt");
     R_SetPatchNum(&brdr_b, "bordb");
+    R_SetPatchNum(&brdr_l, "bordl");
+    R_SetPatchNum(&brdr_r, "bordr");
+    R_SetPatchNum(&brdr_tl, "bordtl");
+    R_SetPatchNum(&brdr_tr, "bordtr");
+    R_SetPatchNum(&brdr_bl, "bordbl");
+    R_SetPatchNum(&brdr_br, "bordbr");
     R_SetPatchNum(&stbarbg, "BARBACK");
 
     for (i = 0; i < 11; ++i)
@@ -943,7 +951,14 @@ static void Hexen_SB_Init(void)
     sb_full_inv_gem_xr = 268;
 
     // magic globals that ends up in the background
+    R_SetPatchNum(&brdr_t, "bordt");
     R_SetPatchNum(&brdr_b, "bordb");
+    R_SetPatchNum(&brdr_l, "bordl");
+    R_SetPatchNum(&brdr_r, "bordr");
+    R_SetPatchNum(&brdr_tl, "bordtl");
+    R_SetPatchNum(&brdr_tr, "bordtr");
+    R_SetPatchNum(&brdr_bl, "bordbl");
+    R_SetPatchNum(&brdr_br, "bordbr");
     R_SetPatchNum(&stbarbg, "H2BAR");
 
     for (i = 0; i < 33; ++i)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1504,19 +1504,23 @@ void M_ChangeMessages(void)
 
 static void M_SizeDisplay(int choice)
 {
+  int screenblocks;
+
+  screenblocks = R_ViewSize();
+
   switch(choice) {
     case 0:
-      if (R_FullView())
+      if (screenblocks > 3)
         dsda_DecrementIntConfig(dsda_config_screenblocks, true);
       break;
     case 1:
-      if (R_PartialView())
+      if (screenblocks < 11)
         dsda_IncrementIntConfig(dsda_config_screenblocks, true);
       else
         dsda_ToggleConfig(dsda_config_hud_displayed, true);
       break;
     case 2:
-      if (R_PartialView()) {
+      if (screenblocks < 11) {
         dsda_UpdateIntConfig(dsda_config_screenblocks, 11, true);
         dsda_UpdateIntConfig(dsda_config_hud_displayed, true, true);
       }

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -539,19 +539,7 @@ void R_FillBackScreen (void)
     {
       int stbar_top = SCREENHEIGHT - ST_SCALED_HEIGHT;
 
-      if (V_IsOpenGLMode())
-        V_FillFlat(grnrock.lumpnum, 1, 0, stbar_top, SCREENWIDTH, ST_SCALED_HEIGHT, VPT_STRETCH);
-      else
-      {
-        V_FillFlat(grnrock.lumpnum, 1,
-          0, stbar_top, ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_STRETCH);
-        V_FillFlat(grnrock.lumpnum, 1,
-          SCREENWIDTH - ST_SCALED_OFFSETX, stbar_top, ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_STRETCH);
-
-        // For custom huds, need to put the backfill inside the bar area (in the copy buffer)
-        V_FillFlat(grnrock.lumpnum, 0,
-          ST_SCALED_OFFSETX, stbar_top, SCREENWIDTH - 2 * ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_STRETCH);
-      }
+      V_FillFlat(grnrock.lumpnum, 1, 0, 0, SCREENWIDTH, SCREENHEIGHT, VPT_STRETCH);
 
       // heretic_note: I think this looks bad, so I'm skipping it...
       if (!heretic)

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -502,6 +502,7 @@ static void R_InitLightTables (void)
 // The change will take effect next refresh.
 //
 
+dboolean ScreenSize_Interpolate;
 dboolean setsizeneeded;
 static int setblocks;
 
@@ -512,6 +513,9 @@ int R_ViewSize(void)
 
 void R_SetViewSize(void)
 {
+  // Do not interpolate weapon when changing screensize
+  ScreenSize_Interpolate = false;
+
   setsizeneeded = true;
   setblocks = dsda_IntConfig(dsda_config_screenblocks);
 }

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -505,6 +505,11 @@ static void R_InitLightTables (void)
 dboolean setsizeneeded;
 static int setblocks;
 
+int R_ViewSize(void)
+{
+  return setblocks;
+}
+
 void R_SetViewSize(void)
 {
   setsizeneeded = true;
@@ -563,10 +568,22 @@ int R_Project(float objx, float objy, float objz, float *winx, float *winy, floa
 
 void R_SetupViewport(void)
 {
-  viewport[0] = 0;
-  viewport[1] = (SCREENHEIGHT - viewheight) / 2;
+  int screenblocks;
+  int height;
+
+  screenblocks = R_ViewSize();
+
+  if (screenblocks == 11)
+    height = SCREENHEIGHT;
+  else if (screenblocks == 10)
+    height = SCREENHEIGHT;
+  else
+    height = (screenblocks * SCREENHEIGHT / 10) & ~7;
+
+  viewport[0] = viewwindowx;
+  viewport[1] = SCREENHEIGHT - (height + viewwindowy - ((height - viewheight) / 2));
   viewport[2] = viewwidth;
-  viewport[3] = SCREENHEIGHT;
+  viewport[3] = height;
 }
 
 void R_SetupPerspective(float fovy, float aspect, float znear)
@@ -658,17 +675,27 @@ void R_ExecuteSetViewSize (void)
 
   if (setblocks == 11)
   {
+    scaledviewwidth = SCREENWIDTH;
     viewheight = SCREENHEIGHT;
     freelookviewheight = viewheight;
   }
   // proff 09/24/98: Added for high-res
-  else
+  else if (setblocks == 10)
   {
+    scaledviewwidth = SCREENWIDTH;
     viewheight = SCREENHEIGHT - ST_SCALED_HEIGHT;
     freelookviewheight = SCREENHEIGHT;
   }
+  // proff 09/24/98: Added for high-res
+  else
+  {
+  // proff 08/17/98: Changed for high-res
+    scaledviewwidth = setblocks * SCREENWIDTH / 10;
+    viewheight = (setblocks * (SCREENHEIGHT - ST_SCALED_HEIGHT) / 10) & ~7;
+    freelookviewheight = setblocks * SCREENHEIGHT / 10;
+  }
 
-  viewwidth = SCREENWIDTH;
+  viewwidth = scaledviewwidth;
 
   viewheightfrac = viewheight<<FRACBITS;//e6y
 
@@ -699,7 +726,7 @@ void R_ExecuteSetViewSize (void)
 
   dsda_SetupStretchParams();
 
-  R_InitBuffer (SCREENWIDTH, viewheight);
+  R_InitBuffer (scaledviewwidth, viewheight);
 
   R_InitTextureMapping();
 
@@ -708,7 +735,7 @@ void R_ExecuteSetViewSize (void)
   // proff 11/06/98: Added for high-res
   // e6y: wide-res
   pspritexscale = (wide_centerx << FRACBITS) / 160;
-  pspriteyscale = (cheight << FRACBITS) / 200;
+  pspriteyscale = (((cheight * viewwidth) / SCREENWIDTH) << FRACBITS) / 200;
   pspriteiscale = FixedDiv (FRACUNIT, pspritexscale);
   // [FG] make sure that the product of the weapon sprite scale factor
   //      and its reciprocal is always at least FRACUNIT to
@@ -719,9 +746,9 @@ void R_ExecuteSetViewSize (void)
 
   //e6y: added for GL
   pspritexscale_f = (float)wide_centerx/160.0f;
-  pspriteyscale_f = (float)cheight / 200.0f;
+  pspriteyscale_f = (((float)cheight * viewwidth) / (float)SCREENWIDTH) / 200.0f;
 
-  skyiscale = (200 << FRACBITS) / SCREENHEIGHT;
+  skyiscale = (fixed_t)(((uint64_t)FRACUNIT * SCREENWIDTH * 200) / (viewwidth * SCREENHEIGHT));
 
 	// [RH] Sky height fix for screens not 200 (or 240) pixels tall
 	R_InitSkyMap();
@@ -1012,7 +1039,7 @@ static void R_InitDrawScene(void)
     if (dsda_IntConfig(dsda_config_flashing_hom))
     { // killough 2/10/98: add flashing red HOM indicators
       unsigned char color=(gametic % 20) < 9 ? 0xb0 : 0;
-      V_FillRect(0, 0, 0, viewwidth, viewheight, color);
+      V_FillRect(0, viewwindowx, viewwindowy, viewwidth, viewheight, color);
       R_DrawViewBorder();
     }
 

--- a/prboom2/src/r_main.h
+++ b/prboom2/src/r_main.h
@@ -49,6 +49,8 @@ extern fixed_t  viewtancos;
 extern fixed_t  viewtansin;
 extern int      viewwidth;
 extern int      viewheight;
+extern int      viewwindowx;
+extern int      viewwindowy;
 extern int      centerx;
 extern int      centery;
 extern fixed_t  globaluclip;
@@ -150,6 +152,7 @@ angle_t R_PointToPseudoAngle(fixed_t x, fixed_t y);
 void R_ResetColorMap(void);
 void R_RenderPlayerView(player_t *player);   // Called by G_Drawer.
 void R_Init(void);                           // Called by startup code.
+int R_ViewSize(void);
 void R_SetViewSize(void);              // Called by M_Responder.
 void R_ExecuteSetViewSize(void);             // cph - called by D_Display to complete a view resize
 dboolean R_FullView(void);

--- a/prboom2/src/r_sky.c
+++ b/prboom2/src/r_sky.c
@@ -66,7 +66,10 @@ void R_InitSkyMap(void)
   {
     skystretch = false;
     skytexturemid = (raven ? 200 : 100) * FRACUNIT;
-    skyiscale = (200 << FRACBITS) / SCREENHEIGHT;
+    if (viewwidth != 0)
+    {
+      skyiscale = (fixed_t)(((uint64_t)FRACUNIT * SCREENWIDTH * 200) / (viewwidth * SCREENHEIGHT));
+    }
   }
   else
   {
@@ -102,7 +105,14 @@ void R_InitSkyMap(void)
       skytexturemid = (200 - skyheight) << FRACBITS;
     }
 
-    skyiscale = (200 << FRACBITS) / SCREENHEIGHT;
+    if (viewwidth != 0 && viewheight != 0)
+    {
+      //skyiscale = 200 * FRACUNIT / freelookviewheight;
+      skyiscale = (fixed_t)(((uint64_t)FRACUNIT * SCREENWIDTH * 200) / (viewwidth * SCREENHEIGHT));
+      // line below is from zdoom, but it works incorrectly with prboom
+      // with widescreen resolutions (eg 1280x720) by some reasons
+      //skyiscale = (fixed_t)((int64_t)skyiscale * FieldOfView / 2048);
+    }
 
     if (skystretch)
     {

--- a/prboom2/src/r_state.h
+++ b/prboom2/src/r_state.h
@@ -47,6 +47,8 @@
 // needed for texture pegging
 extern fixed_t *textureheight;
 
+extern int scaledviewwidth;
+
 extern int firstflat, numflats;
 
 // for global animation

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1234,7 +1234,10 @@ static void R_DrawPSprite (pspdef_t *psp)
     // Do not interpolate on the first tic of the level
     if (leveltime > 1)
     {
-      if (lump == psp_inter.lump)
+      // Interpolate weapon only when not changing screensize
+      extern dboolean ScreenSize_Interpolate;
+
+      if (lump == psp_inter.lump && ScreenSize_Interpolate)
       {
         int deltax = vis->x2 - vis->x1;
         vis->x1 = psp_inter.x1 + FixedMul (tic_vars.frac, (vis->x1 - psp_inter.x1));

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -304,7 +304,8 @@ static patchnum_t faceback; // CPhipps - single background, translated for diffe
 //e6y: status bar background
 patchnum_t stbarbg;
 patchnum_t grnrock;
-patchnum_t brdr_b;
+patchnum_t brdr_t, brdr_b, brdr_l, brdr_r;
+patchnum_t brdr_tl, brdr_tr, brdr_bl, brdr_br;
 
 // main bar right
 static patchnum_t armsbg;
@@ -968,7 +969,14 @@ static void ST_loadGraphics(void)
 
   //e6y: status bar background
   R_SetPatchNum(&stbarbg, "STBAR");
+  R_SetPatchNum(&brdr_t, "brdr_t");
   R_SetPatchNum(&brdr_b, "brdr_b");
+  R_SetPatchNum(&brdr_l, "brdr_l");
+  R_SetPatchNum(&brdr_r, "brdr_r");
+  R_SetPatchNum(&brdr_tl, "brdr_tl");
+  R_SetPatchNum(&brdr_tr, "brdr_tr");
+  R_SetPatchNum(&brdr_bl, "brdr_bl");
+  R_SetPatchNum(&brdr_br, "brdr_br");
 
   // arms background
   R_SetPatchNum(&armsbg, "STARMS");

--- a/prboom2/src/st_stuff.h
+++ b/prboom2/src/st_stuff.h
@@ -94,6 +94,7 @@ extern int st_palette;    // cph 2006/04/06 - make palette visible
 
 // e6y: makes sense for wide resolutions
 extern patchnum_t grnrock;
-extern patchnum_t brdr_b;
+extern patchnum_t brdr_t, brdr_b, brdr_l, brdr_r;
+extern patchnum_t brdr_tl, brdr_tr, brdr_bl, brdr_br;
 
 #endif


### PR DESCRIPTION
This adds back the functionality of being able to shrink/grow the screensize via "-"/"+".

I've also added a few improvements:
- fixed weapon interpolation causing the weapon to "wiggle" during screensize changes
- Added a menu option to enable or disable the feature. This means that players who don't like the classic zooms and prefer how dsda-doom is currently set up can continue to use dsda-doom without this feature (I've set the option to "no" by default)

There are two things I'd like to mention that I haven't been able to solve / figure out.
1. I'd like to scale the screensize border graphics similar to the grnrock flat
2. This is a carryover from PrBoom, but it's weird that the automap is forced in the screensize, instead of Vanilla where the automap is the same fullscreen size regardless of screen zoom size. I think it makes more sense to have the automap fullscreen at all times, as it's useless to use under smaller screen sizes.