### PR TITLE
Doom 1 intermission fixes

### DIFF
--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -257,15 +257,7 @@ int dsda_UFTicker(void) {
   const int TEXTWAIT = 250;
   const int NEWTEXTWAIT = 1000;
 
-  if (!demo_compatibility)
-    WI_checkForAccelerate();
-  else {
-    int i;
-
-    for (i = 0; i < g_maxplayers; i++)
-      if (players[i].cmd.buttons)
-        next_level = true;
-  }
+  WI_checkForAccelerate();
 
   if (!next_level) {
     // advance animation

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -257,7 +257,15 @@ int dsda_UFTicker(void) {
   const int TEXTWAIT = 250;
   const int NEWTEXTWAIT = 1000;
 
-  WI_checkForAccelerate();
+  if (!demo_compatibility || allow_incompatibility)
+    WI_checkForAccelerate();
+  else {
+    int i;
+
+    for (i = 0; i < g_maxplayers; i++)
+      if (players[i].cmd.buttons)
+        next_level = true;
+  }
 
   if (!next_level) {
     // advance animation

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -2087,7 +2087,10 @@ void WI_loadData(void)
           else
           {
             // HACK ALERT!
-            a->p[i] = anims[1][4].p[i];
+            if ( gamemap == 8 )
+              a->p[i] = anims[1][6].p[i]; // if map is E2M8, use E2M7 data
+            else
+              a->p[i] = anims[1][4].p[i]; // E2M5 data (for E2M9)
           }
         }
       }

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -814,6 +814,14 @@ void WI_drawAnimatedBack(void)
   if (wbs->epsd < 0 || wbs->epsd > 2)
     return;
 
+  // [crispy] show Fortress of Mystery if it has been completed
+  if (wbs->epsd == 1 && wbs->didsecret)
+  {
+    a = &anims[1][7];
+
+    V_DrawNumPatch(a->loc.x, a->loc.y, FB, a->p[2].lumpnum, CR_DEFAULT, VPT_STRETCH);
+  }
+
   for (i=0 ; i<NUMANIMS[wbs->epsd] ; i++)
   {
     a = &anims[wbs->epsd][i];

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -715,7 +715,11 @@ void WI_initAnimatedBack(int entering)
     a = &anims[wbs->epsd][i];
 
     // init variables
-    a->ctr = -1;
+    // [crispy] Do not reset animation timers upon switching to "Entering" state
+    // via WI_initShowNextLoc. Fixes notable blinking of Tower of Babel drawing
+    // and the rest of animations from being restarted.
+    if (!entering)
+      a->ctr = -1;
 
     // specify the next time to draw it
     if (a->type == ANIM_ALWAYS)


### PR DESCRIPTION
This fixes quite a few little things regarding the Doom 1 Intermission screen.
- Do not reset Intermission animation timers when "Entering" _(from Crispy Doom)_
  - fixes E2 Tower of Babel flicker (required for the next fix)
- Show E2M9 on Intermission screens if it has been completed _(from Crispy Doom)_
  - Note this has been tweaked to print E2M9 _under_ E2M# graphics due to PWADs using unorthodox level graphics (example: fullscreen E2 intermission graphics).
- Show E2M7 screen on intermission for E2M8
  - instead of showing E2M5 which made no sense.
- Always use `WI_checkForAccelerate` for UMAPINFO ending _(from Woof)_
  - May be worth discussing when it comes to demo compat.
  - This fixes an issue in Doom 1 wads that use UMAPINFO, where if it was E1M8, E2M8, E3M8, etc, it would completely skip the text screen if that UMAPINFO map entry was read... no matter if it had `intertext` or not.