### PR TITLE
Stop sounds from SNDINFO overriding DEHACKED sounds

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -3169,7 +3169,7 @@ static void deh_procBexSounds(DEHFILE *fpin, char *line)
     if (match >= 0)
     {
       deh_log("Substituting '%s' for sound '%s'\n", candidate, key);
-      S_sfx[match].name = deh_sfx_name(candidate);
+      dsda_GetDehSFX(match)->name = deh_sfx_name(candidate);
     }
   }
 }


### PR DESCRIPTION
Note: this commit is just a minimal fix, if this was *my* code and I had the time then I'd completely rework the sfx.h API, including hiding the S_sfx arrays so invariants aren't broken so easily. Feel free to fix the issue in some other way, so one option I considered was to include code to bump highest_index inside dsda_GetOriginalSFXIndex, but that function is a bit of a mess as it both looks up sfx names and converts strings to a numeric index.  

I was trying to play Matt Eldrydge’s Innawoods weapons mod together with his recommendation of DBP11, but discovered that DSDA has somehow mixed up the sounds, so when you fire the pistol you get a grunting sound, and the two knife attacks (hit & miss) are also wrong.  This doesn’t happen with Woof/Nugget Doom, which was what Matt had tested with.  After a lot of digging I determined the problem is that DBP11 includes a SNDINFO file with 3 sounds, and these 3 sounds overrode what Innawood set.  Digging further, the issue is that SNDINFO sounds clobber any previously defined sounds from DEHACKED files, as the DEHACKED sounds don’t reserve their slots and dsda_NewSFX reuses slots that DEHACKED sounds are already using.  In the function deh_procBexSounds dsda_GetOriginalSFXIndex is used to get a slot for a particular index, but that doesn’t adjust highest_index inside sfx.c so the slot can be reused later by a call to dsda_NewSFX, which returns the next empty slot.  However dsda_SFXAtIndex does update highest_index, and so prevents reusing the slot.

This issue isn’t limited to DBP11 & Innawoods, it also happens for several other weapon mods + wad combos, eg Pirate Doom 2 + Matt’s Agitator & TheAtomMace’s Sweeper.