### PR TITLE
Dont allow fullscreen window to be bigger than screen

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1294,6 +1294,14 @@ void I_UpdateVideoMode(void)
     }
   }
 
+  if (desired_fullscreen)
+  {
+    if (exclusive_fullscreen)
+      init_flags |= SDL_WINDOW_FULLSCREEN;
+    else
+      init_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+  }
+
   if (V_IsOpenGLMode())
   {
     SDL_GL_SetAttribute( SDL_GL_RED_SIZE, 0 );


### PR DESCRIPTION
So we need to set fullscreen in the init_flags so that the window is not bigger than the screen (try setting a resolution bigger than your monitor).
And we also need to use SDL_SetWindowFullscreen after creating the window, so that we can move the window from one display to the other.