### PR TITLE
Automap - "Secret Exit" and "Tag Finder" Line Colours

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -1883,7 +1883,7 @@ static void AM_DrawConnections(void)
       AM_SetMPointFloatValue(&l.b);
     }
 
-    AM_drawMline(&l, mapcolor_p->exit);
+    AM_drawMline(&l, mapcolor_p->tagfinder);
   }
 }
 

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -1664,7 +1664,10 @@ static automap_style_t AM_wallStyle(int i)
     )
       return ams_locked;
 
-    if (mapcolor_p->exit && dsda_IsExitLine(i))
+    if (mapcolor_p->exitsecr && (dsda_IsSecretExitLine(i) && !dsda_IsExitLine(i)))
+      return ams_exit_secret;
+
+    if (mapcolor_p->exit && (dsda_IsExitLine(i) || dsda_IsSecretExitLine(i)))
       return ams_exit;
 
     if (!lines[i].backsector) // 1-sided
@@ -1811,6 +1814,10 @@ static void AM_drawWalls(void)
 
       case ams_exit:
         AM_drawMline(&l, mapcolor_p->exit);
+        continue;
+
+      case ams_exit_secret:
+        AM_drawMline(&l, mapcolor_p->exitsecr);
         continue;
 
       case ams_one_sided:

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -59,6 +59,7 @@ typedef struct
   int tele;
   int secr;
   int revsecr;
+  int tagfinder;
   int exit;
   int exitsecr;
   int unsn;

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -60,6 +60,7 @@ typedef struct
   int secr;
   int revsecr;
   int exit;
+  int exitsecr;
   int unsn;
   int flat;
   int sprt;

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -544,6 +544,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "mapcolor_exit", dsda_config_mapcolor_exit,
     CONF_COLOR(0), &mapcolor.exit
   },
+  [dsda_config_mapcolor_exitsecr] = {
+    "mapcolor_exitsecr", dsda_config_mapcolor_exitsecr,
+    CONF_COLOR(0), &mapcolor.exitsecr
+  },
   [dsda_config_mapcolor_unsn] = {
     "mapcolor_unsn", dsda_config_mapcolor_unsn,
     CONF_COLOR(104), &mapcolor.unsn

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -540,6 +540,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "mapcolor_revsecr", dsda_config_mapcolor_revsecr,
     CONF_COLOR(112), &mapcolor.revsecr
   },
+  [dsda_config_mapcolor_tagfinder] = {
+    "mapcolor_tagfinder", dsda_config_mapcolor_tagfinder,
+    CONF_COLOR(252), &mapcolor.tagfinder
+  },
   [dsda_config_mapcolor_exit] = {
     "mapcolor_exit", dsda_config_mapcolor_exit,
     CONF_COLOR(0), &mapcolor.exit

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -105,6 +105,7 @@ typedef enum {
   dsda_config_mapcolor_tele,
   dsda_config_mapcolor_secr,
   dsda_config_mapcolor_revsecr,
+  dsda_config_mapcolor_tagfinder,
   dsda_config_mapcolor_exit,
   dsda_config_mapcolor_exitsecr,
   dsda_config_mapcolor_unsn,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -106,6 +106,7 @@ typedef enum {
   dsda_config_mapcolor_secr,
   dsda_config_mapcolor_revsecr,
   dsda_config_mapcolor_exit,
+  dsda_config_mapcolor_exitsecr,
   dsda_config_mapcolor_unsn,
   dsda_config_mapcolor_flat,
   dsda_config_mapcolor_sprt,

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -120,10 +120,16 @@ dboolean dsda_IsExitLine(int index) {
 
   return special == 11  ||
          special == 52  ||
-         special == 197 ||
-         special == 51  ||
-         special == 124 ||
-         special == 198;
+         special == 197;
+}
+
+dboolean dsda_IsSecretExitLine(int index) {
+  int special = lines[index].special;
+
+  if (!map_format.hexen)
+    return special == 51  ||
+           special == 124 ||
+           special == 198;
 }
 
 dboolean dsda_IsTeleportLine(int index) {

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -88,6 +88,7 @@ extern map_format_t map_format;
 
 int dsda_DoorType(int index);
 dboolean dsda_IsExitLine(int index);
+dboolean dsda_IsSecretExitLine(int index);
 dboolean dsda_IsTeleportLine(int index);
 void dsda_ApplyZDoomMapFormat(void);
 void dsda_ApplyDefaultMapFormat(void);

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -214,6 +214,7 @@ static dsda_option_t option_list[] = {
   { "mapcolor_tele", NULL, 0, 255, dsda_config_mapcolor_tele },
   { "mapcolor_secr", NULL, 0, 255, dsda_config_mapcolor_secr },
   { "mapcolor_revsecr", NULL, 0, 255, dsda_config_mapcolor_revsecr },
+  { "mapcolor_tagfinder", NULL, 0, 255, dsda_config_mapcolor_tagfinder },
   { "mapcolor_exit", NULL, 0, 255, dsda_config_mapcolor_exit },
   { "mapcolor_exitsecr", NULL, 0, 255, dsda_config_mapcolor_exitsecr },
   { "mapcolor_unsn", NULL, 0, 255, dsda_config_mapcolor_unsn },

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -215,6 +215,7 @@ static dsda_option_t option_list[] = {
   { "mapcolor_secr", NULL, 0, 255, dsda_config_mapcolor_secr },
   { "mapcolor_revsecr", NULL, 0, 255, dsda_config_mapcolor_revsecr },
   { "mapcolor_exit", NULL, 0, 255, dsda_config_mapcolor_exit },
+  { "mapcolor_exitsecr", NULL, 0, 255, dsda_config_mapcolor_exitsecr },
   { "mapcolor_unsn", NULL, 0, 255, dsda_config_mapcolor_unsn },
   { "mapcolor_flat", NULL, 0, 255, dsda_config_mapcolor_flat },
   { "mapcolor_sprt", NULL, 0, 255, dsda_config_mapcolor_sprt },

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2963,6 +2963,7 @@ setup_menu_t auto_colors_settings[] =  // 2st AutoMap Settings screen
   {"teleporter line"                ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_tele},
   {"secret sector boundary"         ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_secr},
   {"revealed secret sector boundary",S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_revsecr},
+  {"tag finder line"                ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_tagfinder},
   //jff 4/23/98 add exit line to automap
   {"exit line"                      ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_exit},
   {"alt secret exit line"           ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_exitsecr},

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2965,6 +2965,7 @@ setup_menu_t auto_colors_settings[] =  // 2st AutoMap Settings screen
   {"revealed secret sector boundary",S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_revsecr},
   //jff 4/23/98 add exit line to automap
   {"exit line"                      ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_exit},
+  {"alt secret exit line"           ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_exitsecr},
   {"computer map unseen line"       ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_unsn},
   {"line w/no floor/ceiling changes",S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_flat},
   {"general sprite"                 ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_sprt},

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -221,6 +221,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_mapcolor_tele),
   MIGRATED_SETTING(dsda_config_mapcolor_secr),
   MIGRATED_SETTING(dsda_config_mapcolor_revsecr),
+  MIGRATED_SETTING(dsda_config_mapcolor_tagfinder),
   MIGRATED_SETTING(dsda_config_mapcolor_exit),
   MIGRATED_SETTING(dsda_config_mapcolor_exitsecr),
   MIGRATED_SETTING(dsda_config_mapcolor_unsn),

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -222,6 +222,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_mapcolor_secr),
   MIGRATED_SETTING(dsda_config_mapcolor_revsecr),
   MIGRATED_SETTING(dsda_config_mapcolor_exit),
+  MIGRATED_SETTING(dsda_config_mapcolor_exitsecr),
   MIGRATED_SETTING(dsda_config_mapcolor_unsn),
   MIGRATED_SETTING(dsda_config_mapcolor_flat),
   MIGRATED_SETTING(dsda_config_mapcolor_sprt),

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -298,6 +298,7 @@ typedef enum
   ams_locked,
   ams_teleport,
   ams_exit,
+  ams_exit_secret,
   ams_unseen_secret,
   ams_portal,
 


### PR DESCRIPTION
This adds two additional line colours to the automap:
- Alt Secret Exit Line
- Tag Finder Line

For the secret exit line, if blank, it will default to using the normal "exit line" color. That's why I added "alt" to the name.

For the "tag finder" line, I'm unsure if we want to include that in the OPTIONS lump or not.