### PR TITLE
Better Skill Definitions

### DIFF
--- a/prboom2/src/dsda/skill_info.h
+++ b/prboom2/src/dsda/skill_info.h
@@ -52,6 +52,7 @@ typedef struct {
 } skill_info_t;
 
 extern skill_info_t skill_info;
+extern skill_info_t *skill_infos;
 
 extern int num_skills;
 

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -266,16 +266,19 @@ void dsda_WadStatsEnterMap(void) {
 
 void dsda_WadStatsExitMap(int missed_monsters) {
   int skill;
-
-  // TODO: remap 5 -> num_skills and 4 -> num_skills - 1
+  int nightmare_skill;
+  int best_normal_skill;
 
   if (!current_map_stats || demoplayback)
     return;
 
+  nightmare_skill = num_skills;
+  best_normal_skill = num_skills - 1;   
+
   if (!nomonsters) {
     skill = gameskill + 1;
     if (skill > current_map_stats->best_skill) {
-      if (current_map_stats->best_skill < 4) {
+      if (current_map_stats->best_skill < best_normal_skill) {
         current_map_stats->best_time = -1;
         current_map_stats->best_max_time = -1;
         current_map_stats->best_kills = 0;
@@ -286,12 +289,12 @@ void dsda_WadStatsExitMap(int missed_monsters) {
       current_map_stats->best_skill = skill;
     }
 
-    if (skill >= current_map_stats->best_skill || skill == 4) {
+    if (skill >= current_map_stats->best_skill || skill == best_normal_skill) {
       if (levels_completed == 1)
         if (current_map_stats->best_time == -1 || current_map_stats->best_time > leveltime)
           current_map_stats->best_time = leveltime;
 
-      if (levels_completed == 1 && skill == 5)
+      if (levels_completed == 1 && skill == nightmare_skill)
         if (current_map_stats->best_nm_time == -1 || current_map_stats->best_nm_time > leveltime)
           current_map_stats->best_nm_time = leveltime;
 

--- a/prboom2/src/dsda/wad_stats.c
+++ b/prboom2/src/dsda/wad_stats.c
@@ -138,7 +138,7 @@ static void dsda_CreateWadStats(void) {
 
       ms->best_time = -1;
       ms->best_max_time = -1;
-      ms->best_sk5_time = -1;
+      ms->best_nm_time = -1;
       ms->max_kills = -1;
       ms->max_items = -1;
       ms->max_secrets = -1;
@@ -181,7 +181,7 @@ static void dsda_LoadWadStats(void) {
           sscanf(
             lines[i], "%8s %d %d %d %d %d %d %d %d %d %d %d %d %d %d",
             ms.lump, &ms.episode, &ms.map,
-            &ms.best_skill, &ms.best_time, &ms.best_max_time, &ms.best_sk5_time,
+            &ms.best_skill, &ms.best_time, &ms.best_max_time, &ms.best_nm_time,
             &ms.total_exits, &ms.total_kills,
             &ms.best_kills, &ms.best_items, &ms.best_secrets,
             &ms.max_kills, &ms.max_items, &ms.max_secrets
@@ -241,7 +241,7 @@ void dsda_SaveWadStats(void) {
     ms = &wad_stats.maps[i];
     fprintf(file, "%s %d %d %d %d %d %d %d %d %d %d %d %d %d %d\n",
             ms->lump, ms->episode, ms->map,
-            ms->best_skill, ms->best_time, ms->best_max_time, ms->best_sk5_time,
+            ms->best_skill, ms->best_time, ms->best_max_time, ms->best_nm_time,
             ms->total_exits, ms->total_kills,
             ms->best_kills, ms->best_items, ms->best_secrets,
             ms->max_kills, ms->max_items, ms->max_secrets);
@@ -292,8 +292,8 @@ void dsda_WadStatsExitMap(int missed_monsters) {
           current_map_stats->best_time = leveltime;
 
       if (levels_completed == 1 && skill == 5)
-        if (current_map_stats->best_sk5_time == -1 || current_map_stats->best_sk5_time > leveltime)
-          current_map_stats->best_sk5_time = leveltime;
+        if (current_map_stats->best_nm_time == -1 || current_map_stats->best_nm_time > leveltime)
+          current_map_stats->best_nm_time = leveltime;
 
       current_map_stats->max_kills = totalkills;
       current_map_stats->max_items = totalitems;

--- a/prboom2/src/dsda/wad_stats.h
+++ b/prboom2/src/dsda/wad_stats.h
@@ -25,7 +25,7 @@ typedef struct {
   int best_skill;
   int best_time;
   int best_max_time;
-  int best_sk5_time;
+  int best_nm_time;
   int total_exits;
   int total_kills;
   int best_kills;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2358,6 +2358,10 @@ const char * comp_lev_str[MAX_COMPATIBILITY_LEVEL] =
   "MBF", "PrBoom 2.03beta", "PrBoom v2.1.0-2.1.1", "PrBoom v2.1.2-v2.2.6",
   "PrBoom v2.3.x", "PrBoom 2.4.0", "Current PrBoom", "", "", "", "MBF21" };
 
+const char * hexen_skill_fighter[5] = { "SQUIRE", "KNIGHT", "WARRIOR", "BERSERKER", "TITAN" };
+const char * hexen_skill_cleric[5] = { "ALTAR BOY", "ACOLYTE", "PRIEST", "CARDINAL", "POPE" };
+const char * hexen_skill_mage[5] = { "APPRENTICE", "ENCHANTER", "SORCERER", "WARLOCK", "ARCHIMAGE" };  
+
 //==========================================================================
 //
 // RecalculateDrawnSubsectors

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2352,11 +2352,6 @@ static void G_LoadGameErr(const char *msg)
   M_ForcedLoadGame(msg);             // Print message asking for 'Y' to force
 }
 
-const char * skill_str[] = {
-  // dummy first option because defaultskill is 1-based
-  "", "ITYTD", "HNTR", "HMP", "UV", "NM"
-};
-
 const char * comp_lev_str[MAX_COMPATIBILITY_LEVEL] =
 { "Doom v1.2", "Doom v1.666", "Doom/Doom2 v1.9", "Ultimate Doom/Doom95", "Final Doom",
   "early DosDoom", "TASDoom", "\"boom compatibility\"", "boom v2.01", "boom v2.02", "lxdoom v1.3.2+",

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -112,8 +112,10 @@ extern char savedescription[SAVEDESCLEN];  // Description to save in savegame
 /* cph - compatibility level strings */
 extern const char * comp_lev_str[];
 
-/* default skill strings */
-extern const char * skill_str[];
+// Hexen Skill Strings
+extern const char * hexen_skill_fighter[5];
+extern const char * hexen_skill_cleric[5];
+extern const char * hexen_skill_mage[5];
 
 // e6y
 // There is a new command-line switch "-shorttics".

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -20,6 +20,7 @@
 #include "w_wad.h"
 #include "v_video.h"
 #include "m_menu.h"
+#include "g_game.h"
 #include "dsda/settings.h"
 #include "heretic/dstrings.h"
 #include "heretic/mn_menu.h"
@@ -360,27 +361,27 @@ void MN_UpdateClass(int choice)
   {
     case PCLASS_FIGHTER:
       SkillDef.x = 120;
-      SkillDef.menuitems[0].alttext = "SQUIRE";
-      SkillDef.menuitems[1].alttext = "KNIGHT";
-      SkillDef.menuitems[2].alttext = "WARRIOR";
-      SkillDef.menuitems[3].alttext = "BERSERKER";
-      SkillDef.menuitems[4].alttext = "TITAN";
+      SkillDef.menuitems[0].alttext = hexen_skill_fighter[0];
+      SkillDef.menuitems[1].alttext = hexen_skill_fighter[1];
+      SkillDef.menuitems[2].alttext = hexen_skill_fighter[2];
+      SkillDef.menuitems[3].alttext = hexen_skill_fighter[3];
+      SkillDef.menuitems[4].alttext = hexen_skill_fighter[4];
       break;
     case PCLASS_CLERIC:
       SkillDef.x = 116;
-      SkillDef.menuitems[0].alttext = "ALTAR BOY";
-      SkillDef.menuitems[1].alttext = "ACOLYTE";
-      SkillDef.menuitems[2].alttext = "PRIEST";
-      SkillDef.menuitems[3].alttext = "CARDINAL";
-      SkillDef.menuitems[4].alttext = "POPE";
+      SkillDef.menuitems[0].alttext = hexen_skill_cleric[0];
+      SkillDef.menuitems[1].alttext = hexen_skill_cleric[1];
+      SkillDef.menuitems[2].alttext = hexen_skill_cleric[2];
+      SkillDef.menuitems[3].alttext = hexen_skill_cleric[3];
+      SkillDef.menuitems[4].alttext = hexen_skill_cleric[4];
       break;
     case PCLASS_MAGE:
       SkillDef.x = 112;
-      SkillDef.menuitems[0].alttext = "APPRENTICE";
-      SkillDef.menuitems[1].alttext = "ENCHANTER";
-      SkillDef.menuitems[2].alttext = "SORCERER";
-      SkillDef.menuitems[3].alttext = "WARLOCK";
-      SkillDef.menuitems[4].alttext = "ARCHIMAGE";
+      SkillDef.menuitems[0].alttext = hexen_skill_mage[0];
+      SkillDef.menuitems[1].alttext = hexen_skill_mage[1];
+      SkillDef.menuitems[2].alttext = hexen_skill_mage[2];
+      SkillDef.menuitems[3].alttext = hexen_skill_mage[3];
+      SkillDef.menuitems[4].alttext = hexen_skill_mage[4];
       break;
   }
 }

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -579,13 +579,19 @@ static void cheat_comp(char buf[3])
   }
 }
 
+// Get skill strings
+static const char* dsda_skill_str(void)
+{
+  return skill_infos[gameskill].name;
+}
+
 // Check skill cheat
 static void cheat_skill0()
 {
-  if (raven || tc_game)
-    return doom_printf("Skill: %i", gameskill + 1);
-
-  doom_printf("Skill: %i - %s", gameskill + 1, skill_str[gameskill + 1]);
+  if (!tc_game && !hexen)
+    doom_printf("Skill: %i - %s", gameskill + 1, dsda_skill_str());
+  else
+    doom_printf("Skill: %i", gameskill + 1);
 }
 
 // Skill cheat
@@ -593,14 +599,14 @@ static void cheat_skill(char buf[1])
 {
   int skill = buf[0] - '0';
 
-  if (skill >= 1 && skill <= 5)
+  if (skill >= 1 && skill <= num_skills)
   {
     gameskill = skill - 1;
 
-    if (raven || tc_game)
-      doom_printf("Next Level Skill: %i", gameskill + 1);
+    if (!tc_game && !hexen)
+      doom_printf("Next Level Skill: %i - %s", gameskill + 1, dsda_skill_str());
     else
-      doom_printf("Next Level Skill: %i - %s", gameskill + 1, skill_str[gameskill + 1]);
+      doom_printf("Next Level Skill: %i", gameskill + 1);
 
     dsda_UpdateGameSkill(gameskill);
   }

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -582,13 +582,23 @@ static void cheat_comp(char buf[3])
 // Get skill strings
 static const char* dsda_skill_str(void)
 {
+  if (hexen)
+  {
+    if (PlayerClass[consoleplayer] == PCLASS_FIGHTER)
+        return hexen_skill_fighter[gameskill];
+    else if (PlayerClass[consoleplayer] == PCLASS_CLERIC)
+        return hexen_skill_cleric[gameskill];
+    else if (PlayerClass[consoleplayer] == PCLASS_MAGE)
+        return hexen_skill_mage[gameskill];
+  }
+
   return skill_infos[gameskill].name;
 }
 
 // Check skill cheat
 static void cheat_skill0()
 {
-  if (!tc_game && !hexen)
+  if (!tc_game)
     doom_printf("Skill: %i - %s", gameskill + 1, dsda_skill_str());
   else
     doom_printf("Skill: %i", gameskill + 1);
@@ -603,7 +613,7 @@ static void cheat_skill(char buf[1])
   {
     gameskill = skill - 1;
 
-    if (!tc_game && !hexen)
+    if (!tc_game)
       doom_printf("Next Level Skill: %i - %s", gameskill + 1, dsda_skill_str());
     else
       doom_printf("Next Level Skill: %i", gameskill + 1);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3709,7 +3709,7 @@ static void M_BuildLevelTable(void)
     if (map->best_skill) {
       dsda_StringPrintF(&m_text, "%d", map->best_skill);
       entry->m_text = m_text.string;
-      if (map->best_skill == 5)
+      if (map->best_skill == num_skills)
         entry->m_flags |= S_TC_SEL;
     }
     else {

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3577,7 +3577,7 @@ typedef struct {
   int completed_count;
   int timed_count;
   int max_timed_count;
-  int sk5_timed_count;
+  int nm_timed_count;
   int best_skill;
   int best_kills;
   int best_items;
@@ -3587,7 +3587,7 @@ typedef struct {
   int max_secrets;
   int best_time;
   int best_max_time;
-  int best_sk5_time;
+  int best_nm_time;
 } wad_stats_summary_t;
 
 static wad_stats_summary_t wad_stats_summary;
@@ -3630,10 +3630,10 @@ static void M_CalculateWadStatsSummary(void)
       wad_stats_summary.best_max_time += map->best_max_time;
     }
 
-    if (map->best_sk5_time >= 0)
+    if (map->best_nm_time >= 0)
     {
-      ++wad_stats_summary.sk5_timed_count;
-      wad_stats_summary.best_sk5_time += map->best_sk5_time;
+      ++wad_stats_summary.nm_timed_count;
+      wad_stats_summary.best_nm_time += map->best_nm_time;
     }
   }
 }
@@ -3820,14 +3820,14 @@ static void M_BuildLevelTable(void)
   END_LOOP_LEVEL_TABLE_COLUMN
 
   column_x += 80;
-  INSERT_LEVEL_TABLE_COLUMN("SK 5 TIME", column_x)
+  INSERT_LEVEL_TABLE_COLUMN("NM TIME", column_x)
 
   LOOP_LEVEL_TABLE_COLUMN
     entry->m_flags = S_LABEL | S_SKIP;
     entry->m_x = column_x;
 
-    if (map->best_sk5_time >= 0) {
-      M_PrintTime(&m_text, map->best_sk5_time);
+    if (map->best_nm_time >= 0) {
+      M_PrintTime(&m_text, map->best_nm_time);
       entry->m_text = m_text.string;
       entry->m_flags |= S_TC_SEL;
     }
@@ -3902,7 +3902,7 @@ static void M_BuildLevelTable(void)
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  dsda_StringPrintF(&m_text, "Sk 5 Time");
+  dsda_StringPrintF(&m_text, "Nightmare Time");
   level_table_page[page][base_i].m_text = m_text.string;
   level_table_page[page][base_i].m_flags = S_TITLE | S_SKIP;
   level_table_page[page][base_i].m_x = 162;
@@ -3990,8 +3990,8 @@ static void M_BuildLevelTable(void)
 
   INSERT_LEVEL_TABLE_EMPTY_LINE
 
-  if (wad_stats_summary.sk5_timed_count)
-    M_PrintTime(&m_text, wad_stats_summary.best_sk5_time);
+  if (wad_stats_summary.nm_timed_count)
+    M_PrintTime(&m_text, wad_stats_summary.best_nm_time);
   else
     dsda_StringPrintF(&m_text, "- : --");
   level_table_page[page][base_i].m_text = m_text.string;


### PR DESCRIPTION
So when adding the new bonus UV Plus skill for Nyan (and when working on a new skill definition functionality), I noticed some flaws with some of the logic pertaining to skills.

Much of the logic for stuff like the level table was specific to 4 being UV and 5 being NM skill. The problem with this is when a WAD uses MAPINFO to add skill definitions... as then NM skill may not be skill 5.

And so this PR tweaks some of these definitions to consider the last skill to be the "nightmare" skill, with the one under being the "best normal skill".

I also added Skill Cheat string support for Raven games, as well as custom MAPINFO skills... so it now uses the actual difficulty names of the skills when using the SKILL cheat.

Either way, this is worth implementing as whenever we get to the point of having a universal skill customisation lump, the skill logic will have already bene set up for that.

_(PS I have replaces SK5 with NM in the level table, however that may not be the best given that the final difficulty may not be nightmare - aka raven skills. Although we should rename SK5 to something else, as there's no guarantee the final skill will be skill 5)_