### PR TITLE
Fix warnings on mingw

### DIFF
--- a/prboom2/src/SDL/i_sndfile.c
+++ b/prboom2/src/SDL/i_sndfile.c
@@ -51,7 +51,7 @@ static sf_count_t sfvio_tell(void *user_data)
   return mem_ftell((MEMFILE *)user_data);
 } 
 
-void *Load_SNDFile(void *data, SDL_AudioSpec *sample, void **sampledata,
+void *Load_SNDFile(const void *data, SDL_AudioSpec *sample, void **sampledata,
                    Uint32 *samplelen)
 {
   SNDFILE *sndfile;

--- a/prboom2/src/SDL/i_sndfile.h
+++ b/prboom2/src/SDL/i_sndfile.h
@@ -18,7 +18,7 @@
 
 #include "SDL_audio.h"
 
-void *Load_SNDFile(void *data, SDL_AudioSpec *sample, void **sampledata,
+void *Load_SNDFile(const void *data, SDL_AudioSpec *sample, void **sampledata,
 				   Uint32 *samplelen);
 
 #endif

--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -234,7 +234,7 @@ static snd_data_t *GetSndData(int sfxid, const unsigned char *data, size_t len)
     void *sampledata;
     Uint32 samplelen = (Uint32)len;
 
-    if (Load_SNDFile((void *)data, &sample, &sampledata, &samplelen) == NULL)
+    if (Load_SNDFile(data, &sample, &sampledata, &samplelen) == NULL)
     {
       lprintf(LO_WARN, "Can't open sfx file: %s\n", S_sfx[sfxid].name);
       return NULL;

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -732,7 +732,7 @@ int force_singletics_to = 0;
 
 int HU_DrawDemoProgress(int force)
 {
-  extern float mouse_hide_timer;
+  extern int mouse_hide_timer;
   static unsigned int last_update = 0;
   static int prev_len = -1;
 

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -825,7 +825,7 @@ void F_BunnyScroll (void)
     laststage = stage;
   }
 
-  sprintf (name,"END%i",stage);
+  snprintf(name, sizeof name, "END%i", stage);
   // CPhipps - patch drawing updated
   V_DrawNamePatch((320-13*8)/2, (200-8*8)/2, 0, name, CR_DEFAULT, VPT_STRETCH);
 }


### PR DESCRIPTION
This PR brings a few fixes to have a warning-free build on an x86_64 mingw toolchain with GCC 15.

The warnings were:
- In `i_sound.c`, the cast to `(void*)` would trigger `-Wcast-qual`, it was possible to make the function just accept a const pointer.
- In `e6y.c` and `SDL/i_video.c`, building with LTO highlights that the global `mouse_hide_timer` had mismatched type declaration. It *seems* that the correct type is `int`, but correct me if I'm wrong.
- In `f_finale.c`, the call to `sprintf` would trigger `-Wformat-overflow`. Probably a false positive with the analyser not noticing the early returns with `finalecount`. Since the size of `name` is known, moving to `snprintf` is trivial and silences the warning, alternatively, clamping `stage` between 0 and 6 would also fix this.