### PR TITLE
Automap - "Clear Last Mark" instead of "Clear Marks"

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -732,6 +732,16 @@ void AM_clearMarks(void)
   markpointnum = 0;
 }
 
+// [Alaux] Clear just the last mark
+static void AM_clearLastMark(void)
+{
+  AM_initPlayerTrail();
+  AM_ResetTagHighlight();
+
+  if (markpointnum)
+    markpointnum--;
+}
+
 void AM_InitParams(void)
 {
   map_blinking_locks = dsda_IntConfig(dsda_config_map_blinking_locks);
@@ -1150,8 +1160,13 @@ dboolean AM_Responder
   }
   else if (dsda_InputActivated(dsda_input_map_clear))
   {
-    AM_clearMarks();  // Ty 03/27/98 - *not* externalized
-    dsda_AddMessage(s_AMSTR_MARKSCLEARED);
+    // [Alaux] Clear just the last mark
+    if (!markpointnum)
+      dsda_AddMessage(s_AMSTR_MARKSCLEARED);
+    else {
+      AM_clearLastMark();
+      doom_printf("Cleared spot %d", markpointnum);
+    }
 
     return true;
   }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4281,7 +4281,7 @@ setup_menu_t helpstrings[] =  // HELP screen strings
   {"ZOOM IN"     ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_zoomin},
   {"ZOOM OUT"    ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_zoomout},
   {"MARK PLACE"  ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_mark},
-  {"CLEAR MARKS" ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_clear},
+  {"CLEAR LAST MARK",S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_clear},
   {"FULL/ZOOM"   ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_gobig},
   {"GRID"        ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_grid},
   {"ROTATE"      ,S_SKIP|S_INPUT,m_null,KT_X1,0,dsda_input_map_rotate},


### PR DESCRIPTION
Very simple PR that changes the automap "Clear Marks" option to only clear the last mark placed, instead of clearing all marks.
Code adapted from Woof.

This is sort of unrelated to this exact PR, but I'd like to interpolate the automap marks, as they are currently jittery on the automap (I've took a couple stabs at this, but have been unsuccessful)