### PR TITLE
Fix Vanilla complevel "previous weapon" not working for the Chainsaw

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -412,6 +412,16 @@ static dboolean WeaponSelectable(weapontype_t weapon)
     return false;
   }
 
+  // Can't select the fist if we have the chainsaw, unless
+  // we also have the berserk pack.
+  if ((demo_compatibility)
+      && weapon == wp_fist
+      && players[consoleplayer].weaponowned[wp_chainsaw]
+      && !players[consoleplayer].powers[pw_strength])
+  {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Both Woof and Crispy Doom use this code.