### PR TITLE
Fix reading signatures of older demos

### DIFF
--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -442,14 +442,14 @@ const byte* dsda_EvaluateDemoStartPoint(const byte* demo_p) {
   return demo_p;
 }
 
-void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, byte* demo, size_t demo_size) {
+void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, size_t feature_slots, byte* demo, size_t demo_size) {
   struct MD5Context md5;
 
   MD5Init(&md5);
 
   MD5Update(&md5, demo, demo_size);
 
-  MD5Update(&md5, features, FEATURE_SLOTS);
+  MD5Update(&md5, features, feature_slots);
 
   MD5Final(cksum->bytes, &md5);
 
@@ -461,7 +461,7 @@ void dsda_GetDemoRecordingCheckSum(dsda_cksum_t* cksum) {
 
   dsda_CopyFeatures(features);
 
-  dsda_GetDemoCheckSum(cksum, features, dsda_demo_write_buffer, dsda_DemoBufferOffset());
+  dsda_GetDemoCheckSum(cksum, features, FEATURE_SLOTS, dsda_demo_write_buffer, dsda_DemoBufferOffset());
 }
 
 static int dsda_ExportDemoToFile(const char* demo_name) {

--- a/prboom2/src/dsda/demo.h
+++ b/prboom2/src/dsda/demo.h
@@ -45,7 +45,7 @@ void dsda_JoinDemoCmd(ticcmd_t* cmd);
 const byte* dsda_StripDemoVersion255(const byte* demo_p, const byte* header_p, size_t size);
 void dsda_WriteDSDADemoHeader(byte** p);
 void dsda_ApplyDSDADemoFormat(byte** demo_p);
-void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, byte* demo, size_t demo_size);
+void dsda_GetDemoCheckSum(dsda_cksum_t* cksum, byte* features, size_t feature_slots, byte* demo, size_t demo_size);
 void dsda_GetDemoRecordingCheckSum(dsda_cksum_t* cksum);
 void dsda_EndDemoRecording(void);
 int dsda_DemoDataSize(byte complete);

--- a/prboom2/src/dsda/exdemo.c
+++ b/prboom2/src/dsda/exdemo.c
@@ -416,27 +416,31 @@ static void DemoEx_GetFeatures(const wadinfo_t* header) {
 
   if (sscanf(str, "%*[^\n]\n0x%n%[^-]%n-%32s", &ftext_start, ftext, &ftext_end, signature) == 2) {
     dsda_cksum_t cksum;
-    char padded_ftext[2 * FEATURE_SLOTS + 1];
+    int ftext_slots = (ftext_end - ftext_start) / 2;
+    byte *features;
     int i;
 
-    memset(&padded_ftext, 0, sizeof(padded_ftext));
-    for (i = 0; i < (2 * FEATURE_SLOTS) - (ftext_end - ftext_start); i++)
-      strcat(padded_ftext, "0");
-    strncat(padded_ftext, ftext, ftext_end - ftext_start);
+    features = Z_Calloc(ftext_slots, sizeof(byte));
 
-    for (int f = 0; f < FEATURE_SLOTS; f++) {
+    for (i = 0; i < ftext_slots; i++) {
       char current_text[3];
-      strncpy(current_text, padded_ftext + f * 2, 2);
+      strncpy(current_text, ftext + i * 2, 2);
       current_text[2] = '\0';
-      exdemo.features[FEATURE_SLOTS - f - 1] = strtol(current_text, NULL, 16);
+      features[ftext_slots - i - 1] = strtol(current_text, NULL, 16);
+
+      // Add it to the padded features as well
+      if (i < FEATURE_SLOTS)
+        exdemo.features[FEATURE_SLOTS - i - 1] = features[ftext_slots - i - 1];
     }
 
-    dsda_GetDemoCheckSum(&cksum, exdemo.features, exdemo.demo, exdemo.demo_size);
+    dsda_GetDemoCheckSum(&cksum, features, ftext_slots, exdemo.demo, exdemo.demo_size);
 
     if (!strcmp(signature, cksum.string))
       exdemo.is_signed = 1;
     else
       exdemo.is_signed = -1;
+
+    Z_Free(features);
   }
   else
     exdemo.is_signed = -1;


### PR DESCRIPTION
Since we increased the features size to 128bits, we were padding the 64bits into 128bits, and doing a checksum using that. Which obviously doesnt match the checksum present in the demo.

`-analysis` would output `signature -1`

This also prevents future increases to feature_size to fail the checksum from now on

[demos.zip](https://github.com/user-attachments/files/19637060/demos.zip)
