### PR TITLE
Only draw freelook sky, if freelook is allowed

### DIFF
--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -85,6 +85,7 @@
 #include "m_file.h"
 
 #include "dsda/args.h"
+#include "dsda/excmd.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
 #include "dsda/playback.h"
@@ -281,7 +282,7 @@ void M_ChangeSkyMode(void)
   gl_skymode = dsda_IntConfig(dsda_config_gl_skymode);
 
   if (gl_skymode == skytype_auto)
-    gl_drawskys = (dsda_MouseLook() ? skytype_skydome : skytype_standard);
+    gl_drawskys = (dsda_FreeAim() ? skytype_skydome : skytype_standard);
   else
     gl_drawskys = gl_skymode;
 }

--- a/prboom2/src/r_sky.c
+++ b/prboom2/src/r_sky.c
@@ -39,6 +39,7 @@
 #include "e6y.h"
 
 #include "dsda/configuration.h"
+#include "dsda/excmd.h"
 #include "dsda/mapinfo.h"
 #include "dsda/settings.h"
 
@@ -62,7 +63,7 @@ void R_InitSkyMap(void)
 
   r_stretchsky = dsda_IntConfig(dsda_config_render_stretchsky);
 
-  if (raven || !dsda_MouseLook())
+  if (raven || !dsda_FreeAim())
   {
     skystretch = false;
     skytexturemid = (raven ? 200 : 100) * FRACUNIT;


### PR DESCRIPTION
During demos you cant freelook (except with mapinfo), so even if freelook is on, we should draw the skies normally.
We cannot just make freelook strict, since mapinfo may allow it.

(Idea for the future: allow dynamic strict values so that we can mark this as strict and have a mapinfo condition that makes it non strict)

![Screenshot 2025-04-01 at 19 33 38](https://github.com/user-attachments/assets/aa2f48b3-590e-4799-86ec-0189154802cb)
