### PR TITLE
Level Table Fix - mark values as max if above max

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3727,7 +3727,7 @@ static void M_BuildLevelTable(void)
     if (map->best_skill) {
       dsda_StringPrintF(&m_text, "%d/%d", map->best_kills, map->max_kills);
       entry->m_text = m_text.string;
-      if (map->best_kills == map->max_kills)
+      if (map->best_kills >= map->max_kills)
         entry->m_flags |= S_TC_SEL;
     }
     else {
@@ -3745,7 +3745,7 @@ static void M_BuildLevelTable(void)
     if (map->best_skill) {
       dsda_StringPrintF(&m_text, "%d/%d", map->best_items, map->max_items);
       entry->m_text = m_text.string;
-      if (map->best_items == map->max_items)
+      if (map->best_items >= map->max_items)
         entry->m_flags |= S_TC_SEL;
     }
     else {
@@ -3763,7 +3763,7 @@ static void M_BuildLevelTable(void)
     if (map->best_skill) {
       dsda_StringPrintF(&m_text, "%d/%d", map->best_secrets, map->max_secrets);
       entry->m_text = m_text.string;
-      if (map->best_secrets == map->max_secrets)
+      if (map->best_secrets >= map->max_secrets)
         entry->m_flags |= S_TC_SEL;
     }
     else {


### PR DESCRIPTION
For the level table, it marks kills/items/secrets as a "finished" colour, if you max one of those values...

However it does not account for when those values exceed the max value... A couple examples being with Heretic and the ability for monsters to spawn extra items, or in Doom when a secret sector can be copied other to other sectors creating more secrets.

This simple fix changes the logic of the "finished" colour to "more than and equal" instead.