### PR TITLE
Fix tiled flat (grnrock) offsets on statusbar

### DIFF
--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -520,19 +520,10 @@ void R_FillBackScreen (void)
     {
       int stbar_top = SCREENHEIGHT - ST_SCALED_HEIGHT;
 
-      if (V_IsOpenGLMode())
-        V_FillFlat(grnrock.lumpnum, 1, 0, stbar_top, SCREENWIDTH, ST_SCALED_HEIGHT, VPT_STRETCH);
+      if (V_IsOpenGLMode()) // OpenGL has no way to adjust y-offset independent from height
+        V_FillFlat(grnrock.lumpnum, 1, 0, 0, SCREENWIDTH, SCREENHEIGHT, VPT_STRETCH);
       else
-      {
-        V_FillFlat(grnrock.lumpnum, 1,
-          0, stbar_top, ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_STRETCH);
-        V_FillFlat(grnrock.lumpnum, 1,
-          SCREENWIDTH - ST_SCALED_OFFSETX, stbar_top, ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_STRETCH);
-
-        // For custom huds, need to put the backfill inside the bar area (in the copy buffer)
-        V_FillFlat(grnrock.lumpnum, 0,
-          ST_SCALED_OFFSETX, stbar_top, SCREENWIDTH - 2 * ST_SCALED_OFFSETX, ST_SCALED_HEIGHT, VPT_STRETCH);
-      }
+        V_FillFlat(grnrock.lumpnum, 1, 0, stbar_top, SCREENWIDTH, ST_SCALED_HEIGHT, VPT_STRETCH);
 
       // heretic_note: I think this looks bad, so I'm skipping it...
       if (!heretic)

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -278,7 +278,7 @@ static void FUNC_V_FillFlat(int lump, int scrn, int x, int y, int width, int hei
 
   for (sy = y; sy < y + height; ++sy)
   {
-    src_y_offset = 64 * ((int) ((sy - y) / ratio_y) % 64);
+    src_y_offset = 64 * ((int) (sy / ratio_y) % 64);
     dest = screens[scrn].data + pitch * sy + x;
 
     for (sx = x; sx < x + width; ++sx)


### PR DESCRIPTION
So while the my "Zoom-Levels" PR #614 was discarded, this should probably be added in.

This issue was also pointed out in that PR, but also mentioned here on the Nyan Doom thread asking to be added to DSDA as well: https://www.doomworld.com/forum/post/2910001

Basically the way that the background flat (grnrock in doom) is tiling is actually not correct. The reason for this is because for some reason it's only being printed on the right and left sides of the statusbar...

While this make some sense, it also means that the starting point of the tiling ends up being incorrect. And so this PR fixes this issue.