### PR TITLE
CMake: Bump minimum version to 3.17

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,7 +29,6 @@ jobs:
               -A x64
               -DCMAKE_TOOLCHAIN_FILE="${env:VCPKG_INSTALLATION_ROOT}\scripts\buildsystems\vcpkg.cmake"
               -DVCPKG_TARGET_TRIPLET=x64-windows-static-release
-              -DCMAKE_POLICY_DEFAULT_CMP0091=NEW
               -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
               -DCMAKE_IGNORE_PATH="C:/Strawberry/perl/bin;C:/Strawberry/c/lib"
 

--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.17...4.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
@@ -18,18 +18,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-if(POLICY CMP0099)
-  cmake_policy(SET CMP0099 NEW)
-else()
-  message(WARNING "Your version of CMake is very old. This may cause linking issues if your dependencies are not in your compiler's default search paths.")
-endif()
-
 if(VCPKG_TOOLCHAIN)
     set(ENV{PKG_CONFIG_PATH} "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib/pkgconfig")
-endif()
-
-if(POLICY CMP0069)
-    cmake_policy(SET CMP0069 NEW)
 endif()
 
 set(PROJECT_TARNAME "dsda-doom")


### PR DESCRIPTION
This PR bumps the minimum version of CMake to 3.17.

The main reasons for this change are:
- No more deprecation warning every time CMake is configured! And since the version is set as a range, there shouldn't be any for a decade or two.
- The project was actually using features from versions >3.9, most notably CPack's External generator is a 3.13 feature.
- When using vcpkg in completely static builds on macOS/Linux, it may fail the link step due to how link flags are handled.
- vcpkg's `X_VCPKG_APPLOCAL_DEPS_INSTALL` (which copies DLL to the install directory) requires CMake 3.14.

If bumping the minimum version sounds scary, here's the platform support for reference:
- macOS/Windows typically get the latest (or close to) CMake version through brew, chocolatey, or even Visual Studio.
- the current Debian oldstable ships with CMake 3.18.
- Installing a newer CMake version on Linux can be done rather trivially, either downloading the prebuilt binaries from cmake.org, or by running `pip install cmake`.

---

Don't hesitate to let me know if that is too high of a requirement for the project! At a bare minimum, 3.13 should be used to reflect what is actually used in the project, but I picked 3.17 as it ensures all the policies we want are available while having good platform support.