### PR TITLE
Add Automap Title / Author Cycle

### DIFF
--- a/docs/hud.md
+++ b/docs/hud.md
@@ -114,6 +114,8 @@ Unless otherwise specified, argument values are integers. For toggles, a 1 means
   - Uses the message font
 - `map_title`: shows the current map's title
   - Uses the message font
+  - Supports 1 argument: `cycle_author`
+  - `cycle_author`: cycles between map title and author on automap
 - `message`: shows the current player message
   - Uses the message font
   - Supports 1 argument: `center`

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1057,6 +1057,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "map_title", dsda_config_map_title,
     CONF_BOOL(1), NULL, NOT_STRICT, dsda_RefreshMapTitle
   },
+  [dsda_config_map_title_author_cycle] = {
+    "map_title_author_cycle", dsda_config_map_title_author_cycle,
+    CONF_BOOL(1), NULL, NOT_STRICT
+  },
   [dsda_config_map_trail] = {
     "map_trail", dsda_config_map_trail,
     CONF_BOOL(0), NULL, STRICT_INT(0), AM_initPlayerTrail

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -233,6 +233,7 @@ typedef enum {
   dsda_config_map_totals,
   dsda_config_map_time,
   dsda_config_map_title,
+  dsda_config_map_title_author_cycle,
   dsda_config_map_trail,
   dsda_config_map_trail_collisions,
   dsda_config_map_trail_size,

--- a/prboom2/src/dsda/hud_components/map_title.c
+++ b/prboom2/src/dsda/hud_components/map_title.c
@@ -19,27 +19,70 @@
 
 #include "map_title.h"
 
+extern dsda_string_t hud_title_cycle;
+extern dsda_string_t hud_title;
+extern dsda_string_t hud_author;
+
 typedef struct {
   dsda_text_t component;
+  dboolean cycle_author;
 } local_component_t;
 
 static local_component_t* local;
 
+int titleTime = 3 * TICRATE;
+short titleCounter;
+short titleSwap;
+
+void dsda_UpdateTitleSwap(void)
+{
+  // Reset / init counter
+  if (hud_title_cycle.string == NULL)
+  {
+    titleSwap = 0;
+    titleCounter = titleTime;  
+    dsda_StringPrintF(&hud_title_cycle, hud_title.string);
+  }
+
+  // Restart counter + init swap 
+  if (--titleCounter <= 0)
+  {
+    titleSwap ^= 1;
+    titleCounter = titleTime;
+  }
+
+  // Swap title to map or author
+  if (titleCounter == titleTime)
+  {
+    if (titleSwap)
+      dsda_StringPrintF(&hud_title_cycle, "Author: %s", hud_author.string);
+    else
+      dsda_StringPrintF(&hud_title_cycle, hud_title.string);
+  }
+}
+
+
 static void dsda_UpdateComponentText(char* str, size_t max_size) {
-  extern dsda_string_t hud_title;
+  dboolean cycle_title_active = (hud_author.string != NULL) &&
+                                (local->cycle_author || dsda_IntConfig(dsda_config_map_title_author_cycle));
+
+  if (cycle_title_active)
+    dsda_UpdateTitleSwap();
 
   snprintf(
     str,
     max_size,
     "%s%s",
     dsda_TextColor(dsda_tc_map_title),
-    hud_title.string
+    cycle_title_active ? hud_title_cycle.string : hud_title.string
   );
 }
 
 void dsda_InitMapTitleHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
   *data = Z_Calloc(1, sizeof(local_component_t));
   local = *data;
+
+  local->cycle_author = arg_count > 0 ? !!args[0] : false;
 
   dsda_InitBlockyHC(&local->component, x_offset, y_offset, vpt);
 }

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -94,6 +94,7 @@ void HU_InitThresholds(void)
 }
 
 dsda_string_t hud_title;
+dsda_string_t hud_title_cycle;
 
 static void HU_FetchTitle(void)
 {
@@ -101,6 +102,19 @@ static void HU_FetchTitle(void)
     dsda_FreeString(&hud_title);
 
   dsda_HUTitle(&hud_title);
+}
+
+dsda_string_t hud_author;
+
+static void HU_FetchAuthor(void)
+{
+  const char* author = dsda_MapAuthor();
+
+  if (hud_author.string)
+    dsda_FreeString(&hud_author);
+
+  if (author && author[0])
+    dsda_StringPrintF(&hud_author, author);
 }
 
 static void HU_InitMessages(void)
@@ -310,17 +324,15 @@ void HU_AnnounceMap(void)
 
     if (gamemap != last_gamemap || gameepisode != last_gameepisode)
     {
-      const char *author;
 
       last_gamemap = gamemap;
       last_gameepisode = gameepisode;
 
-      author = dsda_MapAuthor();
-      if (author && author[0])
+      if (hud_author.string)
       {
         dsda_string_t message;
 
-        dsda_StringPrintF(&message, "%s by %s", hud_title.string, author);
+        dsda_StringPrintF(&message, "%s by %s", hud_title.string, hud_author.string);
         dsda_AddAlert(message.string);
         dsda_FreeString(&message);
       }
@@ -348,6 +360,7 @@ void HU_Start(void)
   HU_InitPlayer();
   HU_InitMessages();
   HU_FetchTitle();
+  HU_FetchAuthor();
   HU_InitCrosshair();
 
   dsda_InitExHud();
@@ -421,6 +434,12 @@ void HU_Ticker(void)
     {
       S_StartVoidSound(custom_message_p->sfx);
     }
+  }
+
+  // Reset map/author cycle when leaving automap
+  if (hud_title_cycle.string && !automap_active)
+  {
+    dsda_FreeString(&hud_title_cycle);
   }
 
   dsda_UpdateExHud();

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -243,6 +243,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_map_totals),
   MIGRATED_SETTING(dsda_config_map_time),
   MIGRATED_SETTING(dsda_config_map_title),
+  MIGRATED_SETTING(dsda_config_map_title_author_cycle),
   MIGRATED_SETTING(dsda_config_map_trail),
   MIGRATED_SETTING(dsda_config_map_trail_collisions),
   MIGRATED_SETTING(dsda_config_map_trail_size),


### PR DESCRIPTION
Here's a feature I've been working on for a while...

The idea was that the "author" field of UMAPINFO or MAPINFO is not used very much, so what if the automap title cycled between the map name and the author (if the author field was found).

Yes, it may be a good idea to add a dedicated "author" field to DSDAHUD, but I probably wouldn't use it personally since it would take more screen real estate.

I've added both a DSDAHUD parameter and a config option. (I personally don't like having DSDAHUD parameters... Right now I've included a config option for easy testing, altho I didn't include a menu option cuz PBeGood doesn't like those :P ).

The swap transition is a bit abrupt at the moment, but it's a little tricky to implement a true transition since DSDAHUD doesn't currently 1) have translucency functionality yet and 2) we don't really have any precedent for fancy transitions.

In this implementation I haven't added an option to customise the speed of the "title swap", but it could probably be done via the `titleTime` variable if need be. I just worry adding that feature would be extraneous... In my opinion we should pick a speed that's generally good for the default.

I currently have the swap setup only to happen when the automap is active.

A good wad to test this functionality would be [Plutonic Visions](https://www.doomworld.com/idgames/levels/doom2/megawads/plutonic). Just warp to map04, enable the automap, and you'll see the feature in action.