### PR TITLE
Heretic - Fix Inaccessible Menu Bug

### DIFF
--- a/prboom2/src/f_finale.h
+++ b/prboom2/src/f_finale.h
@@ -51,6 +51,5 @@ void F_StartFinale (void);
 void F_StartCast (const char* background, const char* music, dboolean loop_music);
 void F_StartScroll (const char* right, const char* left, const char* music, dboolean loop_music);
 void F_StartPostFinale (void);
-dboolean F_BlockingInput(void);
 
 #endif

--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -83,24 +83,25 @@ void Heretic_F_StartFinale(void)
   S_ChangeMusic(heretic_mus_cptd, true);
 }
 
-dboolean F_BlockingInput(void)
+static dboolean F_BlockingInput(void)   // Avoid bringing up menu when loading Heretic's custom E2 palette
 {
   return finalestage == 1 && gameepisode == 2;
 }
 
 dboolean Heretic_F_Responder(event_t * event)
 {
-  if (event->type != ev_keydown)
-  {
-    return false;
-  }
-
   if (F_BlockingInput())
   {                           // we're showing the water pic, make any key kick to demo mode
     V_SetPlayPal(playpal_default);
     finalestage++;
     return true;
   }
+
+  if (event->type != ev_keydown)
+  {
+    return false;
+  }
+
   return false;
 }
 

--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -18,6 +18,7 @@
 #include "doomstat.h"
 #include "w_wad.h"
 #include "v_video.h"
+#include "m_menu.h"
 #include "s_sound.h"
 #include "sounds.h"
 
@@ -236,6 +237,12 @@ void F_DrawUnderwater(void)
   switch (finalestage)
   {
     case 1:
+      if (menuactive) // Force menu off to avoid bad palette on menu
+      {
+        M_LeaveSetupMenu();
+        M_ClearMenus();
+        S_StartVoidSound(g_sfx_swtchx);
+      }
       V_SetPlayPal(playpal_heretic_e2end);
       V_DrawRawScreen("E2END");
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5998,9 +5998,6 @@ dboolean M_Responder(event_t* ev) {
   if (dsda_InputActivated(dsda_input_screenshot))
     I_QueueScreenshot();
 
-  if (heretic && F_BlockingInput())
-    return false;
-
   if (!menuactive)
   {
     if (M_InactiveMenuResponder(ch, action, ev))

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4589,7 +4589,7 @@ dboolean M_ConsoleOpen(void)
   return menuactive && currentMenu == &dsda_ConsoleDef;
 }
 
-static void M_LeaveSetupMenu(void)
+void M_LeaveSetupMenu(void)
 {
   M_SetSetupMenuItemOn(set_menu_itemon);
   setup_active = false;

--- a/prboom2/src/m_menu.h
+++ b/prboom2/src/m_menu.h
@@ -174,6 +174,8 @@ typedef struct menu_s
 void M_SetupNextMenu(menu_t *menudef);
 void M_DrawDelVerify(void);
 void M_ChangeMessages(void);
+void M_LeaveSetupMenu(void);
+void M_ClearMenus(void);
 
 extern dboolean delete_verify;
 


### PR DESCRIPTION
Ok, so this is going to require a bit of background to explain what this issue is, and why it was an issue.

So there was some special logic added for the Heretic End Screens pertaining to E2's graphic. The reason for this is because Heretic E2's graphic is unique in that it uses a completely different palette. A sort of fix was implemented to avoid the player bringing up the menu during this screen... Since if they did, the menu would look really messed up as it would try and use the E2 end screen palette.

For E2, this worked fine... However it caused an issue with all the other end screens... Essentially what would happen is that if the player ended an episode other than E2, waited til the graphic to show after the text crawl, and then chose another episode, they would be unable to bring up the menu and press many of the keys when starting the new episode... Aka ESC and the F# keys would do nothing.

The culprit here was the line in `M_Responder()` function, as removing that fixed the issue. I had to rearrange a few things in the Heretic `f_finale.c` to get it to work the same... But now when starting a new episode after an episode end screen, it no longer blocks the player from accessing the menu and a bunch of other inputs.

The second commit is probably unneeded for DSDA-Doom, but it is a fix I had to add to Nyan Doom, as Nyan has an "Vanilla" option to allow for text screens and demos to play under the menu... And so to avoid weird palette issues, I had to force the menu to exit if it was up.