### PR TITLE
CMake: Make a helper for setting build config.

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -7,15 +7,14 @@ include(DsdaDepsSetup)
 
 project("dsda-doom" VERSION 0.29.3)
 
-# Set a default build type if none was specified
-set(default_build_type "RelWithDebInfo")
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+set(dsda_is_top_project FALSE)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(dsda_is_top_project TRUE)
+endif()
+
+include(DsdaHelpers)
+if(dsda_is_top_proejct)
+    dsda_set_default_build_config(RelWithDebInfo)
 endif()
 
 if(VCPKG_TOOLCHAIN)

--- a/prboom2/cmake/DsdaHelpers.cmake
+++ b/prboom2/cmake/DsdaHelpers.cmake
@@ -5,3 +5,24 @@ function(dsda_fail_if_invalid_target tgt)
     message(FATAL_ERROR "${tgt} is not a valid CMake target.")
   endif()
 endfunction()
+
+function(dsda_set_default_build_config build_config)
+  get_cmake_property(is_multi_config GENERATOR_IS_MULTI_CONFIG)
+  if(NOT is_multi_config AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "${build_config}"
+      CACHE STRING "Build configuration"
+      FORCE
+    )
+    set_property(
+      CACHE CMAKE_BUILD_TYPE
+      PROPERTY STRINGS
+      "Debug" "Release" "MinSizeRel" "RelWithDebInfo"
+    )
+  elseif(CMAKE_GENERATOR STREQUAL "Ninja Multi-Config")
+    if(build_config IN_LIST CMAKE_CONFIGURATION_TYPES)
+      set(CMAKE_DEFAULT_BUILD_TYPE ${build_config})
+    else()
+      message(AUTHOR_WARNING "${build_config} is not a known config type.")
+    endif()
+  endif()
+endfunction()


### PR DESCRIPTION
This PR moves setting the default build configuration to its own helper.

Additionally, it better handles multi-config generators, setting the default there too when possible (currently only for `Ninja Multi-Config`), and not setting `CMAKE_BUILD_TYPE` when unnecessary.