### PR TITLE
CMake: Move config.h generation to its own module.

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -80,24 +80,6 @@ set(PROJECT_TARNAME "dsda-doom")
 set(WAD_DATA "dsda-doom.wad")
 set(PROJECT_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
 
-include(CheckSymbolExists)
-
-check_symbol_exists(stricmp "string.h" HAVE_STRICMP)
-check_symbol_exists(strnicmp "string.h" HAVE_STRNICMP)
-check_symbol_exists(getopt "unistd.h" HAVE_GETOPT)
-check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
-check_symbol_exists(CreateFileMapping "windows.h" HAVE_CREATE_FILE_MAPPING)
-check_symbol_exists(strsignal "string.h" HAVE_STRSIGNAL)
-check_symbol_exists(mkstemp "stdlib.h" HAVE_MKSTEMP)
-check_symbol_exists(getpwuid "unistd.h;sys/types.h;pwd.h" HAVE_GETPWUID)
-
-include(CheckIncludeFile)
-
-check_include_file("sys/wait.h" HAVE_SYS_WAIT_H)
-check_include_file("unistd.h" HAVE_UNISTD_H)
-check_include_file("asm/byteorder.h" HAVE_ASM_BYTEORDER_H)
-check_include_file("dirent.h" HAVE_DIRENT_H)
-
 include(DsdaTargetFeatures)
 
 include(PkgConfigHelper)
@@ -178,7 +160,7 @@ option(SIMPLECHECKS "Enable checks which only impose significant overhead if a p
 # Debug options, disabled by default
 option(RANGECHECK "Enable internal range checking" OFF)
 
-configure_file(cmake/config.h.cin config.h)
+include(DsdaConfigHeader)
 
 set(DSDA_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -49,9 +49,6 @@ endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-include(CheckBigEndian)
-check_big_endian(WORDS_BIGENDIAN)
-
 include(GNUInstallDirs)
 
 if(POLICY CMP0099)

--- a/prboom2/cmake/DsdaConfigHeader.cmake
+++ b/prboom2/cmake/DsdaConfigHeader.cmake
@@ -1,0 +1,85 @@
+include_guard()
+
+include(DsdaHelpers)
+
+set(DSDA_INTERNAL_GENERATED_CONFIG_DIR "${PROJECT_BINARY_DIR}/build-config")
+
+# Internal functions, these should not be called from outside this module
+
+function(dsda_internal_check_symbols)
+  include(CheckSymbolExists)
+
+  check_symbol_exists(stricmp "string.h" HAVE_STRICMP)
+  check_symbol_exists(strnicmp "string.h" HAVE_STRNICMP)
+  check_symbol_exists(getopt "unistd.h" HAVE_GETOPT)
+  check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
+  check_symbol_exists(CreateFileMapping "windows.h" HAVE_CREATE_FILE_MAPPING)
+  check_symbol_exists(strsignal "string.h" HAVE_STRSIGNAL)
+  check_symbol_exists(mkstemp "stdlib.h" HAVE_MKSTEMP)
+  check_symbol_exists(getpwuid "unistd.h;sys/types.h;pwd.h" HAVE_GETPWUID)
+endfunction()
+
+function(dsda_internal_check_includes)
+  include(CheckIncludeFile)
+
+  check_include_file("sys/wait.h" HAVE_SYS_WAIT_H)
+  check_include_file("unistd.h" HAVE_UNISTD_H)
+  check_include_file("asm/byteorder.h" HAVE_ASM_BYTEORDER_H)
+  check_include_file("dirent.h" HAVE_DIRENT_H)
+endfunction()
+
+function(dsda_internal_check_variables)
+  set(expected_vars
+    PROJECT_NAME
+    PROJECT_TARNAME
+    WAD_DATA
+    PROJECT_VERSION
+    PROJECT_STRING
+    DOOMWADDIR
+    DSDA_ABSOLUTE_PWAD_PATH
+    WORDS_BIGENDIAN
+    SIMPLECHECKS
+    RANGECHECK
+  )
+  foreach(var IN LISTS expected_vars)
+    if(NOT DEFINED ${var})
+      message(FATAL_ERROR "config.h cannot be generated: \"${var}\" is not set")
+    endif()
+  endforeach()
+endfunction()
+
+function(dsda_internal_generate_build_config)
+  dsda_internal_check_symbols()
+  dsda_internal_check_includes()
+  dsda_internal_check_variables()
+
+  configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/config.h.cin" 
+    "${DSDA_INTERNAL_GENERATED_CONFIG_DIR}/config.h"
+  )
+endfunction()
+
+dsda_internal_generate_build_config()
+
+# Public functions
+
+function(dsda_target_use_config_h tgt)
+  dsda_fail_if_invalid_target(${tgt})
+
+  target_sources(${tgt}
+    PRIVATE
+    "${DSDA_INTERNAL_GENERATED_CONFIG_DIR}/config.h"
+  )
+
+  target_include_directories(${tgt}
+    PRIVATE
+    $<BUILD_INTERFACE:${DSDA_INTERNAL_GENERATED_CONFIG_DIR}>
+  )
+
+  target_compile_definitions(${TARGET}
+    PRIVATE
+    HAVE_CONFIG_H
+    $<$<NOT:$<BOOL:${HAVE_STRICMP}>>:stricmp=strcasecmp>
+    $<$<NOT:$<BOOL:${HAVE_STRNICMP}>>:strnicmp=strncasecmp>
+  )
+endfunction()

--- a/prboom2/cmake/DsdaConfigHeader.cmake
+++ b/prboom2/cmake/DsdaConfigHeader.cmake
@@ -49,6 +49,9 @@ function(dsda_internal_check_variables)
 endfunction()
 
 function(dsda_internal_generate_build_config)
+  include(CheckBigEndian)
+  check_big_endian(WORDS_BIGENDIAN)
+
   dsda_internal_check_symbols()
   dsda_internal_check_includes()
   dsda_internal_check_variables()

--- a/prboom2/cmake/DsdaHelpers.cmake
+++ b/prboom2/cmake/DsdaHelpers.cmake
@@ -1,0 +1,7 @@
+include_guard()
+
+function(dsda_fail_if_invalid_target tgt)
+  if(NOT TARGET ${tgt})
+    message(FATAL_ERROR "${tgt} is not a valid CMake target.")
+  endif()
+endfunction()

--- a/prboom2/cmake/DsdaTargetFeatures.cmake
+++ b/prboom2/cmake/DsdaTargetFeatures.cmake
@@ -1,12 +1,8 @@
 include_guard()
 
-# Internal functions, these should not be called from outside this module
+include(DsdaHelpers)
 
-function(dsda_internal_fail_if_invalid_target tgt)
-  if(NOT TARGET ${tgt})
-    message(FATAL_ERROR "${tgt} is not a valid CMake target.")
-  endif()
-endfunction()
+# Internal functions, these should not be called from outside this module
 
 function(dsda_internal_setup_warnings_msvc result_var)
   set(${result_var}
@@ -102,7 +98,7 @@ endfunction()
 # Public functions
 
 function(dsda_target_set_warnings tgt)
-  dsda_internal_fail_if_invalid_target(${tgt})
+  dsda_fail_if_invalid_target(${tgt})
   
   if(NOT DEFINED CACHE{DSDA_ENABLED_WARNINGS})
     dsda_internal_setup_warnings()
@@ -115,7 +111,7 @@ function(dsda_target_set_warnings tgt)
 endfunction()
 
 function(dsda_target_silence_deprecation tgt)
-  dsda_internal_fail_if_invalid_target(${tgt})
+  dsda_fail_if_invalid_target(${tgt})
 
   if(WIN32)
     target_compile_definitions(${tgt}
@@ -132,7 +128,7 @@ function(dsda_target_silence_deprecation tgt)
 endfunction()
 
 function(dsda_target_enable_fast_math tgt)
-  dsda_internal_fail_if_invalid_target(${tgt})
+  dsda_fail_if_invalid_target(${tgt})
 
   if(NOT DEFINED CACHE{DSDA_FAST_MATH_FLAG})
     dsda_internal_check_fast_math_flag()

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -533,17 +533,10 @@ function(AddGameExecutable TARGET SOURCES)
     dsda_target_set_warnings(${TARGET})
     dsda_target_silence_deprecation(${TARGET})
     dsda_target_enable_fast_math(${TARGET})
-
-    target_compile_definitions(${TARGET}
-        PRIVATE
-        HAVE_CONFIG_H
-        $<$<NOT:$<BOOL:${HAVE_STRICMP}>>:stricmp=strcasecmp>
-        $<$<NOT:$<BOOL:${HAVE_STRNICMP}>>:strnicmp=strncasecmp>
-    )
+    dsda_target_use_config_h(${TARGET})
 
     target_include_directories(${TARGET} PRIVATE
         ${SDL2_INCLUDE_DIRS}
-        ${CMAKE_BINARY_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
     )
 


### PR DESCRIPTION
This moves all config.h-related checks and target settings to its own module.

In addition, a basic check is added to verify all the needed CMake variables are defined.