### PR TITLE
Port level brightness adjustment slider from Woof!

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1576,6 +1576,10 @@ int dsda_TransientIntConfig(dsda_config_identifier_t id) {
   return dsda_config[id].transient_value.v_int;
 }
 
+int dsda_UpperLimitConfig(dsda_config_identifier_t id) {
+  return dsda_config[id].upper_limit;
+}
+
 const char* dsda_StringConfig(dsda_config_identifier_t id) {
   return dsda_config[id].transient_value.v_string;
 }

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1312,6 +1312,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "announce_map", dsda_config_announce_map,
     CONF_BOOL(0),
   },
+  [dsda_config_extra_level_brightness] = {
+    "extra_level_brightness", dsda_config_extra_level_brightness,
+    dsda_config_int, 0, 4, {0}, NULL, STRICT_INT(0)
+  },
 };
 
 static void dsda_PersistIntConfig(dsda_config_t* conf) {

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1576,10 +1576,6 @@ int dsda_TransientIntConfig(dsda_config_identifier_t id) {
   return dsda_config[id].transient_value.v_int;
 }
 
-int dsda_UpperLimitConfig(dsda_config_identifier_t id) {
-  return dsda_config[id].upper_limit;
-}
-
 const char* dsda_StringConfig(dsda_config_identifier_t id) {
   return dsda_config[id].transient_value.v_string;
 }

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -295,6 +295,7 @@ typedef enum {
   dsda_config_ansi_endoom,
   dsda_config_quit_sounds,
   dsda_config_announce_map,
+  dsda_config_extra_level_brightness,
   dsda_config_count,
 } dsda_config_identifier_t;
 

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -321,7 +321,6 @@ int dsda_UpdateIntConfig(dsda_config_identifier_t id, int value, dboolean persis
 const char* dsda_UpdateStringConfig(dsda_config_identifier_t id, const char* value, dboolean persist);
 int dsda_IntConfig(dsda_config_identifier_t id);
 int dsda_TransientIntConfig(dsda_config_identifier_t id);
-int dsda_UpperLimitConfig(dsda_config_identifier_t id);
 const char* dsda_StringConfig(dsda_config_identifier_t id);
 char* dsda_ConfigSummary(const char* name);
 int dsda_ConfigIDByName(const char* name);

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -321,6 +321,7 @@ int dsda_UpdateIntConfig(dsda_config_identifier_t id, int value, dboolean persis
 const char* dsda_UpdateStringConfig(dsda_config_identifier_t id, const char* value, dboolean persist);
 int dsda_IntConfig(dsda_config_identifier_t id);
 int dsda_TransientIntConfig(dsda_config_identifier_t id);
+int dsda_UpperLimitConfig(dsda_config_identifier_t id);
 const char* dsda_StringConfig(dsda_config_identifier_t id);
 char* dsda_ConfigSummary(const char* name);
 int dsda_ConfigIDByName(const char* name);

--- a/prboom2/src/dsda/features.c
+++ b/prboom2/src/dsda/features.c
@@ -33,6 +33,7 @@ static const char* feature_names[FEATURE_SIZE] = {
   [uf_quickstartcache] = "Quickstart Cache",
   [uf_100k] = "100K Tracker",
   [uf_console] = "Console",
+  [uf_levelbrightness] = "Extra Lighting",
 
   [uf_iddt] = "IDDT",
   [uf_automap] = "IDBEHOLD Map",

--- a/prboom2/src/dsda/features.h
+++ b/prboom2/src/dsda/features.h
@@ -25,7 +25,7 @@ typedef enum {
   uf_quickstartcache,
   uf_100k,
   uf_console,
-  uf_levelbrightness,
+  // 7
   // 8
   // 9
   // 10
@@ -87,7 +87,8 @@ typedef enum {
   // uf_fuzz = 64
   uf_vanillatrans = 65,
   uf_ghosttrans,
-  // 67
+  uf_levelbrightness,
+  // 68
 
   // 127
 } dsda_feature_flag_t;

--- a/prboom2/src/dsda/features.h
+++ b/prboom2/src/dsda/features.h
@@ -25,7 +25,7 @@ typedef enum {
   uf_quickstartcache,
   uf_100k,
   uf_console,
-  // 7
+  uf_levelbrightness,
   // 8
   // 9
   // 10

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2040,7 +2040,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
   }
 
   if (flags & S_THERMO) {
-    M_DrawThermo(x, y, 8, dsda_UpperLimitConfig(s->config_id) + 1, dsda_IntConfig(s->config_id));
+    M_DrawThermo(x, y, 8, 16, dsda_IntConfig(s->config_id));
 
     sprintf(menu_buffer, "%d", dsda_IntConfig(s->config_id));
 
@@ -3159,7 +3159,6 @@ setup_menu_t gen_video_settings[] = {
   EMPTY_LINE,
   { "Fake Contrast", S_CHOICE, m_conf, G_X, dsda_config_fake_contrast_mode, 0, fake_contrast_list },
   { "OpenGL Light Fade", S_CHOICE, m_conf, G_X, dsda_config_gl_fade_mode, 0, gl_fade_mode_list },
-  { "Extra Lighting", S_THERMO, m_conf, G_X, dsda_config_extra_level_brightness },
 
   NEXT_PAGE(gen_audio_settings),
   FINAL_ENTRY

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3159,6 +3159,7 @@ setup_menu_t gen_video_settings[] = {
   EMPTY_LINE,
   { "Fake Contrast", S_CHOICE, m_conf, G_X, dsda_config_fake_contrast_mode, 0, fake_contrast_list },
   { "OpenGL Light Fade", S_CHOICE, m_conf, G_X, dsda_config_gl_fade_mode, 0, gl_fade_mode_list },
+  { "Extra Lighting", S_THERMO, m_conf, G_X, dsda_config_extra_level_brightness },
 
   NEXT_PAGE(gen_audio_settings),
   FINAL_ENTRY

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2040,7 +2040,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
   }
 
   if (flags & S_THERMO) {
-    M_DrawThermo(x, y, 8, 16, dsda_IntConfig(s->config_id));
+    M_DrawThermo(x, y, 8, dsda_UpperLimitConfig(s->config_id) + 1, dsda_IntConfig(s->config_id));
 
     sprintf(menu_buffer, "%d", dsda_IntConfig(s->config_id));
 

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -170,6 +170,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_render_linearsky),
   MIGRATED_SETTING(dsda_config_aspect_ratio_correction),
   MIGRATED_SETTING(dsda_config_freelook),
+  MIGRATED_SETTING(dsda_config_extra_level_brightness),
 
   SETTING_HEADING("OpenGL settings"),
   MIGRATED_SETTING(dsda_config_gl_render_multisampling),

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -931,6 +931,11 @@ static void R_SetupFrame (player_t *player)
   viewplayer = player;
 
   extralight = player->extralight;
+  int extra_brightness = dsda_IntConfig(dsda_config_extra_level_brightness);
+  if (extra_brightness < 0 || extra_brightness > 4) {
+    extra_brightness = 0;
+  }
+  extralight += extra_brightness;
 
   viewsin = finesine[viewangle>>ANGLETOFINESHIFT];
   viewcos = finecosine[viewangle>>ANGLETOFINESHIFT];

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -63,6 +63,7 @@
 
 #include "dsda/configuration.h"
 #include "dsda/exhud.h"
+#include "dsda/features.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
 #include "dsda/render_stats.h"
@@ -934,6 +935,9 @@ static void R_SetupFrame (player_t *player)
   int extra_brightness = dsda_IntConfig(dsda_config_extra_level_brightness);
   if (extra_brightness < 0 || extra_brightness > 4) {
     extra_brightness = 0;
+  }
+  if (extra_brightness != 0) {
+      dsda_TrackFeature(uf_levelbrightness);
   }
   extralight += extra_brightness;
 


### PR DESCRIPTION
Woof! has a feature to raise the brightness of the lighting in a map (different from gamma adjustment) (https://github.com/fabiangreffrath/woof/pull/778). I find this useful for combating mild monitor glare, and so I've attempted to port it to DSDA-Doom.

The setting is not available in Woof! when strict mode is enabled, and I've kept that restriction here (though I personally don't see any harm in allowing it). The tweaks to the S_THERMO call are to scale the widget's central bar position according to the max setting value.

I know this port can have a skeptical view of certain kinds of "enhancements", so if this feature is not wanted, I will keep it in my own forked repo instead.
