### PR TITLE
Enable the Boom ANIMATED feature for the default sky texture

### DIFF
--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -139,7 +139,7 @@ void gld_AddSkyTexture(GLWall *wall, int sky1, int sky2, int skytype)
 {
   side_t *s = NULL;
   line_t *l = NULL;
-  int sky = skytexture;
+  int sky = texturetranslation[skytexture];
 
   wall->gltexture = NULL;
 

--- a/prboom2/src/r_plane.c
+++ b/prboom2/src/r_plane.c
@@ -584,7 +584,7 @@ static void R_DoDrawPlane(visplane_t *pl)
       else
       {    // Normal Doom sky, only one allowed per level
         dcvars.texturemid = skytexturemid;    // Default y-offset
-        texture = skytexture;             // Default texture
+        texture = texturetranslation[skytexture]; // Default texture
         flip = 0;                         // Doom flips it
       }
 


### PR DESCRIPTION
Fix #639 