### PR TITLE
Intermission "Now Entering" Extended Pause

### DIFF
--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -285,7 +285,7 @@ float Get_TextSpeed(void)
 // killough 5/10/98: add back v1.9 demo compatibility
 //
 
-static dboolean F_ShowCast(void)
+dboolean F_ShowCast(void)
 {
   return gamemap == 30 ||
          (gamemission == pack_nerve && allow_incompatibility && gamemap == 8) ||

--- a/prboom2/src/f_finale.h
+++ b/prboom2/src/f_finale.h
@@ -47,6 +47,8 @@ void F_Ticker (void);
 /* Called by main loop. */
 void F_Drawer (void);
 
+dboolean F_ShowCast(void);
+
 void F_StartFinale (void);
 void F_StartCast (const char* background, const char* music, dboolean loop_music);
 void F_StartScroll (const char* right, const char* left, const char* music, dboolean loop_music);

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -1169,8 +1169,7 @@ void WI_drawShowNextLoc(void)
     return; // MAP08 end game
 
   // draws which level you are entering..
-  if ( (gamemode != commercial)
-     || wbs->next != 30)  // check for MAP30 end game
+  if ( (gamemode != commercial) || (gamemap != 30) )  // allows for MAP31 entering screen, if not MAP30
   WI_drawEL();
 }
 

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -35,6 +35,7 @@
 #include "doomstat.h"
 #include "m_random.h"
 #include "w_wad.h"
+#include "f_finale.h"
 #include "g_game.h"
 #include "r_main.h"
 #include "v_video.h"
@@ -968,6 +969,15 @@ void WI_End(void)
     WI_endStats();
 }
 
+#define WI_LONGER_NOW_ENTERING (allow_incompatibility && gamemode == commercial && !netgame)
+
+void WI_wait(void)
+{
+  if (WI_LONGER_NOW_ENTERING && !F_ShowCast())
+      cnt = TICRATE + 10;
+  else
+      cnt = 10;
+}
 
 // ====================================================================
 // WI_initNoState
@@ -979,7 +989,7 @@ void WI_initNoState(void)
 {
   state = NoState;
   acceleratestage = 0;
-  cnt = 10;
+  WI_wait();
 }
 
 
@@ -1032,10 +1042,9 @@ static void WI_drawTimeStats(int cnt_time, int cnt_total_time, int cnt_par)
 //
 void WI_updateNoState(void)
 {
-
   WI_updateAnimatedBack();
 
-  if (!--cnt)
+  if (!--cnt || (WI_LONGER_NOW_ENTERING && acceleratestage))
     G_WorldDone();
 }
 


### PR DESCRIPTION
This is a pretty simple PR. Many people complain (including me) that for Doom 2 you can't read the mapname on "Now Entering" screen, like in some other ports like GZDoom.

This PR adds an extended pause (not in demos) that is also skippable via a keypress.

I also threw in another fix that's tangentially related, which allows the "Now Entering" to show when entering MAP31. Currently it shows nothing when entering MAP31 (you can see this in Eviternity II). This is because this code was supposed to avoid the "Now Entering" for after MAP30 (i.e. next map would be MAP31), but ended up also not showing "Now Entering" for any map entering MAP31.