### PR TITLE
Add colored statusbar background option

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -27,6 +27,7 @@
 #include "r_main.h"
 #include "r_segs.h"
 #include "s_sound.h"
+#include "st_stuff.h"
 #include "smooth.h"
 #include "v_video.h"
 #include "z_zone.h"
@@ -311,6 +312,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
   [dsda_config_sts_traditional_keys] = {
     "sts_traditional_keys", dsda_config_sts_traditional_keys,
     CONF_BOOL(0), &sts_traditional_keys
+  },
+  [dsda_config_sts_solid_bg_color] = {
+    "sts_solid_bg_color", dsda_config_sts_solid_bg_color,
+    CONF_BOOL(0), NULL, NOT_STRICT, ST_SetResolution
   },
   [dsda_config_strict_mode] = {
     "dsda_strict_mode", dsda_config_strict_mode,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -48,6 +48,7 @@ typedef enum {
   dsda_config_sts_always_red,
   dsda_config_sts_pct_always_gray,
   dsda_config_sts_traditional_keys,
+  dsda_config_sts_solid_bg_color,
   dsda_config_strict_mode,
   dsda_config_vertmouse,
   dsda_config_freelook,

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3330,6 +3330,7 @@ setup_menu_t display_statbar_settings[] =  // Demos Settings screen
 {
   { "Hide Status Bar Horns", S_YESNO, m_conf, DM_X, dsda_config_hide_horns },
   { "Single Key Display", S_YESNO, m_conf, DM_X, dsda_config_sts_traditional_keys },
+  { "Solid Color Background", S_YESNO, m_conf, DM_X, dsda_config_sts_solid_bg_color },
   EMPTY_LINE,
   TITLE("Coloring", DM_X),
   { "Gray %",S_YESNO, m_conf, DM_X, dsda_config_sts_pct_always_gray },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -101,6 +101,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_sts_always_red),
   MIGRATED_SETTING(dsda_config_sts_pct_always_gray),
   MIGRATED_SETTING(dsda_config_sts_traditional_keys),
+  MIGRATED_SETTING(dsda_config_sts_solid_bg_color),
   MIGRATED_SETTING(dsda_config_show_messages),
   MIGRATED_SETTING(dsda_config_autorun),
   MIGRATED_SETTING(dsda_config_deh_apply_cheats),


### PR DESCRIPTION
This is my attempt to add this feature: https://github.com/fabiangreffrath/woof/pull/655

I've set this as a draft because it still needs work.

We can't use the method that Woof uses because it's software only, and so I've tried a slightly different method that also works for OpenGL.

it's based off these 2 functions: [dsda_CalculateFontBounds](https://github.com/kraflab/dsda-doom/blob/51d4226b7e7d4db8d51512a906f2e5de124dc6d2/prboom2/src/dsda/cr_table.c#L76-L120) and [dsda_PaletteEntryLightness](https://github.com/kraflab/dsda-doom/blob/51d4226b7e7d4db8d51512a906f2e5de124dc6d2/prboom2/src/dsda/palette.c#L102-L141) which are used to determine brightness (and colours) for fonts in DSDA (hence this works in both software and opengl).

Main issue with this at the moment is that it needs a way to average the values... which I guess I can't seem to figure out.