### PR TITLE
CMake: Group and update options

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -1,38 +1,9 @@
 cmake_minimum_required(VERSION 3.9)
 
-option(WITH_XMP "Use libxmp if available" ON)
-if(WITH_XMP)
-    list(APPEND VCPKG_MANIFEST_FEATURES "libxmp")
-endif()
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-option(WITH_FLUIDSYNTH "Use FluidSynth if available" ON)
-if(WITH_FLUIDSYNTH)
-    list(APPEND VCPKG_MANIFEST_FEATURES "fluidsynth")
-endif()
-
-option(WITH_IMAGE "Use SDL2_image if available" ON)
-if(WITH_IMAGE)
-    list(APPEND VCPKG_MANIFEST_FEATURES "sdl2-image")
-endif()
-
-option(WITH_MAD "Use libmad if available" ON)
-if(WITH_MAD)
-    list(APPEND VCPKG_MANIFEST_FEATURES "libmad")
-endif()
-
-option(WITH_PORTMIDI "Use PortMidi if available" ON)
-if(WITH_PORTMIDI)
-    list(APPEND VCPKG_MANIFEST_FEATURES "portmidi")
-endif()
-
-option(WITH_VORBISFILE "Use vorbisfile if available" ON)
-if(WITH_VORBISFILE)
-    list(APPEND VCPKG_MANIFEST_FEATURES "libvorbis")
-endif()
-
-# Automatically install dependencies
-set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-set(X_VCPKG_APPLOCAL_DEPS_INSTALL TRUE)
+# Setup dependencies options before `project()` so vcpkg features can be used
+include(DsdaDepsSetup)
 
 project("dsda-doom" VERSION 0.29.3)
 
@@ -46,8 +17,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
-
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(GNUInstallDirs)
 

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -18,15 +18,11 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-include(GNUInstallDirs)
-
 if(POLICY CMP0099)
   cmake_policy(SET CMP0099 NEW)
 else()
   message(WARNING "Your version of CMake is very old. This may cause linking issues if your dependencies are not in your compiler's default search paths.")
 endif()
-
-option(CMAKE_FIND_PACKAGE_PREFER_CONFIG "Search for package config before using Find modules" ON)
 
 if(VCPKG_TOOLCHAIN)
     set(ENV{PKG_CONFIG_PATH} "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/pkgconfig")
@@ -36,16 +32,11 @@ if(POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW)
 endif()
 
-include(CheckIPOSupported)
-check_ipo_supported(RESULT HAVE_LTO)
-
-include(CMakeDependentOption)
-cmake_dependent_option(ENABLE_LTO "Use link-time optimisation" OFF "HAVE_LTO" OFF)
-
 set(PROJECT_TARNAME "dsda-doom")
 set(WAD_DATA "dsda-doom.wad")
 set(PROJECT_STRING "${PROJECT_NAME} ${PROJECT_VERSION}")
 
+include(DsdaOptions)
 include(DsdaTargetFeatures)
 
 include(PkgConfigHelper)
@@ -118,26 +109,6 @@ if(WITH_PORTMIDI)
     endif()
 endif()
 
-if(WIN32)
-    set(DEFAULT_WAD_DIR ".")
-else()
-    set(DEFAULT_WAD_DIR "share/games/doom")
-endif()
-
-set(DSDAPWADDIR "${DEFAULT_WAD_DIR}" CACHE STRING "Path to install DSDA-Doom internal WAD, relative to CMAKE_INSTALL_PREFIX or absolute.")
-set(DOOMWADDIR "${CMAKE_INSTALL_PREFIX}/${DEFAULT_WAD_DIR}" CACHE PATH "Path to look for WAD files.")
-
-if(IS_ABSOLUTE "${DSDAPWADDIR}")
-    set(DSDA_ABSOLUTE_PWAD_PATH "${DSDAPWADDIR}")
-else()
-    set(DSDA_ABSOLUTE_PWAD_PATH "${CMAKE_INSTALL_PREFIX}/${DSDAPWADDIR}")
-endif()
-
-option(SIMPLECHECKS "Enable checks which only impose significant overhead if a posible error is detected" ON)
-
-# Debug options, disabled by default
-option(RANGECHECK "Enable internal range checking" OFF)
-
 include(DsdaConfigHeader)
 
 set(DSDA_OUTPUT_PATH ${CMAKE_BINARY_DIR})
@@ -181,11 +152,10 @@ install(FILES
     DESTINATION "${DSDAPWADDIR}"
 )
 
-if(WIN32)
-    install(FILES COPYING DESTINATION . RENAME COPYING.txt)
-else()
-    install(FILES COPYING DESTINATION "share/doc/${PROJECT_NAME}")
-endif()
+install(FILES
+    "COPYING"
+    DESTINATION "${DSDA_INSTALL_COPYRIGHT_DIR}"
+)
 
 if(WIN32)
     set(CPACK_GENERATOR ZIP)

--- a/prboom2/cmake/DsdaDepsSetup.cmake
+++ b/prboom2/cmake/DsdaDepsSetup.cmake
@@ -1,0 +1,34 @@
+option(WITH_FLUIDSYNTH "Use FluidSynth if available" ON)
+if(WITH_FLUIDSYNTH)
+    list(APPEND VCPKG_MANIFEST_FEATURES "fluidsynth")
+endif()
+
+option(WITH_IMAGE "Use SDL2_image if available" ON)
+if(WITH_IMAGE)
+    list(APPEND VCPKG_MANIFEST_FEATURES "sdl2-image")
+endif()
+
+option(WITH_MAD "Use libmad if available" ON)
+if(WITH_MAD)
+    list(APPEND VCPKG_MANIFEST_FEATURES "libmad")
+endif()
+
+option(WITH_PORTMIDI "Use PortMidi if available" ON)
+if(WITH_PORTMIDI)
+    list(APPEND VCPKG_MANIFEST_FEATURES "portmidi")
+endif()
+
+option(WITH_VORBISFILE "Use vorbisfile if available" ON)
+if(WITH_VORBISFILE)
+    list(APPEND VCPKG_MANIFEST_FEATURES "libvorbis")
+endif()
+
+option(WITH_XMP "Use libxmp if available" ON)
+if(WITH_XMP)
+    list(APPEND VCPKG_MANIFEST_FEATURES "libxmp")
+endif()
+
+if(CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg.cmake$")
+  option(VCPKG_APPLOCAL_DEPS "Copy dependencies in the output directory" ON)
+  option(X_VCPKG_APPLOCAL_DEPS_INSTALL "Copy dependencies during installation" ON)
+endif()

--- a/prboom2/cmake/DsdaOptions.cmake
+++ b/prboom2/cmake/DsdaOptions.cmake
@@ -1,0 +1,34 @@
+include_guard()
+
+if(WIN32)
+  set(default_bin_dir ".")
+  set(default_wad_dir ".")
+  set(default_copyright_dir ".")
+else()
+  include(GNUInstallDirs)
+  set(default_bin_dir "${CMAKE_INSTALL_BINDIR}")
+  set(default_wad_dir "${CMAKE_INSTALL_DATAROOTDIR}/games/doom")
+  set(default_copyright_dir "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}")
+endif()
+
+set(DSDAPWADDIR "${default_wad_dir}" CACHE STRING "Path to install DSDA-Doom internal WAD")
+set(DOOMWADDIR "${CMAKE_INSTALL_PREFIX}/${default_wad_dir}" CACHE PATH "Path to look for WAD files.")
+set(DSDA_INSTALL_COPYRIGHT_DIR "${default_copyright_dir}" CACHE STRING "Destination of the copyright file")
+set(DSDA_INSTALL_BINDIR "${default_bin_dir}" CACHE STRING "Destination of the dsda-doom binary")
+
+option(SIMPLECHECKS "Enable checks which only impose significant overhead if a posible error is detected" ON)
+option(RANGECHECK "Enable internal range checking" OFF)
+
+option(CMAKE_FIND_PACKAGE_PREFER_CONFIG "Search for package config before using Find modules" ON)
+
+if(IS_ABSOLUTE "${DSDAPWADDIR}")
+    set(DSDA_ABSOLUTE_PWAD_PATH "${DSDAPWADDIR}")
+else()
+    set(DSDA_ABSOLUTE_PWAD_PATH "${CMAKE_INSTALL_PREFIX}/${DSDAPWADDIR}")
+endif()
+
+# Removed options
+
+if(DEFINED CACHE{ENABLE_LTO})
+  message(AUTHOR_WARNING "ENABLE_LTO has been removed, set CMAKE_INTERPROCEDURAL_OPTIMIZATION instead")
+endif()

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -559,7 +559,6 @@ function(AddGameExecutable TARGET SOURCES)
 
     set_target_properties(${TARGET} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${DSDA_OUTPUT_PATH}
-        INTERPROCEDURAL_OPTIMIZATION ${ENABLE_LTO}
         C_STANDARD 99
     )
 
@@ -603,12 +602,6 @@ function(AddGameExecutable TARGET SOURCES)
         )
     endif()
 
-    if(WIN32)
-        set(DSDA_BINARY_INSTALL_DIR ".")
-    else()
-        set(DSDA_BINARY_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
-    endif()
-
     if(CMAKE_VERSION VERSION_GREATER 3.20
         AND WIN32
         AND NOT VCPKG_TOOLCHAIN
@@ -619,10 +612,10 @@ function(AddGameExecutable TARGET SOURCES)
                 PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
                 POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
                 DIRECTORIES $<TARGET_FILE_DIR:${TARGET}> $ENV{PATH}
-            RUNTIME DESTINATION "${DSDA_BINARY_INSTALL_DIR}"
+            RUNTIME DESTINATION "${DSDA_INSTALL_BINDIR}"
         )
     else()
-        install(TARGETS ${TARGET} RUNTIME DESTINATION "${DSDA_BINARY_INSTALL_DIR}")
+        install(TARGETS ${TARGET} RUNTIME DESTINATION "${DSDA_INSTALL_BINDIR}")
     endif()
 
     target_link_libraries(${TARGET} PRIVATE


### PR DESCRIPTION
This PR moves all CMake options into two modules:
- `DsdaDepsSetup`, for all dependencies and vcpkg options, as they should be set *before* `project` is called.
- `DsdaOptions`, for all the other options.

Additionally, a few tweaks are made:
- vcpkg options are set in cache with a default value instead of being forcefully enabled, and are only set if the vcpkg toolchain is detected.
- Instead of forcing the install directory of the license file and the binary on Windows, the cache settings `DSDA_INSTALL_COPYRIGHT_DIR` and `DSDA_INSTALL_BINDIR` are added and default to the same values used on each platforms before this patch.
- The `ENABLE_LTO` option **is removed**. Setting `CMAKE_INTERPROCEDURAL_OPTIMIZATION` offers the exact same functionality, but also let's the user selectively enable it for specific build config by setting `CMAKE_INTERPROCEDURAL_OPTIMIZATION_<build config>`. A warning is printed if `ENABLE_LTO` is set, encouraging users to use CMake's built-in variable.