### PR TITLE
Saves menus improvements

### DIFF
--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -600,7 +600,7 @@ extern char savegamestrings[10][SAVESTRINGSIZE];
 static void MN_DrawFileSlots(int x, int y)
 {
   int i;
-  extern char save_page_string[];
+  extern const char *saves_pages[];
 
   for (i = 0; i < g_menu_save_page_size; i++)
   {
@@ -609,7 +609,7 @@ static void MN_DrawFileSlots(int x, int y)
     y += ITEM_HEIGHT;
   }
 
-  MN_DrTextA(save_page_string, x + 5, y + 5);
+  M_DrawTabs(saves_pages, 5, 135);
 }
 
 void MN_DrawLoad(void)

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -784,7 +784,9 @@ enum
   load_end
 } load_e;
 
-int current_save_page = 1; // 0 is the quicksaves page
+static int current_save_page = 1; // 0 is the quicksaves page
+static int current_save_item = 0;
+
 const int save_page_limit = 17;
 const char *saves_pages[] =
 {
@@ -847,6 +849,7 @@ static void M_DrawLoad(void)
 {
   int i;
   current_save_page = current_page;
+  current_save_item = itemOn;
 
   if (raven) return MN_DrawLoad();
 
@@ -945,6 +948,7 @@ void M_LoadGame (int choice)
 
   M_SetupNextMenu(&LoadDef);
   current_page = current_save_page;
+  itemOn = current_save_item;
   M_ReadSaveStrings();
 }
 
@@ -1087,6 +1091,7 @@ static void M_DrawSave(void)
 {
   int i;
   current_save_page = current_page;
+  current_save_item = itemOn;
 
   if (raven) return MN_DrawSave();
 
@@ -1179,6 +1184,7 @@ void M_SaveGame (int choice)
 
   M_SetupNextMenu(&SaveDef);
   current_page = current_save_page;
+  itemOn = current_save_item;
   M_ReadSaveStrings();
 }
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -235,6 +235,9 @@ extern menu_t InfoDef1;
 extern menu_t InfoDef4;
 extern menuitem_t InfoMenu4[];
 
+static int current_page;
+static int previous_page;
+
 //
 // PROTOTYPES
 //
@@ -780,11 +783,16 @@ enum
   load_end
 } load_e;
 
-static int save_page = 0;
-static const int save_page_limit = 16;
+const int save_page_limit = 16;
 
-#define SAVE_PAGE_STRING_SIZE 16
-char save_page_string[SAVE_PAGE_STRING_SIZE];
+const char *saves_pages[] =
+{
+  "1", "2", "3",
+  "4", "5", "6", "7",
+  "8", "9", "10", "11",
+  "12", "13", "14", "15",
+  "16", NULL
+};
 
 // The definitions of the Load Game screen
 
@@ -823,7 +831,7 @@ static void M_DeleteGame(int slot)
   if (dsda_LastSaveSlot() == slot)
     dsda_ResetLastSaveSlot();
 
-  name = dsda_SaveGameName(slot + save_page * g_menu_save_page_size, false);
+  name = dsda_SaveGameName(slot + current_page * g_menu_save_page_size, false);
   remove(name);
   Z_Free(name);
 
@@ -848,7 +856,7 @@ static void M_DrawLoad(void)
     M_WriteText(LoadDef.x,LoadDef.y+LINEHEIGHT*i,savegamestrings[i], CR_DEFAULT);
   }
 
-  M_WriteText(LoadDef.x, LoadDef.y + LINEHEIGHT * load_end, save_page_string, CR_DEFAULT);
+  M_DrawTabs(saves_pages, 5, 145);
 
   if (delete_verify)
     M_DrawDelVerify();
@@ -879,7 +887,7 @@ static void M_DrawSaveLoadBorder(int x,int y)
 
 void M_LoadSelect(int choice)
 {
-  if (!dsda_AllowMenuLoad(choice + save_page * g_menu_save_page_size))
+  if (!dsda_AllowMenuLoad(choice + current_page * g_menu_save_page_size))
   {
     M_StartMessage(
       "you can't load this game\n"
@@ -892,7 +900,7 @@ void M_LoadSelect(int choice)
   //  to g_game.c, this only passes the slot.
 
   // killough 3/16/98, 5/15/98: add slot, cmd
-  G_LoadGame(choice + save_page * g_menu_save_page_size);
+  G_LoadGame(choice + current_page * g_menu_save_page_size);
   M_ClearMenus();
 }
 
@@ -979,7 +987,7 @@ static void M_ReadSaveStrings(void)
     FILE *fp;  // killough 11/98: change to use stdio
 
     // killough 3/22/98
-    name = dsda_SaveGameName(i + save_page * g_menu_save_page_size, false);
+    name = dsda_SaveGameName(i + current_page * g_menu_save_page_size, false);
 
     fp = M_OpenFile(name,"rb");
     Z_Free(name);
@@ -999,8 +1007,6 @@ static void M_ReadSaveStrings(void)
       fclose(fp);
     }
   }
-
-  snprintf(save_page_string, SAVE_PAGE_STRING_SIZE, "PAGE %d/%d", save_page + 1, save_page_limit);
 }
 
 #define SLOT_SCAN_MAX 112
@@ -1083,7 +1089,7 @@ static void M_DrawSave(void)
     M_WriteText(LoadDef.x,LoadDef.y+LINEHEIGHT*i,savegamestrings[i], CR_DEFAULT);
     }
 
-  M_WriteText(LoadDef.x, LoadDef.y + LINEHEIGHT * load_end, save_page_string, CR_DEFAULT);
+  M_DrawTabs(saves_pages, 5, 145);
 
   if (saveStringEnter)
     {
@@ -1100,7 +1106,7 @@ static void M_DrawSave(void)
 //
 static void M_DoSave(int slot)
 {
-  G_SaveGame(slot + save_page * g_menu_save_page_size, savegamestrings[slot]);
+  G_SaveGame(slot + current_page * g_menu_save_page_size, savegamestrings[slot]);
   M_ClearMenus();
 }
 
@@ -1576,8 +1582,6 @@ static void M_SizeDisplay(int choice)
 
 static int set_menu_itemon; // which setup item is selected?   // phares 3/98
 static setup_menu_t* current_setup_menu; // points to current setup menu table
-static int current_page;
-static int previous_page;
 
 // save the setup menu's itemon value in the S_END element's x coordinate
 
@@ -2157,35 +2161,32 @@ static void M_DrawScreenItems(const setup_menu_t* base_src, int base_y)
   }
 }
 
-// Draws the name of each page. If there are more than 5, uses a carousel
-static void M_DrawTabs(const char **pages)
+// Draws the name of each page. If there are more than m, uses a carousel
+void M_DrawTabs(const char **pages, int m, int y)
 {
   int x = 0;
   int w = 0;
   int i = 0;
   int start_i = 0;
-  int end_i = 4;
+  int end_i = m - 1;
+  int s = (m / 2); // halfway point
 
   // Figure out what tabs should be drawn if using carousel
-  if (current_page > 2)
+  if (current_page > s)
   {
-    if (previous_page < current_page)
-    {
-      start_i = current_page - 2;
-      end_i = current_page + 2;
-    }
-    else if (previous_page > current_page)
-    {
-      start_i = current_page - 2;
-      end_i = current_page + 2;
-    }
+    while (pages[current_page + i] != NULL)
+      i++;
 
-    if (pages[current_page + 1] == NULL)
-      start_i = current_page - 4;
-    else if (pages[current_page + 2] == NULL)
-      start_i = current_page - 3;
-
-    if (start_i < 0) start_i = 0;
+    if (i <= s)
+    {
+      start_i = current_page + i - m;
+      end_i = current_page + i;
+    }
+    else
+    {
+        start_i = current_page - s;
+        end_i = current_page + s;
+    }
   }
 
   // Find the initial offset to center text
@@ -2198,14 +2199,14 @@ static void M_DrawTabs(const char **pages)
 
   // Draw the arrows on the sides
   if (start_i > 0)
-    M_DrawString(x -  M_GetPixelWidth("<-") - 1, TABS_Y , cr_tab, "<-");
+    M_DrawString(x - M_GetPixelWidth("<-") - 2, y , cr_tab, "<-");
   if (pages[i] != NULL)
-    M_DrawString(320 - x, TABS_Y , cr_tab, "->");
+    M_DrawString(320 - x + 2, y , cr_tab, "->");
 
   // Draw the page names
   for (i = start_i; (i <= end_i && pages[i] != NULL); i++)
   {
-    M_DrawString(x, TABS_Y,i == current_page ? cr_tab_highlight: cr_tab, pages[i]);
+    M_DrawString(x, y,i == current_page ? cr_tab_highlight: cr_tab, pages[i]);
 
     w = M_GetPixelWidth(pages[i]);
     x += w + 6;
@@ -2316,8 +2317,6 @@ static void M_EnterSetup(menu_t *menu, dboolean *setup_flag, setup_menu_t *setup
   setup_select = false;
   colorbox_active = false;
   setup_gather = false;
-  current_page = 0;
-  previous_page = 0;
 
   M_UpdateSetupMenu(setup_menu);
 }
@@ -2720,7 +2719,7 @@ static void M_DrawKeybnd(void)
   // proff/nicolas 09/20/98 -- changed for hi-res
   M_DrawTitle(2, "KEY BINDINGS", cr_title); // M_KEYBND
   M_DrawInstructions();
-  M_DrawTabs(keys_pages);
+  M_DrawTabs(keys_pages, 5, TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -2792,7 +2791,7 @@ static void M_DrawWeapons(void)
   // proff/nicolas 09/20/98 -- changed for hi-res
   M_DrawTitle(2, "WEAPONS", cr_title); // M_WEAP
   M_DrawInstructions();
-  M_DrawTabs(weap_pages);
+  M_DrawTabs(weap_pages, sizeof(weap_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -2877,7 +2876,7 @@ static void M_DrawDemos(void)
   // proff/nicolas 09/20/98 -- changed for hi-res
   M_DrawTitle(2, "DEMOS", cr_title); // M_DEMOS
   M_DrawInstructions();
-  M_DrawTabs(demos_pages);
+  M_DrawTabs(demos_pages, sizeof(demos_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -3053,7 +3052,7 @@ static void M_DrawAutoMap(void)
   // CPhipps - patch drawing updated
   M_DrawTitle(2, "AUTOMAP", cr_title); // M_AUTO
   M_DrawInstructions();
-  M_DrawTabs(auto_pages);
+  M_DrawTabs(auto_pages, sizeof(auto_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 
   // If a color is being selected, need to show color paint chips
@@ -3302,7 +3301,7 @@ static void M_DrawGeneral(void)
   // proff/nicolas 09/20/98 -- changed for hi-res
   M_DrawTitle(2, "GENERAL", cr_title); // M_GENERL
   M_DrawInstructions();
-  M_DrawTabs(gen_pages);
+  M_DrawTabs(gen_pages, sizeof(gen_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -3421,7 +3420,7 @@ static void M_DrawDisplay(void)
 
   M_DrawTitle(2, "DISPLAY", cr_title); // M_DSPLAY
   M_DrawInstructions();
-  M_DrawTabs(display_pages);
+  M_DrawTabs(display_pages, sizeof(display_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -3489,7 +3488,7 @@ static void M_DrawCompatibility(void)
 
   M_DrawTitle(2, "COMPATIBILITY", cr_title); // M_COMP
   M_DrawInstructions();
-  M_DrawTabs(comp_pages);
+  M_DrawTabs(comp_pages, sizeof(comp_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -4022,7 +4021,7 @@ static void M_DrawLevelTable(void)
   if (current_setup_menu != level_table_page[wad_stats_summary_page])
     M_DrawInstructionString(cr_info_edit, "Press ENTER key to warp");
 
-  M_DrawTabs(level_table_pages);
+  M_DrawTabs(level_table_pages, sizeof(level_table_pages), TABS_Y);
   M_DrawScreenItems(current_setup_menu, DEFAULT_LIST_Y);
 }
 
@@ -5842,11 +5841,11 @@ static dboolean M_SaveResponder(int ch, int action, event_t* ev)
 
     if (diff)
     {
-      save_page += diff;
-      if (save_page < 0)
-        save_page = save_page_limit - 1;
-      else if (save_page >= save_page_limit)
-        save_page = 0;
+      current_page += diff;
+      if (current_page < 0)
+        current_page = save_page_limit - 1;
+      else if (current_page >= save_page_limit)
+        current_page = 0;
 
       M_ReadSaveStrings();
     }
@@ -6295,6 +6294,9 @@ void M_SetupNextMenu(menu_t *menudef)
   itemOn = currentMenu->lastOn;
 
   BorderNeedRefresh = true;
+
+  current_page = 0;
+  previous_page = 0;
 }
 
 /////////////////////////////

--- a/prboom2/src/m_menu.h
+++ b/prboom2/src/m_menu.h
@@ -81,6 +81,8 @@ void M_ResetMenu(void);      // killough 11/98: reset main menu ordering
 
 void M_DrawCredits(void);    // killough 11/98
 
+void M_DrawTabs(const char **pages, int m, int y);
+
 /****************************
  *
  * The setup_group enum is used to show which 'groups' keys fall into so


### PR DESCRIPTION
- [x] Reserves a page just for quicksaves, instead of just 1 slot https://github.com/kraflab/dsda-doom/issues/626
- [x] Adds tabs to the Load and Save menus

Ideas for the future:
- Description and screenshot of each save, like in gzdoom and woof