### PR TITLE
CMake: Fix typo

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -13,7 +13,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 endif()
 
 include(DsdaHelpers)
-if(dsda_is_top_proejct)
+if(dsda_is_top_project)
     dsda_set_default_build_config(RelWithDebInfo)
 endif()
 


### PR DESCRIPTION
Fix a typo from #726 that made the `if` always evaluate to false...