### PR TITLE
OpenGL fixes for both dark overlay and statusbar background color

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -526,10 +526,10 @@ void D_Display (fixed_t frac)
     D_DrawPause();
   }
 
-  V_BeginUIDraw();
+  V_BeginMenuDraw();
   if (M_MenuIsShaded())
     M_ShadedScreen(0);
-  V_EndUIDraw();
+  V_EndMenuDraw();
 
   // menus go directly to the screen
   M_Drawer();          // menu is drawn even on top of everything

--- a/prboom2/src/gl_light.c
+++ b/prboom2/src/gl_light.c
@@ -51,6 +51,7 @@
 
 dboolean gl_ui_lightmode_indexed = false;
 dboolean gl_automap_lightmode_indexed = false;
+dboolean gl_menu_lightmode_indexed = false;
 
 static float lighttable[5][256];
 

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -490,6 +490,19 @@ void gld_EndAutomapDraw(void)
   glsl_PopNullShader();
 }
 
+void gld_BeginMenuDraw(void)
+{
+  gld_InitColormapTextures(true);
+  glsl_PushNullShader();
+  gl_menu_lightmode_indexed = true;
+}
+
+void gld_EndMenuDraw(void)
+{
+  gl_menu_lightmode_indexed = false;
+  glsl_PopNullShader();
+}
+
 void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translation_e flags)
 {
   GLTexture *gltexture;
@@ -666,7 +679,7 @@ void gld_FillPatch(int lump, int x, int y, int width, int height, enum patch_tra
 // use colormaps[0] as a fallback in such a case.
 const lighttable_t *gld_GetActiveColormap()
 {
-  if (V_IsAutomapLightmodeIndexed())
+  if (V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed())
     return colormaps[0];
   else if (fixedcolormap)
     return fixedcolormap;
@@ -718,7 +731,7 @@ void gld_DrawLine_f(float x0, float y0, float x1, float y1, int BaseColor)
   if (a == 0)
     return;
 
-  color = gld_LookupIndexedColor(BaseColor, V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed());
+  color = gld_LookupIndexedColor(BaseColor, V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed());
 
   line = M_ArrayGetNewItem(&map_lines, sizeof(line[0]));
 
@@ -826,7 +839,7 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
 
 void gld_FillBlock(int x, int y, int width, int height, int col)
 {
-  color_rgb_t color = gld_LookupIndexedColor(col, V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed());
+  color_rgb_t color = gld_LookupIndexedColor(col, V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed());
 
   glsl_PushNullShader();
 
@@ -850,12 +863,7 @@ void gld_FillBlock(int x, int y, int width, int height, int col)
 
 void gld_DrawShaded(int x, int y, int width, int height, int shade)
 {
-  // This is more messy than I'd like. (I hate this, but this is my current fix for the menu overlay invert)
-  // The `col` fixes the menu overlay from inverting during `invul_cm`.
-  // The 'automap` boolean is to undo the `col` invert for the automap.
-  dboolean automap = V_IsAutomapLightmodeIndexed();
-  int col = invul_cm && !automap ? 256 : 0;
-  color_rgb_t color = gld_LookupIndexedColor(col, V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed());
+  color_rgb_t color = gld_LookupIndexedColor(playpal_darkest, V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed());
 
   glsl_PushNullShader();
 

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -58,6 +58,7 @@ enum bleedtype {
 extern int gl_drawskys;
 extern dboolean gl_ui_lightmode_indexed;
 extern dboolean gl_automap_lightmode_indexed;
+extern dboolean gl_menu_lightmode_indexed;
 void gld_FlushTextures(void);
 
 void gld_InitVertexData();
@@ -71,6 +72,8 @@ void gld_BeginUIDraw(void);
 void gld_EndUIDraw(void);
 void gld_BeginAutomapDraw(void);
 void gld_EndAutomapDraw(void);
+void gld_BeginMenuDraw(void);
+void gld_EndMenuDraw(void);
 
 void gld_DrawNumPatch(int x, int y, int lump, int cm, enum patch_translation_e flags);
 void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translation_e flags);

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -1430,7 +1430,7 @@ void gld_FlushTextures(void)
   gld_ResetLastTexture();
 
   gld_InitSky();
-  gld_InitColormapTextures(V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed());
+  gld_InitColormapTextures(V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed());
 
   // do not draw anything in current frame after flushing
   gld_ResetDrawInfo();

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -555,8 +555,10 @@ void R_FillBackColor (void)
   col = V_BestColor(playpal, r/3, g/3, b/3);
   col_top = V_BestColor(playpal, r/2, g/2, b/2);
 
+  V_BeginMenuDraw();
   V_FillRect(1, 0, stbar_top, SCREENWIDTH, ST_SCALED_HEIGHT, col);
   V_FillRect(1, 0, stbar_top, SCREENWIDTH, ST_SCALED_BORDER, col_top);
+  V_EndMenuDraw();
  }
 
 //

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -739,6 +739,14 @@ static void WRAP_gld_EndAutomapDraw(void)
 {
   gld_EndAutomapDraw();
 }
+static void WRAP_gld_BeginMenuDraw(void)
+{
+  gld_BeginMenuDraw();
+}
+static void WRAP_gld_EndMenuDraw(void)
+{
+  gld_EndMenuDraw();
+}
 static void WRAP_gld_FillRect(int scrn, int x, int y, int width, int height, byte colour)
 {
   gld_FillBlock(x,y,width,height,colour);
@@ -786,6 +794,8 @@ static void NULL_BeginUIDraw(void) {}
 static void NULL_EndUIDraw(void) {}
 static void NULL_BeginAutomapDraw(void) {}
 static void NULL_EndAutomapDraw(void) {}
+static void NULL_BeginMenuDraw(void) {}
+static void NULL_EndMenuDraw(void) {}
 static void NULL_FillRect(int scrn, int x, int y, int width, int height, byte colour) {}
 static void NULL_CopyRect(int srcscrn, int destscrn, int x, int y, int width, int height, enum patch_translation_e flags) {}
 static void NULL_FillFlat(int lump, int n, int x, int y, int width, int height, enum patch_translation_e flags) {}
@@ -805,6 +815,8 @@ V_BeginUIDraw_f V_BeginUIDraw = NULL_BeginUIDraw;
 V_EndUIDraw_f V_EndUIDraw = NULL_EndUIDraw;
 V_BeginUIDraw_f V_BeginAutomapDraw = NULL_BeginAutomapDraw;
 V_EndUIDraw_f V_EndAutomapDraw = NULL_EndAutomapDraw;
+V_BeginUIDraw_f V_BeginMenuDraw = NULL_BeginMenuDraw;
+V_EndUIDraw_f V_EndMenuDraw = NULL_EndMenuDraw;
 V_CopyRect_f V_CopyRect = NULL_CopyRect;
 V_FillRect_f V_FillRect = NULL_FillRect;
 V_DrawNumPatch_f V_DrawNumPatch = NULL_DrawNumPatch;
@@ -829,6 +841,8 @@ void V_InitMode(video_mode_t mode) {
       V_EndUIDraw = NULL_EndUIDraw; // [XA] ditto for the other begin/ends
       V_BeginAutomapDraw = NULL_BeginAutomapDraw;
       V_EndAutomapDraw = NULL_EndAutomapDraw;
+      V_BeginMenuDraw = NULL_BeginMenuDraw;
+      V_EndMenuDraw = NULL_EndMenuDraw;
       V_CopyRect = FUNC_V_CopyRect;
       V_FillRect = V_FillRect8;
       V_DrawNumPatch = FUNC_V_DrawNumPatch;
@@ -849,6 +863,8 @@ void V_InitMode(video_mode_t mode) {
       V_EndUIDraw = WRAP_gld_EndUIDraw;
       V_BeginAutomapDraw = WRAP_gld_BeginAutomapDraw;
       V_EndAutomapDraw = WRAP_gld_EndAutomapDraw;
+      V_BeginMenuDraw = WRAP_gld_BeginMenuDraw;
+      V_EndMenuDraw = WRAP_gld_EndMenuDraw;
       V_CopyRect = WRAP_gld_CopyRect;
       V_FillRect = WRAP_gld_FillRect;
       V_DrawNumPatch = WRAP_gld_DrawNumPatch;
@@ -880,6 +896,10 @@ dboolean V_IsUILightmodeIndexed(void) {
 
 dboolean V_IsAutomapLightmodeIndexed(void) {
   return gl_automap_lightmode_indexed;
+}
+
+dboolean V_IsMenuLightmodeIndexed(void) {
+  return gl_menu_lightmode_indexed;
 }
 
 void V_CopyScreen(int srcscrn, int destscrn)

--- a/prboom2/src/v_video.h
+++ b/prboom2/src/v_video.h
@@ -157,6 +157,7 @@ dboolean V_IsOpenGLMode(void);
 // [XA] indexed lightmode query interface
 dboolean V_IsUILightmodeIndexed(void);
 dboolean V_IsAutomapLightmodeIndexed(void);
+dboolean V_IsMenuLightmodeIndexed(void);
 
 //jff 4/24/98 loads color translation lumps
 void V_InitColorTranslation(void);
@@ -181,6 +182,14 @@ extern V_BeginAutomapDraw_f V_BeginAutomapDraw;
 // V_EndAutomapDraw
 typedef void(*V_EndAutomapDraw_f)(void);
 extern V_EndAutomapDraw_f V_EndAutomapDraw;
+
+// V_BeginMenuDraw
+typedef void(*V_BeginMenuDraw_f)(void);
+extern V_BeginMenuDraw_f V_BeginMenuDraw;
+
+// V_EndMenuDraw
+typedef void(*V_EndMenuDraw_f)(void);
+extern V_EndMenuDraw_f V_EndMenuDraw;
 
 // V_CopyRect
 typedef void (*V_CopyRect_f)(int srcscrn, int destscrn,


### PR DESCRIPTION
Here's the lowdown (I'll go more in-depth below):
- Create new indexed reference for menu elements (currently used for menu overlay and stbar color)
- `V_IsMenuLightmodeIndexed()` forces the main colormap (like `V_IsAutomapLightmodeIndexed()`)
- This fixes OpenGL inverting of the overlay and the statusbar background colour during Invuln or really any colormap change
- Use `playpal_lightest` and `playpal_darkest` for invuln `gld_DrawShaded()` check.

Ok, so here's the problem I ran into. In some WADs the dark overlay would sometimes invert to white when the Invulnerability colormap was active. I already knew about this, but didn't exactly know of a a good fix. However I ran into the exact same issue with the new "statusbar background color" option I added, as I found that would also invert during Invulnerability. It was then that I was able to confirm my suspicions when I checked a WAD that included underwater colormaps, that it also changed the colour of the statusbar background.

So the solution was to add a new Indexed lightmode item to track. This is already done with the automap, and it is used to force the automap to use ONLY the main colormap. And so I did the same thing but for menu elements. The two things that it's currently being used for is the statusbar color background and the menu overlay. This method seems to fix the issues that I was running into before, as we do want palette changes to affect these UI elements (berserk, item pickup, rad suit), but we don't want them to change based on colormap changes.