### PR TITLE
Dont allow saving the game on strict mode

### DIFF
--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -33,6 +33,7 @@
 #include "dsda/mapinfo.h"
 #include "dsda/music.h"
 #include "dsda/options.h"
+#include "dsda/settings.h"
 
 #include "save.h"
 
@@ -249,6 +250,10 @@ static void dsda_MarkSaveSlotUsed(int slot) {
   }
 
   demo_save_slots[demo_save_slot_count - 1] = slot;
+}
+
+int dsda_AllowAnyMenuSave(void) {
+  return !dsda_StrictMode() || dsda_AllowCasualExCmdFeatures();
 }
 
 int dsda_AllowMenuLoad(int slot) {

--- a/prboom2/src/dsda/save.h
+++ b/prboom2/src/dsda/save.h
@@ -28,6 +28,7 @@ void dsda_SetLastLoadSlot(int slot);
 void dsda_SetLastSaveSlot(int slot);
 int dsda_LastSaveSlot(void);
 void dsda_ResetLastSaveSlot(void);
+int dsda_AllowAnyMenuSave(void);
 int dsda_AllowMenuLoad(int slot);
 int dsda_AllowAnyMenuLoad(void);
 void dsda_UpdateAutoSaves(void);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1152,6 +1152,15 @@ void M_SaveGame (int choice)
   if (gamestate != GS_LEVEL)
     return;
 
+  if (!dsda_AllowAnyMenuSave())
+  {
+    M_StartMessage(
+      "you can't save the game\n"
+      "under these conditions!\n\n"PRESSKEY,
+      NULL, false); // killough 5/26/98: not externalized
+    return;
+  }
+
   M_SetupNextMenu(&SaveDef);
   M_ReadSaveStrings();
 }
@@ -1409,6 +1418,15 @@ static void M_QuickSave(void)
 {
   if (gamestate != GS_LEVEL)
     return;
+
+  if (!dsda_AllowAnyMenuSave())
+  {
+    M_StartMessage(
+      "you can't save the game\n"
+      "under these conditions!\n\n"PRESSKEY,
+      NULL, false); // killough 5/26/98: not externalized
+    return;
+  }
 
   G_SaveGame(QUICKSAVESLOT, "quicksave");
   doom_printf("quicksave");


### PR DESCRIPTION
Requested on discord. Saving the game can be used to open the save in a new dsda instance to check where remaining monsters are.