### PR TITLE
Demos: Fix keyframe start point

### DIFF
--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -433,7 +433,7 @@ const byte* dsda_EvaluateDemoStartPoint(const byte* demo_p) {
     memcpy(&key_frame.buffer_length, demo_p, sizeof(key_frame.buffer_length));
     demo_p += sizeof(key_frame.buffer_length);
 
-    key_frame.buffer = u.b;
+    key_frame.buffer = u.b + sizeof(key_frame.buffer_length);
 
     dsda_RestoreKeyFrame(&key_frame, false);
     demo_p += key_frame.buffer_length;


### PR DESCRIPTION
When writing demo files, after writing the header, DSDA will then write the keyframe buffer length to the next 4 bytes, before writing the keyframe itself. However, when loading demos with keyframes, it wasn't shifting the keyframe buffer pointer past these 4 bytes for the buffer length, causing a premature crash when loading due to using misaligned values.

# Testing
[Use these two demo files](https://github.com/user-attachments/files/19525832/resume.zip) for Doom 1 E1M1:
1. Pistol start on Nightmare, without any keyframes
2. Loaded game before the first door, with a keyframe
    - Made possible via an as yet uncommited improvement on [my Always Record branch](https://github.com/Mushman/dsda-doom/tree/always-record)
    - Successfully tested playing demos initiated from the in-game console using `demo.start` too (I haven't uploaded a file for this)