### PR TITLE
option to display things as hitboxes on automap

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -281,6 +281,17 @@ mline_t thintriangle_guy[] =
 #undef R
 #define NUMTHINTRIANGLEGUYLINES (sizeof(thintriangle_guy)/sizeof(mline_t))
 
+#define R (FRACUNIT)
+mline_t thingbox_guy[] =
+{
+{ { (fixed_t)(-R), (fixed_t)(-R) }, { (fixed_t)( R), (fixed_t)(-R) } },
+{ { (fixed_t)( R), (fixed_t)(-R) }, { (fixed_t)( R), (fixed_t)( R) } },
+{ { (fixed_t)( R), (fixed_t)( R) }, { (fixed_t)(-R), (fixed_t)( R) } },
+{ { (fixed_t)(-R), (fixed_t)( R) }, { (fixed_t)(-R), (fixed_t)(-R) } }
+};
+#undef R
+#define NUMTHINGBOXGUYLINES (sizeof(thingbox_guy)/sizeof(mline_t))
+
 int automap_active;
 int automap_overlay;
 int automap_rotate;
@@ -2312,6 +2323,8 @@ static void AM_drawThings(void)
 {
   int   i;
   mobj_t* t;
+  mline_t* lineguy = thintriangle_guy;
+  int lineguylines = NUMTHINTRIANGLEGUYLINES;
 
 #if defined(HAVE_LIBSDL2_IMAGE)
   if (V_IsOpenGLMode())
@@ -2366,7 +2379,8 @@ static void AM_drawThings(void)
         continue;
       }
 
-      if (map_things_appearance == map_things_appearance_scaled)
+      if (map_things_appearance == map_things_appearance_scaled
+        || map_things_appearance == map_things_appearance_box)
         scale = (BETWEEN(4<<FRACBITS, 256<<FRACBITS, t->radius)>>FRACTOMAPBITS);// * 16 / 20;
       else
         scale = 16<<MAPBITS;
@@ -2418,10 +2432,17 @@ static void AM_drawThings(void)
           continue;
         }
       }
+
+      if (map_things_appearance == map_things_appearance_box)
+      {
+        lineguy = thingbox_guy;
+        lineguylines = NUMTHINGBOXGUYLINES;
+        angle = 0x40000000;
+      }
+
       //jff 1/5/98 end added code for keys
       //jff previously entire code
-      AM_drawLineCharacter(thintriangle_guy, NUMTHINTRIANGLEGUYLINES,
-        scale, angle,
+      AM_drawLineCharacter(lineguy, lineguylines, scale, angle,
         t->flags & MF_FRIEND && !t->player ? mapcolor_p->frnd :
         /* cph 2006/07/30 - Show count-as-kills in red. */
         ((t->flags & (MF_COUNTKILL | MF_CORPSE)) == MF_COUNTKILL) ? mapcolor_p->enemy :

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -164,6 +164,7 @@ typedef enum
 #if defined(HAVE_LIBSDL2_IMAGE)
   map_things_appearance_icon,
 #endif
+  map_things_appearance_box,
 
   map_things_appearance_max
 } map_things_appearance_t;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2772,6 +2772,7 @@ static const char *map_things_appearance_list[] =
 #if defined(HAVE_LIBSDL2_IMAGE)
   "icons",
 #endif
+  "hitboxes",
   NULL
 };
 


### PR DESCRIPTION
options - automap - things appearance

- triangle tells the facing but not how things will collide (would it be useful to still indicate facing?)
- hitbox display is always scaled because it needs to appear accurate to in-game
- new enum value is before max to not mess with existing configs
- player hitbox appears too even tho it somewhat duplicates the trail, but maybe it's useful because it shows the final position on top without interfering with the trail itself

![e7b96fcf786fb550](https://github.com/user-attachments/assets/2646e3de-bc4f-433f-9031-d80f7199848e)

![3144171650592b9f](https://github.com/user-attachments/assets/35255d5e-2fe5-428a-8976-52a0d095831c)
