### PR TITLE
Fix building with libxmp disabled

### DIFF
--- a/prboom2/src/MUSIC/flplayer.c
+++ b/prboom2/src/MUSIC/flplayer.c
@@ -35,7 +35,8 @@
 #include "musicplayer.h"
 
 #ifndef HAVE_LIBFLUIDSYNTH
-#include <string.h>
+
+#include <stddef.h>
 
 static const char *fl_name (void)
 {

--- a/prboom2/src/MUSIC/madplayer.c
+++ b/prboom2/src/MUSIC/madplayer.c
@@ -37,7 +37,8 @@
 #include "musicplayer.h"
 
 #ifndef HAVE_LIBMAD
-#include <string.h>
+
+#include <stddef.h>
 
 static const char *mp_name (void)
 {

--- a/prboom2/src/MUSIC/portmidiplayer.c
+++ b/prboom2/src/MUSIC/portmidiplayer.c
@@ -38,7 +38,8 @@
 #include "musicplayer.h"
 
 #ifndef HAVE_LIBPORTMIDI
-#include <string.h>
+
+#include <stddef.h>
 
 static const char *pm_name (void)
 {

--- a/prboom2/src/MUSIC/vorbisplayer.c
+++ b/prboom2/src/MUSIC/vorbisplayer.c
@@ -37,7 +37,8 @@
 #include "musicplayer.h"
 
 #ifndef HAVE_LIBVORBISFILE
-#include <string.h>
+
+#include <stddef.h>
 
 static const char *vorb_name (void)
 {

--- a/prboom2/src/MUSIC/xmpplayer.c
+++ b/prboom2/src/MUSIC/xmpplayer.c
@@ -22,6 +22,8 @@
 
 #ifndef HAVE_LIBXMP
 
+#include <stddef.h>
+
 static const char *xmp_name(void)
 {
   return "libxmp tracker player (DISABLED)";


### PR DESCRIPTION
xmpplayer.c fails building when `WITH_XMP` is disabled from NULL not being defined.

Other players deal with this by including `string.h` when the backend is disabled, this switches to `stddef.h` so it *hopefully* has clearer intent.