### PR TITLE
Add sound clicking fix from Woof

### DIFF
--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -272,7 +272,7 @@ INLINE static dboolean IsDMXSound(const byte *data, int len)
   return len > DMXHDRSIZE && data[0] == 0x03 && data[1] == 0x00;
 }
 
-static void CacheSounds(void)
+void I_CacheSounds(void)
 {
   int id;
   for (id = 1; id < num_sfx; id++)
@@ -824,10 +824,6 @@ void I_InitSound(void)
 
   if (!nomusicparm)
     I_InitMusic();
-
-  lprintf(LO_DEBUG, " Precaching all sound effects... ");
-  CacheSounds();
-  lprintf(LO_DEBUG, "done\n");
 
   lprintf(LO_DEBUG, "I_InitSound: sound module ready\n");
   SDL_PauseAudio(0);

--- a/prboom2/src/dsda/ambient.cpp
+++ b/prboom2/src/dsda/ambient.cpp
@@ -43,6 +43,15 @@ typedef struct {
 std::unordered_map<std::string, named_sfx_t> name_to_sfx;
 std::unordered_map<int, ambient_sfx_t> id_to_ambient_sfx;
 
+dboolean dsda_IsLoopingAmbientSFX(int sfx_id) {
+  for (auto &amb_sfx : id_to_ambient_sfx) {
+    if (amb_sfx.second.sfx_id == sfx_id && amb_sfx.second.min_tics < 0)
+      return true;
+  }
+
+  return false;
+}
+
 static ambient_sfx_t* dsda_AmbientSFX(int id) {
   return id_to_ambient_sfx[id].sfx_id ? &id_to_ambient_sfx[id] : NULL;
 }

--- a/prboom2/src/dsda/ambient.h
+++ b/prboom2/src/dsda/ambient.h
@@ -40,6 +40,7 @@ typedef struct {
   int wait_tics;
 } ambient_source_t;
 
+dboolean dsda_IsLoopingAmbientSFX(int sfx_id);
 void dsda_UpdateAmbientSource(ambient_source_t* source);
 void dsda_SpawnAmbientSource(mobj_t* mobj);
 void dsda_LoadAmbientSndInfo(void);

--- a/prboom2/src/i_sound.h
+++ b/prboom2/src/i_sound.h
@@ -56,6 +56,8 @@ void I_ShutdownSound(void);
 //  SFX I/O
 //
 
+void I_CacheSounds(void);
+
 // Initialize channels?
 void I_SetChannels(void);
 

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -203,6 +203,10 @@ void S_Init(void)
 
       dsda_CacheSoundLumps();
 
+      lprintf(LO_DEBUG, " Precaching all sound effects... ");
+      I_CacheSounds();
+      lprintf(LO_DEBUG, "done\n");
+
       // {
       //   int i;
       //   const int snd_curve_length = 1200;

--- a/prboom2/src/w_memcache.c
+++ b/prboom2/src/w_memcache.c
@@ -88,3 +88,8 @@ const void *W_LockLumpNum(int lump)
 {
   return W_LumpByNum(lump);
 }
+
+void *W_GetModifiableLumpData(int lump)
+{
+  return lump_data[lump];
+}

--- a/prboom2/src/w_mmap.c
+++ b/prboom2/src/w_mmap.c
@@ -260,3 +260,8 @@ const void* W_LockLumpNum(int lump)
 
   return lump_data[lump];
 }
+
+void *W_GetModifiableLumpData(int lump)
+{
+  return lump_data[lump];
+}

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -164,6 +164,7 @@ char*   W_ReadLumpToString (int lump);
 const void* W_SafeLumpByNum (int lump);
 const void* W_LumpByNum (int lump);
 const void* W_LockLumpNum(int lump);
+void *W_GetModifiableLumpData(int lump);
 
 int W_LumpNumExists(int lump);
 int W_LumpNameExists(const char *name);


### PR DESCRIPTION
This applies a short, unnoticeable fade-in/out for sounds that start/end at a non-zero amplitude which would normally cause a "clicking" noise. Looping ambient sounds are excluded. This doesn't fix other types of clicking (e.g. abruptly stopping a sound) due to the simple design of DSDA-Doom's custom mixer.

References:
- https://github.com/fabiangreffrath/woof/pull/1220
- https://github.com/fabiangreffrath/woof/pull/1731
- https://github.com/fabiangreffrath/woof/pull/1732
- https://www.doomworld.com/forum/post/2809830