### PR TITLE
Fix GL mode's vertical position of Doom 2D tall skies to match Software mode

### DIFF
--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -186,7 +186,9 @@ void gld_AddSkyTexture(GLWall *wall, int sky1, int sky2, int skytype)
       wall->skyyaw = skyXShift;
       wall->skypitch = skyYShift;
       // Choose offset based on logic from r_sky.c
-      if (h >= 128 && h < 200)
+      if (!raven)
+        wall->skyoffset = (100 - h) / (float)h;
+      else if (h >= 128 && h < 200)
         wall->skyoffset = -28.0f / 128.0f;
       else if (h > 200)
         wall->skyoffset = (200 - h) / 128.0f;

--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -186,14 +186,7 @@ void gld_AddSkyTexture(GLWall *wall, int sky1, int sky2, int skytype)
       wall->skyyaw = skyXShift;
       wall->skypitch = skyYShift;
       // Choose offset based on logic from r_sky.c
-      if (!raven)
-        wall->skyoffset = (100 - h) / (float)h;
-      else if (h >= 128 && h < 200)
-        wall->skyoffset = -28.0f / 128.0f;
-      else if (h > 200)
-        wall->skyoffset = (200 - h) / 128.0f;
-      else
-        wall->skyoffset = 0.0f;
+      wall->skyoffset = skytexturemid / (float)FRACUNIT / h;
       wall->flag = GLDWF_SKY;
     }
   }
@@ -250,7 +243,7 @@ void gld_SkyTransform(GLWall* wall)
   float flipx = wall->flag == GLDWF_SKYFLIP ? -1.0 : 1.0;
   // Scale factors
   float scalex = scale_correction / skyscale * flipx;
-  float scaley = scale_correction * ratio * (skystretch ? 2.0 : 1.0f) / skyscale;
+  float scaley = scale_correction * ratio * (skystretch ? ( (float)SKYSTRETCH_HEIGHT / h ) : 1.0f) / skyscale;
   // Translations
   float transx = wall->skyyaw * tilex * flipx;
   float transy = wall->skypitch * tiley;

--- a/prboom2/src/r_sky.c
+++ b/prboom2/src/r_sky.c
@@ -75,7 +75,7 @@ void R_InitSkyMap(void)
     if (!textureheight)
       return;
 
-    // There are various combinations for sky rendering depending on how tall the sky is:
+    // There are various combinations for Raven sky rendering depending on how tall the sky is:
     //        h <  128: Unstretched and tiled, centered on horizon
     // 128 <= h <  200: Can possibly be stretched. When unstretched, the baseline is
     //                  28 rows below the horizon so that the top of the texture

--- a/prboom2/src/r_sky.c
+++ b/prboom2/src/r_sky.c
@@ -75,7 +75,7 @@ void R_InitSkyMap(void)
     if (!textureheight)
       return;
 
-    // There are various combinations for Raven sky rendering depending on how tall the sky is:
+    // There are various combinations for sky rendering depending on how tall the sky is:
     //        h <  128: Unstretched and tiled, centered on horizon
     // 128 <= h <  200: Can possibly be stretched. When unstretched, the baseline is
     //                  28 rows below the horizon so that the top of the texture


### PR DESCRIPTION
Addresses #636 - demonstration WAD for comparison is in there

For DSDA v0.26 the GL 2D sky type's code was altered to fix positioning of tall sky textures in Heretic/Hexen, but it also affects Doom.
This caused the vertical alignment of tall sky textures (h > 128) to no longer match up with the Software renderer's sky position in Doom.

Fixed by making the new cases only affect Raven games & added new math for Doom mode to match SW.
Top of sky texture aligns with top of screen with mouselook off & default FOV.
Also adjusted a comment in r_sky (software offset) to reflect that the logic only applies to Raven games.

Heretic/hexen is not affected.
MBF sky transfers is not affected.
The GL 3D dome sky type is not affected (however it also does misalign with software sky in tall sky situations, but perhaps to be left for another issue)

Now, the sky alignment of tall skies matches Software mode, as well as other MBF21 ports such as Woof and Eternity.

Admittedly, this alignment makes tall skies not help at all with mouselook, but I think that can be considered for a future change, or left to SKYDEFS, and until then sw/gl sky can be more consistent with each other & other ports.