### PR TITLE
Get rid of NormalizeSlashes()

### DIFF
--- a/prboom2/src/dsda/data_organizer.c
+++ b/prboom2/src/dsda/data_organizer.c
@@ -63,8 +63,6 @@ char* dsda_DetectDirectory(const char* env_key, int arg_id) {
   if (!result)
     result = Z_Strdup(default_directory);
 
-  dsda_NormalizeSlashes(result);
-
   return result;
 }
 

--- a/prboom2/src/dsda/utility.c
+++ b/prboom2/src/dsda/utility.c
@@ -193,29 +193,6 @@ void dsda_PrintCommandMovement(char* str, ticcmd_t* cmd) {
     str += sprintf(str, "TR%2d", -(cmd->angleturn >> 8));
 }
 
-// Remove trailing slashes, translate backslashes to slashes
-// The string to normalize is passed and returned in str
-//
-// jff 4/19/98 Make killoughs slash fixer a subroutine
-//
-void dsda_NormalizeSlashes(char* str)
-{
-  size_t l;
-
-  // killough 1/18/98: Neater / \ handling.
-  // Remove trailing / or \ to prevent // /\ \/ \\, and change \ to /
-
-  if (!str || !(l = strlen(str)))
-    return;
-
-  if (str[--l] == '/' || str[l] == '\\')     // killough 1/18/98
-    str[l] = 0;
-
-  while (l--)
-    if (str[l] == '\\')
-      str[l] = '/';
-}
-
 char* dsda_ConcatDir(const char* a, const char* b)
 {
   char* buffer;
@@ -224,12 +201,10 @@ char* dsda_ConcatDir(const char* a, const char* b)
   buffer = Z_Malloc(strlen(a) + strlen(b) + 2);
 
   strcpy(buffer, a);
-  dsda_NormalizeSlashes(buffer);
 
   len = strlen(buffer);
   buffer[len] = '/';
   strcpy(buffer + len + 1, b);
-  dsda_NormalizeSlashes(buffer + len);
 
   return buffer;
 }

--- a/prboom2/src/dsda/utility.h
+++ b/prboom2/src/dsda/utility.h
@@ -66,7 +66,6 @@ void dsda_FixedToString(char* str, fixed_t x);
 dsda_fixed_t dsda_SplitFixed(fixed_t x);
 dsda_angle_t dsda_SplitAngle(angle_t x);
 void dsda_PrintCommandMovement(char* str, ticcmd_t* cmd);
-void dsda_NormalizeSlashes(char* str);
 char* dsda_ConcatDir(const char* a, const char* b);
 void dsda_CutExtension(char* str);
 const char* dsda_BaseName(const char* str);


### PR DESCRIPTION
Fixes https://github.com/kraflab/dsda-doom/issues/611

From Woof https://github.com/fabiangreffrath/woof/pull/1593

I still need to test this on Windows. On macOS it works fine.