### PR TITLE
Remove Menu Fade Overlay from Sound Volume Menu

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -6074,7 +6074,7 @@ dboolean fadeBG(void)
 
 dboolean M_MenuIsShaded(void)
 {
-  int Options = (setup_active || currentMenu == &OptionsDef || currentMenu == &SoundDef);
+  int Options = (setup_active || currentMenu == &OptionsDef);
   return fadeBG() && Options;
 }
 


### PR DESCRIPTION
So when I first added the fade overlay to the menus, the "Sound Volume" menu was in the main options. Since the main options had a fade, it felt weird not to also have it on the "Sound Volume"...

However now that the "Sound Volume" menu is only accessible via F4, I think the fade should be removed to be consistent with the "Save Game" and "Load Game" menus.