### PR TITLE
Interpolate bobbing for animated weapons (Chainsaw)

### DIFF
--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1105,7 +1105,7 @@ static void R_DrawPSprite (pspdef_t *psp)
           R_ApplyWeaponBob(NULL, false, &psp_sy, weapon_attack_alignment == CENTERWEAPON_BOB);
       }
     }
-    else if (psp->state->action == A_WeaponReady && psp->state->tics > 1)
+    else if (psp->state->action == A_WeaponReady && psp->state->tics > 1 && movement_smooth)
     {
       // Interpolate bobbing for animated weapons (Chainsaw)
       R_ApplyWeaponBob(&psp_sx, true, &psp_sy, true);

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1105,6 +1105,11 @@ static void R_DrawPSprite (pspdef_t *psp)
           R_ApplyWeaponBob(NULL, false, &psp_sy, weapon_attack_alignment == CENTERWEAPON_BOB);
       }
     }
+    else if (psp->state->action == A_WeaponReady && psp->state->tics > 1)
+    {
+      // Interpolate bobbing for animated weapons (Chainsaw)
+      R_ApplyWeaponBob(&psp_sx, true, &psp_sy, true);
+    }
   }
 
   {


### PR DESCRIPTION
While most weapon's bob looks nice and smooth at high framerates, animated weapons with multiple WeaponReady frames look jittery and awful... This PR fixes that.

I've coded this in a particular way where it applies to any animated idle weapon... as opposed to only the Chainsaw. Let me know if there's a better approach.

I tested this with the [Corruption 2 Demo](doomworld.com/forum/topic/150350), which has animated Chainsaw and BFG weapons.