### PR TITLE
Skip reading SMMU swirling flats

### DIFF
--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -247,11 +247,14 @@ void P_InitPicAnims (void)
     lastanim->istexture = animdefs[i].istexture;
     lastanim->numpics = lastanim->picnum - lastanim->basepic + 1;
 
-    if (lastanim->numpics < 2)
-        I_Error ("P_InitPicAnims: bad cycle from %s to %s",
-                  animdefs[i].startname,
-                  animdefs[i].endname);
-
+    // [crispy] skip reading SMMU swirling flats
+    if (lastanim->speed < 65536 && lastanim->numpics != 1)
+    { 
+      if (lastanim->numpics < 2)
+          I_Error ("P_InitPicAnims: bad cycle from %s to %s",
+                    animdefs[i].startname,
+                    animdefs[i].endname);
+    }
     lastanim->speed = LittleLong(animdefs[i].speed); // killough 5/5/98: add LONG()
     lastanim++;
   }


### PR DESCRIPTION
This fixes WADs with ANIMATED lumps that use SMMU swirling flats.

Fixes "Quoth the Raven":
https://www.doomworld.com/idgames/levels/heretic/Ports/puss28_qtr

Note that this doesn't add support for SMMU swirling flats. That would require more work, as well as finding some kind of solution for OpenGL.

All this PR does is skip over swirling flat definitions in ANIMATED, avoiding a hard crash.