### PR TITLE
Add Customisable View and Weapon Bob

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1022,12 +1022,12 @@ dsda_config_t dsda_config[dsda_config_count] = {
     CONF_BOOL(1), NULL, STRICT_INT(1)
   },
   [dsda_config_viewbob] = {
-    "dsda_viewbob", dsda_config_viewbob,
-    CONF_BOOL(1)
+    "dsda_viewbob_pct", dsda_config_viewbob,
+    dsda_config_int, 0, 4, { 4 }
   },
   [dsda_config_weaponbob] = {
-    "dsda_weaponbob", dsda_config_weaponbob,
-    CONF_BOOL(1)
+    "dsda_weaponbob_pct", dsda_config_weaponbob,
+    dsda_config_int, 0, 4, { 4 }
   },
   [dsda_config_quake_intensity] = {
     "dsda_quake_intensity", dsda_config_quake_intensity,

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -120,11 +120,11 @@ void dsda_SetTas(dboolean t) {
   dsda_UpdateIntConfig(dsda_config_strict_mode, !t, true);
 }
 
-dboolean dsda_ViewBob(void) {
+int dsda_ViewBob(void) {
   return dsda_IntConfig(dsda_config_viewbob);
 }
 
-dboolean dsda_WeaponBob(void) {
+int dsda_WeaponBob(void) {
   return dsda_IntConfig(dsda_config_weaponbob);
 }
 

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -25,8 +25,8 @@
 void dsda_InitSettings(void);
 int dsda_CompatibilityLevel(void);
 void dsda_SetTas(dboolean t);
-dboolean dsda_ViewBob(void);
-dboolean dsda_WeaponBob(void);
+int dsda_ViewBob(void);
+int dsda_WeaponBob(void);
 dboolean dsda_ShowMessages(void);
 dboolean dsda_AutoRun(void);
 dboolean dsda_MouseLook(void);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3366,12 +3366,14 @@ setup_menu_t* display_settings[] =
 
 static const char* menu_background_list[] = { "Off", "Dark", "Texture", NULL };
 static const char* translucent_list[] = { "Off", "Default", "w/ Vanilla", NULL };
+static const char* viewbob_list[] = { "Off", "25%", "50%", "75%", "100%", NULL };
+static const char* weaponbob_list[] = { "Off", "25%", "50%", "75%", "100%", NULL };
 
 setup_menu_t display_options_settings[] = {
   { "Hide Weapon", S_YESNO, m_conf, G_X, dsda_config_hide_weapon },
   { "Wipe Screen Effect", S_YESNO,  m_conf, G_X, dsda_config_render_wipescreen },
-  { "View Bobbing", S_YESNO, m_conf, G_X, dsda_config_viewbob },
-  { "Weapon Bobbing", S_YESNO, m_conf, G_X, dsda_config_weaponbob },
+  { "View Bobbing", S_CHOICE, m_conf, G_X, dsda_config_viewbob, 0, viewbob_list },
+  { "Weapon Bobbing", S_CHOICE, m_conf, G_X, dsda_config_weaponbob, 0, weaponbob_list },
   { "Weapon Attack Alignment", S_CHOICE, m_conf, G_X, dsda_config_weapon_attack_alignment, 0, weapon_attack_alignment_strings },
   { "Linear Sky Scrolling", S_YESNO, m_conf, G_X, dsda_config_render_linearsky },
   { "Quake Intensity", S_NUM, m_conf, G_X, dsda_config_quake_intensity },

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -52,6 +52,7 @@
 #include "dsda.h"
 #include "dsda/aim.h"
 #include "dsda/excmd.h"
+#include "dsda/settings.h"
 
 #define LOWERSPEED   (FRACUNIT*6)
 #define RAISESPEED   (FRACUNIT*6)
@@ -628,10 +629,11 @@ void A_WeaponReady(player_t *player, pspdef_t *psp)
   // bob the weapon based on movement speed
   if (!player->morphTics)
   {
+    fixed_t bob = player->bob * dsda_WeaponBob() / 4;
     int angle = (128 * leveltime) & FINEMASK;
-    psp->sx = FRACUNIT + FixedMul(player->bob, finecosine[angle]);
+    psp->sx = FRACUNIT + FixedMul(bob, finecosine[angle]);
     angle &= FINEANGLES / 2 - 1;
-    psp->sy = WEAPONTOP + FixedMul(player->bob, finesine[angle]);
+    psp->sy = WEAPONTOP + FixedMul(bob, finesine[angle]);
   }
 }
 

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -263,7 +263,8 @@ void P_CalcHeight (player_t* player)
   }
 
   angle = (FINEANGLES / 20 * leveltime) & FINEMASK;
-  bob = dsda_ViewBob() ? FixedMul(player->bob / 2, finesine[angle]) : 0;
+  bob = player->bob * dsda_ViewBob() / 4;
+  bob = FixedMul(bob / 2, finesine[angle]);
 
   // move viewheight
 

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -981,6 +981,7 @@ void R_AddAllAliveMonstersSprites(void)
 static void R_ApplyWeaponBob (fixed_t *sx, dboolean bobx, fixed_t *sy, dboolean boby)
 {
 	const angle_t angle = (128 * leveltime) & FINEMASK;
+	fixed_t bob = viewplayer->bob * dsda_WeaponBob() / 4;
 
 	if (sx)
 	{
@@ -988,7 +989,7 @@ static void R_ApplyWeaponBob (fixed_t *sx, dboolean bobx, fixed_t *sy, dboolean 
 
 		if (bobx)
 		{
-			 *sx += FixedMul(viewplayer->bob, finecosine[angle]);
+			 *sx += FixedMul(bob, finecosine[angle]);
 		}
 	}
 
@@ -998,7 +999,7 @@ static void R_ApplyWeaponBob (fixed_t *sx, dboolean bobx, fixed_t *sy, dboolean 
 
 		if (boby)
 		{
-			*sy += FixedMul(viewplayer->bob, finesine[angle & (FINEANGLES / 2 - 1)]);
+			*sy += FixedMul(bob, finesine[angle & (FINEANGLES / 2 - 1)]);
 		}
 	}
 }


### PR DESCRIPTION
So on my discord (Nyan Doom Development), I got asked to port over the configurable view- and weapon- bobbing from Woof...

And so I did. Instead of a simple toggle on/off, each option has settings that increment by 25% (off, 25%, 50%, 75%, 100%). This is the same as in Woof, however Woof uses a thermo instead, whereas I just used choices instead. _(Note I renamed the option in the config to avoid new configs starting with 25% if set to on)_

Any thoughts on adding this? or any thoughts against it?