### PR TITLE
Reset best kills, items, secrets on new highest skill completion

### DIFF
--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -278,6 +278,9 @@ void dsda_WadStatsExitMap(int missed_monsters) {
       if (current_map_stats->best_skill < 4) {
         current_map_stats->best_time = -1;
         current_map_stats->best_max_time = -1;
+        current_map_stats->best_kills = 0;
+        current_map_stats->best_items = 0;
+        current_map_stats->best_secrets = 0;
       }
 
       current_map_stats->best_skill = skill;


### PR DESCRIPTION
I noticed while reading the source code that these are not reset when they probably should be. I reset them to 0 since that appears to be the value they initialize with. Creating a PR as requested on the Discord. (I'm not a C developer, please have patience, thanks!)