### PR TITLE
rdatawad: fix handling of big-endian hosts

### DIFF
--- a/prboom2/data/CMakeLists.txt
+++ b/prboom2/data/CMakeLists.txt
@@ -38,6 +38,14 @@ include(DsdaTargetFeatures)
 dsda_target_set_warnings(dsda_rdatawad)
 dsda_target_silence_deprecation(dsda_rdatawad)
 
+include(CheckBigEndian)
+check_big_endian(RD_IS_BIG_ENDIAN)
+
+target_compile_definitions(dsda_rdatawad
+    PRIVATE
+    "RD_IS_BIG_ENDIAN=${RD_IS_BIG_ENDIAN}"
+)
+
 # PrBoom-Plus internal WAD
 
 set(PALETTE

--- a/prboom2/data/rd_util.h
+++ b/prboom2/data/rd_util.h
@@ -9,7 +9,7 @@
 #define ATTR(x)
 #endif
 
-#ifdef WORDS_BIGENDIAN
+#if RD_IS_BIG_ENDIAN
 # ifdef __GNUC__
 #define LONG(x) __builtin_bswap32((x))
 #define SHORT(x) (__builtin_bswap32((x))>>16)


### PR DESCRIPTION
Tl;dr: this PR restores support for rdatawad on big-endian hosts.

Turns out `config.h` was used for something in `rdatawad`, although not immediately obvious:
- All .c files started by including `config.h`
- Some .c files include `rd_util.h`, which defines macros to handle endianess based on the value of `WORDS_BIGENDIAN`.
- This leads to all host platforms to be treated as little-endian when building the pwad, which is true for all platforms running in CI.

Since `rd_util.h` did not include `config.h` explicitly, I missed it in #689. Moreover, since the check was using `ifdef`, not defining `WORDS_BIGENDIAN` is not an error and would just treat all platforms as being little-endian.

For the fix, I switched to using `if` and have the define always be set to 0 or 1, so the compiler will at least provide a warning if a similar issue happens again.