### PR TITLE
CMake: Add sanitizers options

### DIFF
--- a/prboom2/CMakeLists.txt
+++ b/prboom2/CMakeLists.txt
@@ -12,6 +12,10 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(dsda_is_top_project TRUE)
 endif()
 
+if(dsda_is_top_project)
+    include(DsdaSanitiser)
+endif()
+
 include(DsdaHelpers)
 if(dsda_is_top_project)
     dsda_set_default_build_config(RelWithDebInfo)

--- a/prboom2/cmake/DsdaSanitiser.cmake
+++ b/prboom2/cmake/DsdaSanitiser.cmake
@@ -1,0 +1,51 @@
+include_guard()
+
+include(CheckCCompilerFlag)
+include(CMakeDependentOption)
+
+if(MSVC)
+  check_c_compiler_flag(/fsanitize=address HAVE_ASAN)
+  cmake_dependent_option(DSDA_ENABLE_ASAN
+    "Enable address sanitiser"
+    OFF "HAVE_ASAN" OFF
+  )
+
+  if(DSDA_ENABLE_ASAN)
+    string(REPLACE "/RTC1" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    add_compile_options(/fsanitize=address /fsanitize-address-use-after-return)
+  endif()
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+  set(sanitiser_names address undefined thread)
+  set(sanitiser_ids ASAN UBSAN TSAN)
+  foreach(santiser_name sanitiser_id IN ZIP_LISTS sanitiser_names sanitiser_ids)
+    list(APPEND CMAKE_REQUIRED_LINK_OPTIONS -fsanitize=${sanitiser_name})
+    check_c_compiler_flag(-fsanitize=${sanitiser_name} HAVE_${sanitiser_id})
+    cmake_dependent_option(DSDA_ENABLE_${sanitiser_id}
+      "Enable ${sanitiser_name} sanitiser"
+      OFF "HAVE_${sanitiser_id}" OFF
+    )
+    list(POP_BACK CMAKE_REQUIRED_LINK_OPTIONS)
+  endforeach()
+
+  if(DSDA_ENABLE_ASAN AND DSDA_ENABLE_TSAN)
+    message(FATAL_ERROR
+      "Invalid sanitizer combination:\n"
+      "  DSDA_ENABLE_ASAN: ${DSDA_ENABLE_ASAN}\n"
+      "  DSDA_ENABLE_UBSAN: ${DSDA_ENABLE_UBSAN}\n"
+      "  DSDA_ENABLE_TSAN: ${DSDA_ENABLE_TSAN}\n"
+    )
+  endif()
+
+  add_compile_options(
+    -fno-omit-frame-pointer
+    $<$<BOOL:${DSDA_ENABLE_ASAN}>:-fsanitize=address>
+    $<$<BOOL:${DSDA_ENABLE_UBSAN}>:-fsanitize=undefined>
+    $<$<BOOL:${DSDA_ENABLE_TSAN}>:-fsanitize=thread>
+  )
+  add_link_options(
+    $<$<BOOL:${DSDA_ENABLE_ASAN}>:-fsanitize=address>
+    $<$<BOOL:${DSDA_ENABLE_UBSAN}>:-fsanitize=undefined>
+    $<$<BOOL:${DSDA_ENABLE_TSAN}>:-fsanitize=thread>
+  )
+endif()


### PR DESCRIPTION
Patch by @FtZPetruska 

UBSAN reports many `"member access within misaligned address"` errors in the save/restore code. I think we should fix them.