### PR TITLE
Rework Centering of Large Patches

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -682,7 +682,7 @@ static void D_PageDrawer(void)
   {
     // e6y: wide-res
     V_ClearBorder();
-    V_DrawNamePatch(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
+    V_DrawNamePatchFS(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
   }
   else
     M_DrawCredits();

--- a/prboom2/src/dsda/mapinfo/doom.c
+++ b/prboom2/src/dsda/mapinfo/doom.c
@@ -459,7 +459,7 @@ void dsda_DoomFDrawer(void) {
   else {
     // e6y: wide-res
     V_ClearBorder();
-    V_DrawNamePatch(0, 0, 0, end_data->end_pic, CR_DEFAULT, VPT_STRETCH);
+    V_DrawNamePatchFS(0, 0, 0, end_data->end_pic, CR_DEFAULT, VPT_STRETCH);
   }
 }
 

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -316,7 +316,7 @@ void dsda_UFDrawer(void) {
   else {
     // e6y: wide-res
     V_ClearBorder();
-    V_DrawNamePatch(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);
+    V_DrawNamePatchFS(0, 0, 0, gamemapinfo->endpic, CR_DEFAULT, VPT_STRETCH);
   }
 }
 

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -364,7 +364,7 @@ void F_TextWrite (void)
   if (finalepatch)
   {
     V_ClearBorder();
-    V_DrawNamePatch(0, 0, 0, finalepatch, CR_DEFAULT, VPT_STRETCH);
+    V_DrawNamePatchFS(0, 0, 0, finalepatch, CR_DEFAULT, VPT_STRETCH);
   }
   else
     V_DrawBackground(finaleflat, 0);
@@ -702,7 +702,7 @@ void F_CastDrawer (void)
   V_ClearBorder();
   // erase the entire screen to a background
   // CPhipps - patch drawing updated
-  V_DrawNamePatch(0,0,0, castbackground, CR_DEFAULT, VPT_STRETCH); // Ty 03/30/98 bg texture extern
+  V_DrawNamePatchFS(0,0,0, castbackground, CR_DEFAULT, VPT_STRETCH); // Ty 03/30/98 bg texture extern
 
   F_CastPrint (*(castorder[castnum].name));
 
@@ -790,14 +790,14 @@ void F_BunnyScroll (void)
   {
     int scrolled = 320 - (finalecount-230)/2;
     if (scrolled <= 0) {
-      V_DrawNamePatch(0, 0, 0, scrollpic2, CR_DEFAULT, VPT_STRETCH);
+      V_DrawNamePatchFS(0, 0, 0, scrollpic2, CR_DEFAULT, VPT_STRETCH);
     } else if (scrolled >= 320) {
-      V_DrawNamePatch(p1offset, 0, 0, scrollpic1, CR_DEFAULT, VPT_STRETCH);
+      V_DrawNamePatchFS(p1offset, 0, 0, scrollpic1, CR_DEFAULT, VPT_STRETCH);
       if (p1offset > 0)
-        V_DrawNamePatch(-320, 0, 0, scrollpic2, CR_DEFAULT, VPT_STRETCH);
+        V_DrawNamePatchFS(-320, 0, 0, scrollpic2, CR_DEFAULT, VPT_STRETCH);
     } else {
-      V_DrawNamePatch(p1offset + 320 - scrolled, 0, 0, scrollpic1, CR_DEFAULT, VPT_STRETCH);
-      V_DrawNamePatch(-scrolled, 0, 0, scrollpic2, CR_DEFAULT, VPT_STRETCH);
+      V_DrawNamePatchFS(p1offset + 320 - scrolled, 0, 0, scrollpic1, CR_DEFAULT, VPT_STRETCH);
+      V_DrawNamePatchFS(-scrolled, 0, 0, scrollpic2, CR_DEFAULT, VPT_STRETCH);
     }
     if (p2width == 320)
       V_ClearBorder();
@@ -860,27 +860,32 @@ void F_Drawer (void)
     F_TextWrite ();
   else
   {
-    // e6y: wide-res
-    V_ClearBorder();
+    const char* finalelump = NULL;
+
+    // Allows use of HELP2 screen for PWADs under DOOM 1
+    dboolean showhelp2 = (gamemode == retail && pwad_help2_check) || gamemode <= registered;
 
     switch (gameepisode)
     {
       // CPhipps - patch drawing updated
       case 1:
-           if ( (gamemode == retail && !pwad_help2_check) || gamemode == commercial )
-             V_DrawNamePatch(0, 0, 0, "CREDIT", CR_DEFAULT, VPT_STRETCH);
-           else
-             V_DrawNamePatch(0, 0, 0, "HELP2", CR_DEFAULT, VPT_STRETCH);
-           break;
+        finalelump = showhelp2 ? "HELP2" : "CREDIT";
+        break;
       case 2:
-           V_DrawNamePatch(0, 0, 0, "VICTORY2", CR_DEFAULT, VPT_STRETCH);
-           break;
+        finalelump = "VICTORY2";
+        break;
       case 3:
-           F_BunnyScroll ();
-           break;
+        F_BunnyScroll ();
+        break;
       case 4:
-           V_DrawNamePatch(0, 0, 0, "ENDPIC", CR_DEFAULT, VPT_STRETCH);
-           break;
+        finalelump = "ENDPIC";
+        break;
+    }
+
+    if (finalelump)
+    {
+      V_ClearBorder(); // e6y: wide-res
+      V_DrawNamePatchFS(0, 0, 0, finalelump, CR_DEFAULT, VPT_STRETCH);
     }
   }
 }

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -503,7 +503,7 @@ void gld_EndMenuDraw(void)
   glsl_PopNullShader();
 }
 
-void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translation_e flags)
+void gld_DrawNumPatch_f(float x, float y, int lump, dboolean center, int cm, enum patch_translation_e flags)
 {
   GLTexture *gltexture;
   float fU1,fU2,fV1,fV2;
@@ -543,8 +543,11 @@ void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translati
   }
 
   // [FG] automatically center wide patches without horizontal offset
-  if (gltexture->width > 320 && leftoffset == 0)
-    x -= (float)(gltexture->width - 320) / 2;
+  if (center)
+  {
+    if (gltexture->width > 320 && leftoffset == 0)
+      x -= (float)(gltexture->width - 320) / 2;
+  }
 
   if (flags & VPT_STRETCH_MASK)
   {
@@ -579,9 +582,9 @@ void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translati
   glEnd();
 }
 
-void gld_DrawNumPatch(int x, int y, int lump, int cm, enum patch_translation_e flags)
+void gld_DrawNumPatch(int x, int y, int lump, dboolean center, int cm, enum patch_translation_e flags)
 {
-  gld_DrawNumPatch_f((float)x, (float)y, lump, cm, flags);
+  gld_DrawNumPatch_f((float)x, (float)y, lump, center, cm, flags);
 }
 
 void gld_FillRaw(int lump, int x, int y, int src_width, int src_height, int dst_width, int dst_height, enum patch_translation_e flags)

--- a/prboom2/src/gl_struct.h
+++ b/prboom2/src/gl_struct.h
@@ -75,8 +75,8 @@ void gld_EndAutomapDraw(void);
 void gld_BeginMenuDraw(void);
 void gld_EndMenuDraw(void);
 
-void gld_DrawNumPatch(int x, int y, int lump, int cm, enum patch_translation_e flags);
-void gld_DrawNumPatch_f(float x, float y, int lump, int cm, enum patch_translation_e flags);
+void gld_DrawNumPatch(int x, int y, int lump, dboolean center, int cm, enum patch_translation_e flags);
+void gld_DrawNumPatch_f(float x, float y, int lump, dboolean center, int cm, enum patch_translation_e flags);
 
 void gld_FillRaw(int lump, int x, int y, int src_width, int src_height, int dst_width, int dst_height, enum patch_translation_e flags);
 #define gld_FillRawName(name, x, y, src_width, src_height, dst_width, dst_height, flags) \

--- a/prboom2/src/heretic/in_lude.c
+++ b/prboom2/src/heretic/in_lude.c
@@ -172,7 +172,7 @@ static void IN_DrawInterpic(void)
 
   // e6y: wide-res
   V_ClearBorder();
-  V_DrawNamePatch(0, 0, 0, name, CR_DEFAULT, VPT_STRETCH);
+  V_DrawNamePatchFS(0, 0, 0, name, CR_DEFAULT, VPT_STRETCH);
 }
 
 static void IN_DrawBeenThere(int i)

--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -555,7 +555,7 @@ void SB_Drawer(dboolean statusbaron, dboolean refresh)
     {
         if (heretic)
         {
-            V_DrawNumPatch(0, 158, 0, LumpBARBACK, CR_DEFAULT, VPT_STRETCH);
+            V_DrawNumPatchFS(0, 158, 0, LumpBARBACK, CR_DEFAULT, VPT_STRETCH);
             if (players[consoleplayer].cheats & CF_GODMODE)
             {
                 V_DrawNamePatch(16, 167, 0, "GOD1", CR_DEFAULT, VPT_STRETCH);
@@ -564,7 +564,7 @@ void SB_Drawer(dboolean statusbaron, dboolean refresh)
         }
         else
         {
-            V_DrawNumPatch(0, 134, 0, LumpH2BAR, CR_DEFAULT, VPT_STRETCH);
+            V_DrawNumPatchFS(0, 134, 0, LumpH2BAR, CR_DEFAULT, VPT_STRETCH);
         }
 
         oldhealth = -1;
@@ -696,12 +696,12 @@ void DrawCommonBar(void)
     {
       if (heretic)
       {
-          V_DrawNumPatch(0,  148, 0, LumpLTFCTOP, CR_DEFAULT, VPT_STRETCH);
-          V_DrawNumPatch(290,  148, 0, LumpRTFCTOP, CR_DEFAULT, VPT_STRETCH);
+          V_DrawNumPatchFS(0,  148, 0, LumpLTFCTOP, CR_DEFAULT, VPT_STRETCH);
+          V_DrawNumPatchFS(290,  148, 0, LumpRTFCTOP, CR_DEFAULT, VPT_STRETCH);
       }
       else
       {
-          V_DrawNumPatch(0, 134, 0, LumpH2TOP, CR_DEFAULT, VPT_STRETCH);
+          V_DrawNumPatchFS(0, 134, 0, LumpH2TOP, CR_DEFAULT, VPT_STRETCH);
       }
     }
 
@@ -725,7 +725,7 @@ void DrawCommonBar(void)
             healthPos = (healthPos * 256) / 100;
             chainY =
                 (HealthMarker == CPlayer->mo->health) ? 191 : 191 + ChainWiggle;
-            V_DrawNumPatch(0,  190, 0, LumpCHAINBACK, CR_DEFAULT, VPT_STRETCH);
+            V_DrawNumPatchFS(0,  190, 0, LumpCHAINBACK, CR_DEFAULT, VPT_STRETCH);
             V_DrawNumPatch(2 + (healthPos % 17),  chainY, 0, LumpCHAIN, CR_DEFAULT, VPT_STRETCH);
             V_DrawNumPatch(17 + healthPos,  chainY, 0, LumpLIFEGEM, CR_DEFAULT, VPT_STRETCH);
             V_DrawNumPatch(0,  190, 0, LumpLTFACE, CR_DEFAULT, VPT_STRETCH);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4207,7 +4207,7 @@ static void M_DrawExtHelp(void)
   namebfr[5] = extended_help_index%10 + '0';
   // CPhipps - patch drawing updated
   V_ClearBorder(); // Redraw background for every ext HELP screen. Fixes widescreen overdraw.
-  V_DrawNamePatch(0, 0, 0, namebfr, CR_DEFAULT, VPT_STRETCH);
+  V_DrawNamePatchFS(0, 0, 0, namebfr, CR_DEFAULT, VPT_STRETCH);
 }
 
 //
@@ -4378,7 +4378,7 @@ static void M_DrawHelp (void)
   M_ChangeMenu(NULL, mnact_full);
 
   V_ClearBorder();
-  V_DrawNamePatch(0, 0, 0, helplump, CR_DEFAULT, VPT_STRETCH);
+  V_DrawNamePatchFS(0, 0, 0, helplump, CR_DEFAULT, VPT_STRETCH);
 }
 
 //
@@ -4394,7 +4394,7 @@ static void M_DrawAd (void)
 
   V_ClearBorder();
   if (pwad_help2_check || gamemode == shareware)
-    V_DrawNamePatch(0, 0, 0, help2, CR_DEFAULT, VPT_STRETCH);
+    V_DrawNamePatchFS(0, 0, 0, help2, CR_DEFAULT, VPT_STRETCH);
   else
     M_DrawCredits();
 }
@@ -4431,7 +4431,7 @@ void M_DrawCredits(void)     // killough 10/98: credit screen
   if (PWADcredit || tc_game)
   {
     V_ClearBorder();
-    V_DrawNamePatch(0, 0, 0, credit, CR_DEFAULT, VPT_STRETCH);
+    V_DrawNamePatchFS(0, 0, 0, credit, CR_DEFAULT, VPT_STRETCH);
   }
   else
   {

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -434,7 +434,7 @@ static void ST_refreshBackground(void)
     {
       flags = VPT_ALIGN_BOTTOM;
 
-      V_DrawNumPatch(ST_X, y, BG, stbarbg.lumpnum, CR_DEFAULT, flags);
+      V_DrawNumPatchFS(ST_X, y, BG, stbarbg.lumpnum, CR_DEFAULT, flags);
       if (!deathmatch)
       {
         V_DrawNumPatch(ST_ARMSBGX, y, BG, armsbg.lumpnum, CR_DEFAULT, flags);

--- a/prboom2/src/v_video.h
+++ b/prboom2/src/v_video.h
@@ -208,20 +208,30 @@ extern V_FillRect_f V_FillRect;
 // CPhipps - patch drawing
 // Consolidated into the 3 really useful functions:
 
-// V_DrawNumPatch - Draws the patch from lump num
-typedef void (*V_DrawNumPatch_f)(int x, int y, int scrn,
-                                 int lump, int cm,
+// V_DrawNumPatchGen - Draws the patch from lump num
+typedef void (*V_DrawNumPatchGen_f)(int x, int y, int scrn,
+                                 int lump, dboolean center, int cm,
                                  enum patch_translation_e flags);
-extern V_DrawNumPatch_f V_DrawNumPatch;
+extern V_DrawNumPatchGen_f V_DrawNumPatchGen;
 
-typedef void (*V_DrawNumPatchPrecise_f)(float x, float y, int scrn,
-                                 int lump, int cm,
+typedef void (*V_DrawNumPatchGenPrecise_f)(float x, float y, int scrn,
+                                 int lump, dboolean center, int cm,
                                  enum patch_translation_e flags);
-extern V_DrawNumPatchPrecise_f V_DrawNumPatchPrecise;
+extern V_DrawNumPatchGenPrecise_f V_DrawNumPatchGenPrecise;
+
+// V_DrawNumPatch - Draws the patch from lump "num"Add commentMore actions
+#define V_DrawNumPatch(x,y,s,n,t,f) V_DrawNumPatchGen(x,y,s,n,false,t,f)
+#define V_DrawNumPatchPrecise(x,y,s,n,t,f) V_DrawNumPatchGenPrecise(x,y,s,n,false,t,f)
 
 // V_DrawNamePatch - Draws the patch from lump "name"
-#define V_DrawNamePatch(x,y,s,n,t,f) V_DrawNumPatch(x,y,s,W_GetNumForName(n),t,f)
-#define V_DrawNamePatchPrecise(x,y,s,n,t,f) V_DrawNumPatchPrecise(x,y,s,W_GetNumForName(n),t,f)
+#define V_DrawNamePatch(x,y,s,n,t,f) V_DrawNumPatchGen(x,y,s,W_GetNumForName(n),false,t,f)
+#define V_DrawNamePatchPrecise(x,y,s,n,t,f) V_DrawNumPatchGenPrecise(x,y,s,W_GetNumForName(n),false,t,f)
+
+// These functions center patches if width > 320 :
+#define V_DrawNumPatchFS(x,y,s,n,t,f) V_DrawNumPatchGen(x,y,s,n,true,t,f)
+#define V_DrawNumPatchPreciseFS(x,y,s,n,t,f) V_DrawNumPatchGenPrecise(x,y,s,n,true,t,f)
+#define V_DrawNamePatchFS(x,y,s,n,t,f) V_DrawNumPatchGen(x,y,s,W_GetNumForName(n),true,t,f)
+#define V_DrawNamePatchPreciseFS(x,y,s,n,t,f) V_DrawNumPatchGenPrecise(x,y,s,W_GetNumForName(n),true,t,f)
 
 /* cph -
  * Functions to return width & height of a patch.

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -469,7 +469,7 @@ static void WI_slamBackground(void)
   V_ClearBorder();
 
   // background
-  V_DrawNamePatch(0, 0, FB, name, CR_DEFAULT, VPT_STRETCH);
+  V_DrawNamePatchFS(0, 0, FB, name, CR_DEFAULT, VPT_STRETCH);
 }
 
 #define SPACEWIDTH 4
@@ -550,7 +550,7 @@ void WI_drawLF(void)
       return;
 
     // CPhipps - patch drawing updated
-    V_DrawNamePatch((320 - V_NamePatchWidth(lname)) / 2, y,
+    V_DrawNamePatchFS((320 - V_NamePatchWidth(lname)) / 2, y,
       FB, lname, CR_DEFAULT, VPT_STRETCH);
 
     y += (5 * V_NamePatchHeight(lname)) / 4;
@@ -618,7 +618,7 @@ void WI_drawEL(void)
 
     // CPhipps - patch drawing updated
     // draw level
-    V_DrawNamePatch((320 - V_NamePatchWidth(lname)) / 2, y, FB,
+    V_DrawNamePatchFS((320 - V_NamePatchWidth(lname)) / 2, y, FB,
       lname, CR_DEFAULT, VPT_STRETCH);
 
     y += (5 * V_NamePatchHeight(lname)) / 4;


### PR DESCRIPTION
- Only center patches larger than 320 for specific cases (backgrounds, stbar, levelname)
- Fixes widescreen assets that rely on offsets (Example Doom E3 intermission wide assets)

Also took the time to restructure the Doom 1 finale sequence, so it doesn't call `V_DrawNamePatch` a bunch of times.

Note that Woof takes this approach having a separate "FullScreen" patch drawing function.