### PR TITLE
Dont delete save using Enter

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5546,7 +5546,7 @@ typedef enum {
 
 static confirmation_t M_EventToConfirmation(int ch, int action, event_t* ev)
 {
-  if (ch == 'y' || action == MENU_ENTER)
+  if (ch == 'y' || (!delete_verify && action == MENU_ENTER))
     return confirmation_yes;
   else if (ch == ' ' || ch == KEYD_ESCAPE || ch == 'n' || action == MENU_BACKSPACE)
     return confirmation_no;


### PR DESCRIPTION
> A usability issue I've been having:
This input prompt accepts ENTER as Y, which is a problem for me because ENTER is very close to DEL, so I occasionally fat-finger both of those keys and boom, I permanently lose a save-game while just trying to load. It would be nice if this prompt only literally accepted Y as a confirmation input for safety.