### PR TITLE
Mark Death Exits on the Automap

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -1698,6 +1698,12 @@ static automap_style_t AM_wallStyle(int i)
     if (mapcolor_p->exit && (dsda_IsExitLine(i) || dsda_IsSecretExitLine(i)))
       return ams_exit;
 
+    if (mapcolor_p->exitsecr && (dsda_IsDeathSecretExitLine(i) && !dsda_IsDeathExitLine(i)))
+      return ams_exit_secret;
+
+    if (mapcolor_p->exit && (dsda_IsDeathExitLine(i) || dsda_IsDeathSecretExitLine(i)))
+      return ams_exit;
+
     if (!lines[i].backsector) // 1-sided
     {
       if (AM_DrawHiddenSecrets() && P_IsSecret(lines[i].frontsector))
@@ -1739,6 +1745,20 @@ static automap_style_t AM_wallStyle(int i)
       )
       {
         return ams_revealed_secret;
+      }
+      else if (
+        (mapcolor_p->exitsecr && !mapcolor_p->exit) &&
+        (P_IsDeathExit(lines[i].frontsector) || P_IsDeathExit(lines[i].backsector))
+      )
+      {
+        return ams_exit_secret;
+      }
+      else if (
+        (mapcolor_p->exit || mapcolor_p->exitsecr) &&
+        (P_IsDeathExit(lines[i].frontsector) || P_IsDeathExit(lines[i].backsector))
+      )
+      {
+        return ams_exit;
       }
       else if (lines[i].backsector->floorheight !=
                 lines[i].frontsector->floorheight)

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -111,6 +111,46 @@ int dsda_DoorType(int index) {
   }
 }
 
+dboolean dsda_IsDeathExitLine(int index)
+{
+  const sector_t *sec = lines[index].frontsector;
+
+  if (raven) return false;
+
+  if (sec->special < 32)
+  {
+    return (sec->special == 11);
+  }
+  else if (mbf21 && sec->special & DEATH_MASK)
+  {
+    const int i = (sec->special & DAMAGE_MASK) >> DAMAGE_SHIFT;
+
+    return (i == 2);
+  }
+
+  return false;
+}
+
+dboolean dsda_IsDeathSecretExitLine(int index)
+{
+  const sector_t *sec = lines[index].frontsector;
+
+  if (raven) return false;
+
+  if (sec->special < 32)
+  {
+    return (sec->special == 11);
+  }
+  else if (mbf21 && sec->special & DEATH_MASK)
+  {
+    const int i = (sec->special & DAMAGE_MASK) >> DAMAGE_SHIFT;
+
+    return (i == 3);
+  }
+
+  return false;
+}
+
 dboolean dsda_IsExitLine(int index) {
   int special = lines[index].special;
 

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -89,6 +89,8 @@ extern map_format_t map_format;
 int dsda_DoorType(int index);
 dboolean dsda_IsExitLine(int index);
 dboolean dsda_IsSecretExitLine(int index);
+dboolean dsda_IsDeathExitLine(int index);
+dboolean dsda_IsDeathSecretExitLine(int index);
 dboolean dsda_IsTeleportLine(int index);
 void dsda_ApplyZDoomMapFormat(void);
 void dsda_ApplyDefaultMapFormat(void);

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -1507,6 +1507,27 @@ dboolean PUREFUNC P_IsSecret(const sector_t *sec)
   return (sec->flags & SECF_SECRET) != 0;
 }
 
+//
+// P_IsDeathExit()
+//
+// If the sector a death exit via E1M8 or MBF21 actions
+//
+dboolean PUREFUNC P_IsDeathExit(const sector_t *sec)
+{
+  if (sec->special < 32)
+  {
+    return (sec->special == 11);
+  }
+  else if (mbf21 && sec->special & DEATH_MASK)
+  {
+    const int i = (sec->special & DAMAGE_MASK) >> DAMAGE_SHIFT;
+
+    return (i == 2 || i == 3);
+  }
+
+  return false;
+}
+
 
 //
 // P_WasSecret()

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -1038,6 +1038,9 @@ dboolean P_CeilingPlanesDiffer(const sector_t *sec, const sector_t *other);
 dboolean PUREFUNC P_IsSecret
 ( const sector_t *sec );
 
+dboolean PUREFUNC P_IsDeathExit
+( const sector_t *sec );
+
 dboolean PUREFUNC P_WasSecret
 ( const sector_t *sec );
 


### PR DESCRIPTION
Decided to use both Exit and Secret Exit map colours for death exits.
Disabled in Raven (there are no death exits).