### PR TITLE
rdatawad: Cleanup header inclusion

### DIFF
--- a/prboom2/data/rd_graphic.c
+++ b/prboom2/data/rd_graphic.c
@@ -3,14 +3,14 @@
 
 // Convert portable pixmap to Doom patch format
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <ctype.h>
-
-#include "rd_util.h"
-#include "rd_palette.h"
 #include "rd_graphic.h"
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rd_palette.h"
+#include "rd_util.h"
 
 //
 // parseppm

--- a/prboom2/data/rd_graphic.h
+++ b/prboom2/data/rd_graphic.h
@@ -1,6 +1,11 @@
 // Copyright (c) 1993-2011 PrBoom developers (see AUTHORS)
 // Licence: GPLv2 or later (see COPYING)
 
+#ifndef RD_GRAPHIC_H
+#define RD_GRAPHIC_H
+
+#include <stddef.h>
+
 // Convert portable pixmap to Doom format
 
 // convert ppm to doom patch format, with insertion point
@@ -9,3 +14,5 @@ size_t ppm_to_patch(void **lumpdata, const char *filename,
 
 // convert ppm to raw bitmap (for use with flats)
 size_t ppm_to_bitmap(void **lumpdata, const char *filename);
+
+#endif /* RD_GRAPHIC_H */

--- a/prboom2/data/rd_main.c
+++ b/prboom2/data/rd_main.c
@@ -3,16 +3,16 @@
 
 // Main program, parse command line arguments
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "rd_util.h"
-#include "rd_output.h"
-#include "rd_sound.h"
-#include "rd_palette.h"
 #include "rd_graphic.h"
+#include "rd_output.h"
+#include "rd_palette.h"
+#include "rd_sound.h"
+#include "rd_util.h"
 
 enum argtype
 {

--- a/prboom2/data/rd_output.c
+++ b/prboom2/data/rd_output.c
@@ -3,13 +3,13 @@
 
 // Output wad construction - add lump data, build wad directory
 
-#include <stdlib.h>
+#include "rd_output.h"
+
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "rd_util.h"
-#include "rd_output.h"
 
 struct lump
 {

--- a/prboom2/data/rd_output.h
+++ b/prboom2/data/rd_output.h
@@ -1,6 +1,11 @@
 // Copyright (c) 1993-2011 PrBoom developers (see AUTHORS)
 // Licence: GPLv2 or later (see COPYING)
 
+#ifndef RD_OUTPUT_H
+#define RD_OUTPUT_H
+
+#include <stddef.h>
+
 // Output wad construction - add lump data, build wad directory
 
 // append lump to output wad
@@ -8,3 +13,5 @@ void output_add(const char *filename, const void *data, size_t size);
 
 // write output file to filename
 void output_write(const char *filename);
+
+#endif /* RD_OUTPUT_H */

--- a/prboom2/data/rd_palette.c
+++ b/prboom2/data/rd_palette.c
@@ -3,12 +3,11 @@
 
 // Chained hash lookup to convert rgb triples to palette indices
 
-#include <stdlib.h>
-#include <stdio.h>
+#include "rd_palette.h"
+
 #include <string.h>
 
 #include "rd_util.h"
-#include "rd_palette.h"
 
 static unsigned char *palette_data;
 

--- a/prboom2/data/rd_palette.h
+++ b/prboom2/data/rd_palette.h
@@ -1,6 +1,9 @@
 // Copyright (c) 1993-2011 PrBoom developers (see AUTHORS)
 // Licence: GPLv2 or later (see COPYING)
 
+#ifndef RD_PALETTE_H
+#define RD_PALETTE_H
+
 // Chained hash lookup to convert rgb triples to palette indices
 
 // load raw palette, create hash table etc.
@@ -8,3 +11,5 @@ void palette_init(const char *filename);
 
 // lookup colour index of rgb triple
 int palette_getindex(const unsigned char *rgb);
+
+#endif /* RD_PALETTE_H */

--- a/prboom2/data/rd_sound.c
+++ b/prboom2/data/rd_sound.c
@@ -3,12 +3,12 @@
 
 // Convert WAVE files to Doom sound format
 
+#include "rd_sound.h"
+
 #include <stdlib.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "rd_util.h"
-#include "rd_sound.h"
 
 //
 // wav_to_doom

--- a/prboom2/data/rd_sound.h
+++ b/prboom2/data/rd_sound.h
@@ -1,7 +1,14 @@
 // Copyright (c) 1993-2011 PrBoom developers (see AUTHORS)
 // Licence: GPLv2 or later (see COPYING)
 
+#ifndef RD_SOUND_H
+#define RD_SOUND_H
+
+#include <stddef.h>
+
 // Convert WAVE files to Doom sound format
 
 // convert wav file to doom sound format
 size_t wav_to_doom(void **lumpdata, const char *filename);
+
+#endif /* RD_SOUND_H */

--- a/prboom2/data/rd_util.c
+++ b/prboom2/data/rd_util.c
@@ -3,12 +3,12 @@
 
 // Useful utility functions
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdarg.h>
-
 #include "rd_util.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 void ATTR((noreturn)) die(const char *error, ...)
 {

--- a/prboom2/data/rd_util.h
+++ b/prboom2/data/rd_util.h
@@ -1,6 +1,11 @@
 // Copyright (c) 1993-2011 PrBoom developers (see AUTHORS)
 // Licence: GPLv2 or later (see COPYING)
 
+#ifndef RD_UTIL_H
+#define RD_UTIL_H
+
+#include <stddef.h>
+
 // Useful utility functions
 
 #ifdef __GNUC__
@@ -36,3 +41,5 @@ char *xstrdup(const char *s);
 // slurp an entire file into memory or kill yourself
 size_t read_or_die(void **ptr, const char *file);
 void search_path(const char *path);
+
+#endif /* RD_UTIL_H */


### PR DESCRIPTION
This PR updates the headers and how they're included in rdatawad's source.

Previously they sort of work through "happy accidents", there were no header guard at all, and some headers relied on being included after `size_t` was defined instead of including `stddef.h`.

This PR attempts to clean that mess a little, by:
- Adding header guards, so things don't explode if a header is included twice.
- Making all header self-contained, so they can be included on their own.
- Updating the inclusions done in .c files (drop unused headers, group them by type, and sort them).