### PR TITLE
Automap Mark Tweaks

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -466,8 +466,11 @@ static void AM_restoreScaleAndLoc(void)
 
 void AM_setMarkParams(int num)
 {
-  int i;
-  static char namebuf[16] = "AMMNUM0";
+  int i, namelen;
+  char namebuf[16];
+
+  sprintf(namebuf,"%s", !raven ? "AMMNUM0" : "SMALLIN0");
+  namelen = !raven ? 6 : 7;
 
   markpoints[num].w = 0;
   markpoints[num].h = 0;
@@ -475,7 +478,7 @@ void AM_setMarkParams(int num)
   snprintf(markpoints[num].label, sizeof(markpoints[num].label), "%d", num);
   for (i = 0; i < (int)strlen(markpoints[num].label); i++)
   {
-    namebuf[6] = markpoints[num].label[i];
+    namebuf[namelen] = markpoints[num].label[i];
     markpoints[num].widths[i] = V_NamePatchWidth(namebuf);
     markpoints[num].w += markpoints[num].widths[i] + 1;
     markpoints[num].h = MAX(markpoints[num].h, V_NamePatchHeight(namebuf));
@@ -1167,7 +1170,7 @@ dboolean AM_Responder
     /* Ty 03/27/98 - *not* externalized
      * cph 2001/11/20 - use doom_printf so we don't have our own buffer */
     doom_printf("%s %d", s_AMSTR_MARKEDSPOT, markpointnum);
-    if (!raven) AM_addMark();
+    AM_addMark();
 
     return true;
   }
@@ -2603,8 +2606,11 @@ static void AM_drawPlayerTrail(void)
 //
 static void AM_drawMarks(void)
 {
-  int i;
-  char namebuf[16] = "AMMNUM0";
+  int i, namelen;
+  char namebuf[16];
+
+  sprintf(namebuf,"%s", !raven ? "AMMNUM0" : "SMALLIN0");
+  namelen = !raven ? 6 : 7;
 
   if (map_trail_mode && dsda_RevealAutomap())
     AM_drawPlayerTrail();
@@ -2647,7 +2653,7 @@ static void AM_drawMarks(void)
         w = 0;
         for (k = 0; k < (int)strlen(markpoints[i].label); k++)
         {
-          namebuf[6] = markpoints[i].label[k];
+          namebuf[namelen] = markpoints[i].label[k];
 
           if (p.x < f_x + f_w &&
               p.x + markpoints[i].widths[k] * SCREENWIDTH / 320 >= f_x)

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -1174,12 +1174,13 @@ dboolean AM_Responder
   else if (dsda_InputActivated(dsda_input_map_clear))
   {
     // [Alaux] Clear just the last mark
-    if (!markpointnum)
-      dsda_AddMessage(s_AMSTR_MARKSCLEARED);
-    else {
+    if (markpointnum)
       AM_clearLastMark();
+
+    if (markpointnum)
       doom_printf("Cleared spot %d", markpointnum);
-    }
+    else
+      dsda_AddMessage(s_AMSTR_MARKSCLEARED);
 
     return true;
   }


### PR DESCRIPTION
- Skip "Cleared spot 0" for clearing marks (since if you've cleared mark 0, all marks are cleared)
- Allow raven games to add marks