### PR TITLE
Catch crash if animation has speed 0

### DIFF
--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -246,16 +246,22 @@ void P_InitPicAnims (void)
 
     lastanim->istexture = animdefs[i].istexture;
     lastanim->numpics = lastanim->picnum - lastanim->basepic + 1;
+    lastanim->speed = LittleLong(animdefs[i].speed);
 
     // [crispy] skip reading SMMU swirling flats
     if (lastanim->speed < 65536 && lastanim->numpics != 1)
-    { 
+    {
       if (lastanim->numpics < 2)
           I_Error ("P_InitPicAnims: bad cycle from %s to %s",
                     animdefs[i].startname,
                     animdefs[i].endname);
     }
-    lastanim->speed = LittleLong(animdefs[i].speed); // killough 5/5/98: add LONG()
+
+    if (lastanim->speed == 0)
+        I_Error ("P_InitPicAnims: %s to %s animation cannot have speed 0",
+                    animdefs[i].startname,
+                    animdefs[i].endname);
+
     lastanim++;
   }
 


### PR DESCRIPTION
Division by zero when animation speed is 0. Somehow it doesnt crash on mac, but does on windows and linux.
Woof also crashes, it would be good to catch it there as well.

[animcrash.wad.zip](https://github.com/user-attachments/files/21093562/animcrash.wad.zip)
