### PR TITLE
Hexen - Fix keys getting lost in the same hub

### DIFF
--- a/prboom2/src/d_player.h
+++ b/prboom2/src/d_player.h
@@ -255,6 +255,7 @@ typedef struct player_s
   pclass_t pclass;            // player class type
   int morphTics;              // player is a pig if > 0
   int pieces;                 // Fourth Weapon pieces
+  int ravenkeys;              // Track statusbar keys
   short yellowMessage;
   int poisoncount;            // screen flash for poison damage
   mobj_t *poisoner;           // NULL for non-player mobjs

--- a/prboom2/src/dsda/console.c
+++ b/prboom2/src/dsda/console.c
@@ -362,8 +362,6 @@ static dboolean console_PlayerSetAmmo(const char* command, const char* args) {
 }
 
 static dboolean console_PlayerGiveKey(const char* command, const char* args) {
-  extern int playerkeys;
-
   int key;
 
   if (sscanf(args, "%i", &key)) {
@@ -371,7 +369,7 @@ static dboolean console_PlayerGiveKey(const char* command, const char* args) {
       return false;
 
     target_player.cards[key] = true;
-    playerkeys |= 1 << key;
+    target_player.ravenkeys |= 1 << key;
 
     return true;
   }
@@ -380,8 +378,6 @@ static dboolean console_PlayerGiveKey(const char* command, const char* args) {
 }
 
 static dboolean console_PlayerRemoveKey(const char* command, const char* args) {
-  extern int playerkeys;
-
   int key;
 
   if (sscanf(args, "%i", &key)) {
@@ -389,7 +385,7 @@ static dboolean console_PlayerRemoveKey(const char* command, const char* args) {
       return false;
 
     target_player.cards[key] = false;
-    playerkeys &= ~(1 << key);
+    target_player.ravenkeys &= ~(1 << key);
 
     return true;
   }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1776,7 +1776,9 @@ static void G_PlayerFinishLevel(int player)
   p->lookdir = 0;
   p->rain1 = NULL;
   p->rain2 = NULL;
-  playerkeys = 0;
+
+  if (!hexen || (hexen && dsda_MapCluster(gamemap) != dsda_MapCluster(leave_data.map)))
+    p->ravenkeys = 0;
 
   memset(p->powers, 0, sizeof p->powers);
   if (flb.flight_carryover)

--- a/prboom2/src/heretic/def.h
+++ b/prboom2/src/heretic/def.h
@@ -23,7 +23,6 @@ extern int inv_ptr;
 extern int curpos;
 extern int ArtifactFlash;
 extern dboolean inventory;
-extern int playerkeys;
 
 #include "dstrings.h"
 

--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -60,7 +60,6 @@ int curpos;
 int inv_ptr;
 int ArtifactFlash;
 int SB_state = -1;
-int playerkeys = 0;
 
 // Private Data
 
@@ -817,7 +816,7 @@ void DrawMainBar(void)
     }
 
     // Keys
-    if (oldkeys != playerkeys)
+    if (oldkeys != CPlayer->ravenkeys)
     {
         if (CPlayer->cards[key_yellow])
         {
@@ -831,7 +830,7 @@ void DrawMainBar(void)
         {
             V_DrawNamePatch(153, 180, 0, "bkeyicon", CR_DEFAULT, VPT_STRETCH);
         }
-        oldkeys = playerkeys;
+        oldkeys = CPlayer->ravenkeys;
     }
     // Ammo
     temp = CPlayer->ammo[wpnlev1info[CPlayer->readyweapon].ammo];
@@ -1215,19 +1214,19 @@ void DrawKeyBar(void)
     int xPosition;
     int temp;
 
-    if (oldkeys != playerkeys)
+    if (oldkeys != CPlayer->ravenkeys)
     {
         xPosition = 46;
         for (i = 0; i < NUMCARDS && xPosition <= 126; i++)
         {
-            if (playerkeys & (1 << i))
+            if (CPlayer->ravenkeys & (1 << i))
             {
                 V_DrawNumPatch(xPosition, 164, 0,
                                W_GetNumForName("keyslot1") + i, CR_DEFAULT, VPT_STRETCH);
                 xPosition += 20;
             }
         }
-        oldkeys = playerkeys;
+        oldkeys = CPlayer->ravenkeys;
     }
     temp = pclass[CPlayer->pclass].auto_armor_save +
         CPlayer->armorpoints[ARMOR_ARMOR] +

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -393,7 +393,7 @@ void P_GiveCard(player_t *player, card_t card)
   player->cards[card] = 1;
 
   if (player == &players[consoleplayer])
-    playerkeys |= 1 << card;
+    player->ravenkeys |= 1 << card;
 
   dsda_WatchCard(card);
 }
@@ -3047,7 +3047,7 @@ int P_GiveKey(player_t * player, card_t key)
     player->cards[key] = true;
 
     if (player == &players[consoleplayer])
-      playerkeys |= 1 << key;
+      player->ravenkeys |= 1 << key;
 
     return true;
 }

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -2157,10 +2157,10 @@ void P_SpawnPlayer (int n, const mapthing_t* mthing)
     for (i = 0 ; i < NUMCARDS ; i++)
       p->cards[i] = true;
     if (p == &players[consoleplayer])
-      playerkeys = 7;
+      p->ravenkeys = 7;
   }
-  else if (p == &players[consoleplayer])
-    playerkeys = 0;
+  else if (p == &players[consoleplayer] && !hexen)
+    p->ravenkeys = 0;
 
   R_SmoothPlaying_Reset(p); // e6y
 }


### PR DESCRIPTION
So in Hexen it seems like the keys on the hud would get removed when taking an exit to another map... in the same hub...

However gameplay wise, the player still had the key, but they couldn't visual see it on the hud.

This PR fixes this behaviour so that it remembers the keys on the hud per hub. Once a new hub is entered, the keys disappear from the hud (like in vanilla hexen).

There is some logic in here that specifically only tailors this behaviour to Hexen, as Heretic also uses this value. I'm unclear if Doom in Hexen format uses this value, so I just made sure that the behaviour would be the same as it was before if it wasn't Hexen.