### PR TITLE
Hexen: fix wyvern + porkalator bug

### DIFF
--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -6492,14 +6492,27 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
                                             actor->target->y);
             for (i = 0; i < 5; i++)
             {
+                int mo_x, mo_y;
                 if (!target->special_args[i])
                 {
                     continue;
                 }
                 search = -1;
                 mo = P_FindMobjFromTID(target->special_args[i], &search);
+                // [crispy] fix wyvern + porkalator bug
+                if (mo == NULL)
+                {
+                    fprintf(stderr, "DragonSeek: P_FindMobjFromTID() returned NULL mobj!\n");
+                    mo_x = 0;
+                    mo_y = 0;
+                }
+                else
+                {
+                    mo_x = mo->x;
+                    mo_y = mo->y;
+                }
                 angleToSpot = R_PointToAngle2(actor->x, actor->y,
-                                              mo->x, mo->y);
+                                              mo_x, mo_y);
                 if (abs((int) angleToSpot - (int) angleToTarget) < bestAngle)
                 {
                     bestAngle = abs((int) angleToSpot - (int) angleToTarget);

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -6502,7 +6502,7 @@ static void DragonSeek(mobj_t * actor, angle_t thresh, angle_t turnMax)
                 // [crispy] fix wyvern + porkalator bug
                 if (mo == NULL)
                 {
-                    fprintf(stderr, "DragonSeek: P_FindMobjFromTID() returned NULL mobj!\n");
+                    lprintf(LO_WARN, "DragonSeek: P_FindMobjFromTID() returned NULL mobj!\n");
                     mo_x = 0;
                     mo_y = 0;
                 }


### PR DESCRIPTION
This fix addresses the "Wyvern + Porkalator" issue described on [DoomWiki](https://doomwiki.org/wiki/Porkalating_enemies_while_a_death_wyvern_is_active_breaks_map_spots).

**Important:**
This patch does not alter or fix gameplay mechanics related to using the Porkalator on monsters while a Wyvern is active. The game simply no longer crashes — but the Wyvern(s) will very likely freeze in place.
This is consistent with the behavior in the original DOS version, with the key difference being that the game does not crash there, even without a fix.

In other words, this is a demo-compatible solution, so please don’t be surprised and don’t compare it with (G)ZDoom or other ports where the Wyvern behavior has been fixed entirely.

Original pull request from Crispy Hexen: https://github.com/fabiangreffrath/crispy-doom/pull/1307
All credits for the fix should be addressed to  @fabiangreffrath, please.