### PR TITLE
Remove Stbar "hiding" Logic on full menus

### DIFF
--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -536,9 +536,9 @@ static int oldmana1 = -1;
 static int oldmana2 = -1;
 static int oldpieces = -1;
 
-void SB_Drawer(dboolean statusbaron, dboolean refresh, dboolean fullmenu)
+void SB_Drawer(dboolean statusbaron, dboolean refresh)
 {
-    if (refresh || fullmenu || fadeBG() || V_IsOpenGLMode()) SB_state = -1;
+    if (refresh || fadeBG() || V_IsOpenGLMode()) SB_state = -1;
 
     if (!statusbaron)
     {

--- a/prboom2/src/heretic/sb_bar.h
+++ b/prboom2/src/heretic/sb_bar.h
@@ -34,7 +34,7 @@
 void SB_Start(void);
 void SB_Init(void);
 void SB_Ticker(void);
-void SB_Drawer(dboolean statusbaron, dboolean refresh, dboolean fullmenu);
+void SB_Drawer(dboolean statusbaron, dboolean refresh);
 void SB_PaletteFlash(dboolean forceChange);
 
 // hexen

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -364,10 +364,6 @@ void HU_Start(void)
 //
 void HU_Drawer(void)
 {
-  // don't draw anything if there's a fullscreen menu up
-  if (menuactive == mnact_full && !M_MenuIsShaded())
-    return;
-
   V_BeginUIDraw();
 
   HU_DrawCrosshair();

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -905,13 +905,12 @@ void ST_Refresh(void)
 void ST_Drawer(dboolean refresh)
 {
   dboolean statusbaron = R_StatusBarVisible();
-  dboolean fullmenu = (menuactive == mnact_full) && !M_MenuIsShaded();
 
   V_BeginUIDraw();
 
   if (raven)
   {
-    SB_Drawer(statusbaron, refresh, fullmenu);
+    SB_Drawer(statusbaron, refresh);
     V_EndUIDraw();
     return;
   }
@@ -920,7 +919,7 @@ void ST_Drawer(dboolean refresh)
    * completely by the call from D_Display
    * proff - really do it
    */
-  st_firsttime = st_firsttime || refresh || fullmenu;
+  st_firsttime = st_firsttime || refresh;
 
   ST_doPaletteStuff();  // Do red-/gold-shifts from damage/items
 
@@ -930,14 +929,12 @@ void ST_Drawer(dboolean refresh)
       /* If just after ST_Start(), refresh all */
       st_firsttime = false;
       ST_refreshBackground(); // draw status bar background to off-screen buff
-      if (!fullmenu)
-        ST_drawWidgets(true); // and refresh all widgets
+      ST_drawWidgets(true); // and refresh all widgets
     }
     else
     {
       /* Otherwise, update as little as possible */
-      if (!fullmenu)
-        ST_drawWidgets(false); // update all widgets
+      ST_drawWidgets(false); // update all widgets
     }
   }
 


### PR DESCRIPTION
This feature was requested by @Pedro-Beirao .

Currently when "menu background" is set to off, when entering a "fullmenu" after the main options menu, certain elements of the statusbar will hide themselves (stuff like the doomguy mug, numbers, and the extended hud). I'm guessing this was for readability reasons?

This PR cuts out that "hiding" logic, and always shows the statusbar as the player would expect. I guess the idea here is that most players will want to use "dark" or "texture" anyway, plus Woof doesn't seem to use this logic anyway.

I think it actually may still be a good idea to still hide the extended hud elements in this state (see `hu_stuff.c`), as I can see having the "coordinate display" making it pretty messy to read the menus.