### PR TITLE
A Few Minor fixes

### DIFF
--- a/prboom2/src/dsda/episode.c
+++ b/prboom2/src/dsda/episode.c
@@ -17,6 +17,7 @@
 
 #include "doomstat.h"
 #include "lprintf.h"
+#include "w_wad.h"
 #include "z_zone.h"
 
 #include "dsda/mapinfo.h"
@@ -55,7 +56,7 @@ void dsda_AddOriginalEpisodes(void) {
     dsda_AddEpisode("e2m1", NULL, "M_EPI2", 't', true);
     dsda_AddEpisode("e3m1", NULL, "M_EPI3", 'i', true);
 
-    if (gamemode == retail && compatibility_level >= ultdoom_compatibility)
+    if (gamemode == retail && (compatibility_level >= ultdoom_compatibility || W_PWADLumpNameExists("E4M1")))
       dsda_AddEpisode("e4m1", NULL, "M_EPI4", 't', true);
   }
 }

--- a/prboom2/src/dsda/exdemo.c
+++ b/prboom2/src/dsda/exdemo.c
@@ -465,7 +465,7 @@ static void DemoEx_AddFeatures(wadtbl_t* wadtbl) {
 
   for (int f = 0; f < FEATURE_SLOTS; f++) {
     snprintf(current_feature, 3, "%02" PRIx8, features[FEATURE_SLOTS - f - 1]);
-    strncat(buffer, current_feature, 2);
+    strcat(buffer, current_feature);
   }
 
   strcat(buffer, "-");

--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -71,7 +71,7 @@ void dsda_GLSetRenderViewportParams() {
   gl_scale_y = (float)gl_viewport_height / (float)SCREENHEIGHT;
 
   // elim - This will be zero if no statusbar is being drawn
-  gl_statusbar_height = (int)ceilf(gl_scale_y * (float)ST_SCALED_HEIGHT) * R_PartialView();
+  gl_statusbar_height = ceilf(gl_scale_y * (float)ST_SCALED_HEIGHT) * R_PartialView();
 
   gl_scene_width = gl_viewport_width;
   gl_scene_height = gl_viewport_height - gl_statusbar_height;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2104,13 +2104,14 @@ static void M_DrawScreenItems(const setup_menu_t* base_src, int base_y)
 
   if (excess_i && !inhelpscreens)
   {
+    int xx, yy, ww, hh;
     while (current_i - scroll_i > limit_i - buffer_i)
       ++scroll_i;
 
     // Draw scrollbar if needed
     scrollbar_scale = (185 - DEFAULT_LIST_Y) / (float)max_i;
 
-    int xx = 310, yy = base_y + scroll_i * scrollbar_scale, ww = 2, hh = limit_i * scrollbar_scale;
+    xx = 310, yy = base_y + scroll_i * scrollbar_scale, ww = 2, hh = limit_i * scrollbar_scale;
     V_GetWideRect(&xx, &yy, &ww, &hh, VPT_STRETCH);
     V_FillRect(0, xx, yy, ww, hh, colrngs[cr_scrollbar][playpal_lightest]);
   }

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2102,7 +2102,7 @@ static void M_DrawScreenItems(const setup_menu_t* base_src, int base_y)
   limit_i = max_i - excess_i;
   buffer_i = (max_i - current_i > 3 ? 3 : max_i - current_i);
 
-  if (excess_i)
+  if (excess_i && !inhelpscreens)
   {
     while (current_i - scroll_i > limit_i - buffer_i)
       ++scroll_i;

--- a/prboom2/src/r_drawflush.inl
+++ b/prboom2/src/r_drawflush.inl
@@ -45,15 +45,19 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
 {
    // Scaled software fuzz algorithm
 #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
+{
+    int yl, yh, count, lines;
+    byte *dest;
+
     if ((temp_x + startx) % fuzzcellsize)
     {
         return;
     }
 
-    int yl = tempyl[temp_x - 1];
-    int yh = tempyh[temp_x - 1];
+    yl = tempyl[temp_x - 1];
+    yh = tempyh[temp_x - 1];
 
-    int count = yh - yl + 1;
+    count = yh - yl + 1;
 
     if (count < 0)
     {
@@ -69,12 +73,15 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
 
     ++count;
 
-    byte *dest = drawvars.topleft + yl * drawvars.pitch + startx + temp_x - fuzzcellsize;
+    dest = drawvars.topleft + yl * drawvars.pitch + startx + temp_x - fuzzcellsize;
 
-    int lines = fuzzcellsize - (yl % fuzzcellsize);
+    lines = fuzzcellsize - (yl % fuzzcellsize);
 
     do
     {
+        int mask;
+        byte fuzz;
+
         count -= lines;
 
         // if (count < 0)
@@ -82,12 +89,11 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
         //    lines += count;
         //    count = 0;
         // }
-        const int mask = count >> (8 * sizeof(mask) - 1);
+        mask = count >> (8 * sizeof(mask) - 1);
         lines += count & mask;
         count &= ~mask;
 
-        const byte fuzz =
-            fullcolormap[6 * 256 + dest[fuzzoffset[fuzzpos]]];
+        fuzz = fullcolormap[6 * 256 + dest[fuzzoffset[fuzzpos]]];
 
         do
         {
@@ -102,7 +108,9 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
 
         lines = fuzzcellsize;
     } while (count);
+}
 #else
+{
    byte *source;
    byte *dest;
    int  count, yl;
@@ -126,6 +134,7 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
          dest += drawvars.pitch;
       }
    }
+}
 #endif
 }
 
@@ -138,16 +147,16 @@ static void R_FLUSHWHOLE_FUNCNAME(void)
 //
 static void R_FLUSHHEADTAIL_FUNCNAME(void)
 {
+   byte *source;
+   byte *dest;
+   int count, colnum = 0;
+   int yl, yh;
+
    #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
       // Only whole flushes are supported for fuzz
       R_FLUSHWHOLE_FUNCNAME();
       return;
    #endif
-
-   byte *source;
-   byte *dest;
-   int count, colnum = 0;
-   int yl, yh;
 
    while(colnum < 4)
    {
@@ -201,15 +210,17 @@ static void R_FLUSHHEADTAIL_FUNCNAME(void)
 
 static void R_FLUSHQUAD_FUNCNAME(void)
 {
+   byte *source;
+   byte *dest;
+   int count;
+
    #if (R_DRAWCOLUMN_PIPELINE & RDC_FUZZ)
       // Only whole flushes are supported for fuzz
       return;
    #endif
 
-   byte *source = &tempbuf[commontop << 2];
-   byte *dest = drawvars.topleft + commontop*drawvars.pitch + startx;
-   int count;
-
+   source = &tempbuf[commontop << 2];
+   dest = drawvars.topleft + commontop*drawvars.pitch + startx;
    count = commonbot - commontop + 1;
 
 #if (R_DRAWCOLUMN_PIPELINE & RDC_TRANSLUCENT)


### PR DESCRIPTION
Really small fixes that I think would be good to add in before release.

- Helpscreen fixes
  - Remove scrollbar
  - Add dark overlay
- Allow episode 4 if PWAD "E4M1" is found
  - I feel this is going to cause problems if we always remove the 4th episode pre complevel 3, since all other source ports don't remove the fourth episode... so if a mapper were to use UMAPINFO to add a new episode (to say replace the missing E4), DSDA would had 4 episodes while all other ports would have 5 including the duplicate 4th UMAPINFO episode
- Fixed a bunch of GCC warnings
  - I'm having some trouble fixing the strncat warning tied to the demo-footer, so I haven't fixed that yet.