### PR TITLE
Add "TITLEPIC/CREDIT cycle" for WADs with blank internal demos

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -683,7 +683,7 @@ static void D_PageDrawer(void)
     V_DrawNamePatchFS(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
   }
   else
-    M_DrawCredits();
+    M_DrawCreditsDynamic();
 }
 
 //

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -654,6 +654,18 @@ void D_PageTicker(void)
     D_AdvanceDemo();
 }
 
+// Check whether to skip IWAD Demos
+static int dsda_SkipIwadDemos(void)
+{
+  int pwaddemo = W_PWADLumpNameExists("DEMO1");
+  int pwadmaps = W_PWADLumpNameExists("THINGS");
+
+  if ((pwadmaps && !pwaddemo) || lumpinfo[W_CheckNumForName("DEMO1")].size == 0)
+    return true;
+  
+  return false;
+}
+
 //
 // D_PageDrawer
 //
@@ -682,6 +694,8 @@ static void D_PageDrawer(void)
     V_ClearBorder();
     V_DrawNamePatchFS(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
   }
+  else if (dsda_SkipIwadDemos() && W_PWADLumpNameExists("CREDIT"))
+    M_DrawCredits();
   else
     M_DrawCreditsDynamic();
 }
@@ -825,6 +839,17 @@ void D_DoAdvanceDemo(void)
   // do not even attempt to play DEMO4 if it is not available
   if (demosequence == 6 && gamemode == commercial && !W_LumpNameExists("demo4"))
     demosequence = 0;
+
+  if (dsda_SkipIwadDemos())
+  {
+    // Skip blank / IWAD demos in PWADs
+    if (demostates[demosequence][gamemode].func == G_DeferedPlayDemo)
+      demosequence++;
+
+    // Limit to just TITLEPIC / CREDIT
+    if (demosequence > (raven ? 3 : 2))
+      demosequence = 0;
+  }
 
   demostates[demosequence][gamemode].func(demostates[demosequence][gamemode].name);
 }

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -658,7 +658,7 @@ void D_PageTicker(void)
 static int dsda_SkipIwadDemos(void)
 {
   int pwaddemo = W_PWADLumpNameExists("DEMO1");
-  int pwadmaps = W_PWADLumpNameExists("THINGS");
+  int pwadmaps = W_PWADMapExists();
 
   if ((pwadmaps && !pwaddemo) || lumpinfo[W_CheckNumForName("DEMO1")].size == 0)
     return true;

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -604,8 +604,17 @@ static void M_DrawReadThis1(void)
 
 static void M_DrawReadThis2(void)
 {
+  const char* helplump = (gamemode == commercial) ? "HELP" : "HELP1";
+  int pwadmaps = W_PWADLumpNameExists("THINGS"); // show help screen for IWAD
+
   inhelpscreens = true;
-  M_DrawHelp();
+
+  if (W_PWADLumpNameExists(helplump) || !pwadmaps)
+    M_DrawHelp();
+  else if (W_PWADLumpNameExists("CREDIT"))
+    M_DrawCredits();
+  else
+    M_DrawCreditsDynamic();
 }
 
 /////////////////////////////
@@ -4427,22 +4436,20 @@ setup_menu_t cred_settings[]={
 
 void M_DrawCredits(void)     // killough 10/98: credit screen
 {
-  const char* credit = "CREDIT";
-  const int PWADcredit = W_PWADLumpNameExists(credit);
-
   inhelpscreens = true;
-  if (PWADcredit || tc_game)
-  {
-    V_ClearBorder();
-    V_DrawNamePatchFS(0, 0, 0, credit, CR_DEFAULT, VPT_STRETCH);
-  }
-  else
-  {
-    // Use V_DrawBackground here deliberately to force drawing a background
-    V_DrawBackground(gamemode==shareware ? "CEIL5_1" : "MFLR8_4", 0);
-    M_DrawTitle(9, PROJECT_NAME " v" PROJECT_VERSION, cr_title); // PRBOOM
-    M_DrawScreenItems(cred_settings, 32);
-  }
+
+  V_ClearBorder();
+  V_DrawNamePatchFS(0, 0, 0, "CREDIT", CR_DEFAULT, VPT_STRETCH);
+}
+
+void M_DrawCreditsDynamic(void)     // Dynamic Credits
+{
+  inhelpscreens = true;
+
+  // Use V_DrawBackground here deliberately to force drawing a background
+  V_DrawBackground(gamemode==shareware ? "CEIL5_1" : "MFLR8_4", 0);
+  M_DrawTitle(9, PROJECT_NAME " v" PROJECT_VERSION, cr_title); // PRBOOM
+  M_DrawScreenItems(cred_settings, 32);
 }
 
 static int M_IndexInChoices(const char *str, const char **choices) {

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -605,7 +605,7 @@ static void M_DrawReadThis1(void)
 static void M_DrawReadThis2(void)
 {
   const char* helplump = (gamemode == commercial) ? "HELP" : "HELP1";
-  int pwadmaps = W_PWADLumpNameExists("THINGS"); // show help screen for IWAD
+  int pwadmaps = W_PWADMapExists(); // show help screen for IWAD
 
   inhelpscreens = true;
 

--- a/prboom2/src/m_menu.h
+++ b/prboom2/src/m_menu.h
@@ -79,7 +79,8 @@ void M_ForcedLoadGame(const char *msg); // killough 5/15/98: forced loadgames
 
 void M_ResetMenu(void);      // killough 11/98: reset main menu ordering
 
-void M_DrawCredits(void);    // killough 11/98
+void M_DrawCredits(void);
+void M_DrawCreditsDynamic(void);    // killough 11/98
 
 void M_DrawTabs(const char **pages, int m, int y);
 

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -625,8 +625,12 @@ int W_LumpNameExists2(const char *name, int ns)
 
 int W_PWADLumpNameExists(const char *name)
 {
-  int lump = W_CheckNumForName(name);
-  return (W_PWADLumpNumExists(lump));
+  return W_PWADLumpNumExists(W_CheckNumForName(name));
+}
+
+int W_PWADMapExists(void)
+{
+  return W_PWADLumpNameExists("THINGS") || W_PWADLumpNameExists("TEXTMAP");
 }
 
 void W_Shutdown(void)

--- a/prboom2/src/w_wad.h
+++ b/prboom2/src/w_wad.h
@@ -171,6 +171,7 @@ int W_LumpNameExists(const char *name);
 int W_LumpNameExists2(const char *name, int ns);
 int W_PWADLumpNumExists(int lump);
 int W_PWADLumpNameExists(const char *name);
+int W_PWADMapExists(void);
 
 // CPhipps - convenience macros
 //#define W_LumpByNum(num) (W_LumpByNum)((num),1)


### PR DESCRIPTION
PR does what the title says.

Due to the cycle being based on other code, I brought over Nyan functionality separating the types of CREDITS (graphic and "dynamic"), as well as allowing the HELP screen to show CREDIT (or Dynamic Credits) based on what lumps are found in the PWAD.

Order goes: PWAD HELP > PWAD CREDIT > DYNAMIC CREDIT

The reasoning for this is that for the longest time, PrBoom used CREDIT for the HELP screen erroneously... which resulted in many wads (i.e Scythe 2) including a CREDIT lump, but not a HELP lump.

Edit: I think it's worth having a discussion around automatically disabling the IWAD internal demos for PWADs (w/ maps)... As Nyan Doom has this functionality tied to a config option. I don't see any reason why anyone would want to see a desyncing "Circle of Death" demo for wads that don't include custom internal demos. We could even just have it enabled by default without a config option. Thoughts?