### PR TITLE
Fix many clang warnings

### DIFF
--- a/prboom2/src/MUSIC/midifile.c
+++ b/prboom2/src/MUSIC/midifile.c
@@ -604,7 +604,7 @@ static dboolean ReadFileHeader(midi_file_t *file, midimem_t *mf)
      || ntohl(file->header.chunk_header.chunk_size) != 6)
     {
         lprintf (LO_WARN, "ReadFileHeader: Invalid MIDI chunk header! "
-                        "chunk_size=%ld\n",
+                        "chunk_size=%" PRIu32 "\n",
                         ntohl(file->header.chunk_header.chunk_size));
         return false;
     }

--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -340,9 +340,12 @@ static const char *I_GetXDGDataHome(void)
 
     if (!xdgdatahome || !*xdgdatahome)
     {
+      size_t datahome_size;
       const char *home = I_GetHomeDir();
-      datahome = Z_Malloc(strlen(home) + 1 + sizeof(".local/share"));
-      sprintf(datahome, "%s%s%s", home, !HasTrailingSlash(home) ? "/" : "", ".local/share");
+
+      datahome_size = strlen(home) + 1 + sizeof(".local/share");
+      datahome = Z_Malloc(datahome_size);
+      snprintf(datahome, datahome_size, "%s%s%s", home, !HasTrailingSlash(home) ? "/" : "", ".local/share");
     }
     else
     {
@@ -580,6 +583,7 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
   for (i = 0; i < num_search; i++) {
     const char  * d = NULL;
     const char  * s = NULL;
+    size_t p_size = PATH_MAX;
     /* Each entry in the switch sets d to the directory to look in,
      * and optionally s to a subdirectory of d */
     // switch replaced with lookup table
@@ -593,10 +597,14 @@ char* I_FindFileInternal(const char* wfname, const char* ext, dboolean isStatic)
     s = search[i].sub;
 
     if (!isStatic)
-      p = (char*)Z_Malloc((d ? strlen(d) : 0) + (s ? strlen(s) : 0) + pl);
-    sprintf(p, "%s%s%s%s%s", d ? d : "", (d && !HasTrailingSlash(d)) ? "/" : "",
-                             s ? s : "", (s && !HasTrailingSlash(s)) ? "/" : "",
-                             wfname);
+    {
+      p_size = (d ? strlen(d) : 0) + (s ? strlen(s) : 0) + pl;
+      p = (char*)Z_Malloc(p_size);
+    }
+
+    snprintf(p, p_size, "%s%s%s%s%s", d ? d : "", (d && !HasTrailingSlash(d)) ? "/" : "",
+                                     s ? s : "", (s && !HasTrailingSlash(s)) ? "/" : "",
+                                     wfname);
 
     if (ext && !M_FileExists(p))
       strcat(p, ext);

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -469,7 +469,7 @@ void AM_setMarkParams(int num)
   int i, namelen;
   char namebuf[16];
 
-  sprintf(namebuf,"%s", !raven ? "AMMNUM0" : "SMALLIN0");
+  snprintf(namebuf, sizeof(namebuf), "%s", !raven ? "AMMNUM0" : "SMALLIN0");
   namelen = !raven ? 6 : 7;
 
   markpoints[num].w = 0;
@@ -1908,6 +1908,9 @@ static void AM_drawWalls(void)
       case ams_unseen:
         AM_drawMline(&l, mapcolor_p->unsn);
         continue;
+
+      default:
+        continue;
     }
   }
 }
@@ -2629,7 +2632,7 @@ static void AM_drawMarks(void)
   int i, namelen;
   char namebuf[16];
 
-  sprintf(namebuf,"%s", !raven ? "AMMNUM0" : "SMALLIN0");
+  snprintf(namebuf, sizeof(namebuf), "%s", !raven ? "AMMNUM0" : "SMALLIN0");
   namelen = !raven ? 6 : 7;
 
   if (map_trail_mode && dsda_RevealAutomap())

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -372,7 +372,7 @@ void D_Display (fixed_t frac)
 {
   static dboolean isborderstate        = false;
   static dboolean borderwillneedredraw = false;
-  static gamestate_t oldgamestate = -1;
+  static gamestate_t oldgamestate = GS_DEFAULT;
   dboolean wipe;
   dboolean viewactive = false, isborder = false;
 
@@ -399,7 +399,7 @@ void D_Display (fixed_t frac)
 
   if (setsizeneeded) {               // change the view size if needed
     R_ExecuteSetViewSize();
-    oldgamestate = -1;            // force background redraw
+    oldgamestate = GS_DEFAULT;            // force background redraw
   }
 
   if (V_IsOpenGLMode() && !exclusive_fullscreen && !nodrawers)
@@ -414,7 +414,7 @@ void D_Display (fixed_t frac)
 
   if (gamestate != GS_LEVEL) { // Not a level
     switch (oldgamestate) {
-    case -1:
+    case GS_DEFAULT:
     case GS_LEVEL:
       V_SetPalette(0); // cph - use default (basic) palette
     default:
@@ -1783,7 +1783,7 @@ static void dsda_DetectEpisodeStructure(void)
   {
     for (ii=0;ii<10;ii++)
     {
-      sprintf(lump, "E%dM%d", i, ii);
+      snprintf(lump, sizeof(lump), "E%dM%d", i, ii);
       if (W_LumpNameExists(lump))
       {
         EpisodeStructure = true;

--- a/prboom2/src/doomdef.h
+++ b/prboom2/src/doomdef.h
@@ -153,6 +153,7 @@ extern int SCREEN_320x200;
 // at the intermission screen, the game final animation, or a demo.
 
 typedef enum {
+  GS_DEFAULT = -1,
   GS_LEVEL,
   GS_INTERMISSION,
   GS_FINALE,

--- a/prboom2/src/dsda/cr_table.c
+++ b/prboom2/src/dsda/cr_table.c
@@ -73,7 +73,7 @@ static void dsda_RegisterFontLightness(double lightness) {
     cr_font.light_upper_bound = lightness;
 }
 
-static void dsda_CalculateFontBounds(const char *playpal) {
+static void dsda_CalculateFontBounds(const byte* playpal) {
   int i, j;
   const byte* lump;
   const byte* p;

--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -511,7 +511,7 @@ static dboolean dsda_UseDemoNameWithTime(void) {
 static char* dsda_DemoNameWithTime(void) {
   char* demo_name;
   char* base_name;
-  int counter = 2;
+  unsigned int counter = 2;
   size_t length;
 
   length = strlen(dsda_demo_name_base) + 16 + 1;
@@ -579,7 +579,7 @@ void dsda_EndDemoRecording(void) {
 void dsda_ExportDemo(const char* name) {
   char* demo_name;
   char* base_name;
-  int counter = 2;
+  unsigned int counter = 2;
   int old_offset;
 
   base_name = Z_Strdup(name);

--- a/prboom2/src/dsda/exdemo.c
+++ b/prboom2/src/dsda/exdemo.c
@@ -76,7 +76,7 @@ static const filelump_t* DemoEx_LumpForName(const char* name, const wadinfo_t* h
 static char* DemoEx_LumpAsString(const char* name, const wadinfo_t* header) {
   char* str;
   const char* lump_data;
-  const byte* buffer;
+  const char* buffer;
   const filelump_t* lump_info;
 
   lump_info = DemoEx_LumpForName(name, header);
@@ -85,7 +85,7 @@ static char* DemoEx_LumpAsString(const char* name, const wadinfo_t* header) {
 
   str = Z_Calloc(lump_info->size + 1, 1);
 
-  buffer = (const byte*) header;
+  buffer = (const char*) header;
   lump_data = buffer + lump_info->filepos;
   strncpy(str, lump_data, lump_info->size);
 
@@ -210,11 +210,11 @@ static void DemoEx_GetParams(const wadinfo_t* header) {
       for (overflow = 0; overflow < OVERFLOW_MAX; overflow++) {
         int value;
         char* pstr;
-        char* mask;
+        size_t mask_size = strlen(overflow_cfgname[overflow]) + 16;
+        char* mask = Z_Malloc(mask_size);
 
-        mask = Z_Malloc(strlen(overflow_cfgname[overflow]) + 16);
         if (mask) {
-          sprintf(mask, "-set %s", overflow_cfgname[overflow]);
+          snprintf(mask, mask_size, "-set %s", overflow_cfgname[overflow]);
           pstr = strstr(str, mask);
 
           if (pstr) {
@@ -311,54 +311,54 @@ static void DemoEx_AddParams(wadtbl_t* wadtbl) {
 
   // add complevel for formats which do not have it in header
   if (demo_compatibility) {
-    sprintf(buf, "-complevel %d ", compatibility_level);
+    snprintf(buf, sizeof(buf), "-complevel %d ", compatibility_level);
     dsda_StringCat(&files, buf);
   }
 
   // for recording or playback using "single-player coop" mode
   if (dsda_Flag(dsda_arg_solo_net)) {
-    sprintf(buf, "-solo-net ");
+    snprintf(buf, sizeof(buf), "-solo-net ");
     dsda_StringCat(&files, buf);
   }
 
   // for recording or playback using "coop in single-player" mode
   if (dsda_Flag(dsda_arg_coop_spawns)) {
-    sprintf(buf, "-coop_spawns ");
+    snprintf(buf, sizeof(buf), "-coop_spawns ");
     dsda_StringCat(&files, buf);
   }
 
   // for recording multiple episodes in one demo
   if (dsda_Flag(dsda_arg_chain_episodes)) {
-    sprintf(buf, "-chain_episodes ");
+    snprintf(buf, sizeof(buf), "-chain_episodes ");
     dsda_StringCat(&files, buf);
   }
 
   arg = dsda_Arg(dsda_arg_emulate);
   if (arg->found) {
-    sprintf(buf, "-emulate %s", arg->value.v_string);
+    snprintf(buf, sizeof(buf), "-emulate %s", arg->value.v_string);
     dsda_StringCat(&files, buf);
   }
 
   // doom 1.2 does not store these params in header
   if (compatibility_level == doom_12_compatibility) {
     if (dsda_Flag(dsda_arg_respawn)) {
-      sprintf(buf, "-respawn ");
+      snprintf(buf, sizeof(buf), "-respawn ");
       dsda_StringCat(&files, buf);
     }
 
     if (dsda_Flag(dsda_arg_fast)) {
-      sprintf(buf, "-fast ");
+      snprintf(buf, sizeof(buf), "-fast ");
       dsda_StringCat(&files, buf);
     }
 
     if (dsda_Flag(dsda_arg_nomonsters)) {
-      sprintf(buf, "-nomonsters ");
+      snprintf(buf, sizeof(buf), "-nomonsters ");
       dsda_StringCat(&files, buf);
     }
   }
 
   if (spechit_baseaddr != 0 && spechit_baseaddr != DEFAULT_SPECHIT_MAGIC) {
-    sprintf(buf, "-spechit %d ", spechit_baseaddr);
+    snprintf(buf, sizeof(buf), "-spechit %d ", spechit_baseaddr);
     dsda_StringCat(&files, buf);
   }
 
@@ -367,7 +367,7 @@ static void DemoEx_AddParams(wadtbl_t* wadtbl) {
     overrun_list_t overflow;
     for (overflow = 0; overflow < OVERFLOW_MAX; overflow++) {
       if (overflows[overflow].happened) {
-        sprintf(buf, "-set %s=%d ", overflow_cfgname[overflow], overflows[overflow].emulate);
+        snprintf(buf, sizeof(buf), "-set %s=%d ", overflow_cfgname[overflow], overflows[overflow].emulate);
         dsda_StringCat(&files, buf);
       }
     }
@@ -451,7 +451,7 @@ static void DemoEx_GetFeatures(const wadinfo_t* header) {
 static void DemoEx_AddFeatures(wadtbl_t* wadtbl) {
   dsda_cksum_t cksum;
   char* description;
-  byte* buffer;
+  char* buffer;
   size_t buffer_length;
   byte *features;
   char current_feature[3];
@@ -475,7 +475,7 @@ static void DemoEx_AddFeatures(wadtbl_t* wadtbl) {
   strcat(buffer, "-");
   strcat(buffer, cksum.string);
 
-  AddPWADTableLump(wadtbl, DEMOEX_FEATURE_LUMPNAME, buffer, buffer_length);
+  AddPWADTableLump(wadtbl, DEMOEX_FEATURE_LUMPNAME, (const byte*)buffer, buffer_length);
 
   Z_Free(buffer);
   Z_Free(description);

--- a/prboom2/src/dsda/font.c
+++ b/prboom2/src/dsda/font.c
@@ -32,7 +32,7 @@ void dsda_InitFont(void) {
 
   j = HU_FONTSTART;
   for (i = 0; i < HU_FONTSIZE - 1; i++, j++) {
-    sprintf(buffer, "DIG%.3d", j);
+    snprintf(buffer, sizeof(buffer), "DIG%.3d", j);
     R_SetPatchNum(&hu_font2[i], buffer);
   }
 
@@ -40,25 +40,25 @@ void dsda_InitFont(void) {
   for (i = 0; i < HU_FONTSIZE; ++i, ++j) {
     if ('0' <= j && j <= '9') {
       if (raven)
-        sprintf(buffer, "FONTA%.2d", j - 32);
+        snprintf(buffer, sizeof(buffer), "FONTA%.2d", j - 32);
       else
-        sprintf(buffer, "STCFN%.3d", j);
+        snprintf(buffer, sizeof(buffer), "STCFN%.3d", j);
       R_SetPatchNum(&hu_font[i], buffer);
     }
     else if ('A' <= j && j <= 'Z') {
       if (raven)
-        sprintf(buffer, "FONTA%.2d", j - 32);
+        snprintf(buffer, sizeof(buffer), "FONTA%.2d", j - 32);
       else
-        sprintf(buffer, "STCFN%.3d", j);
+        snprintf(buffer, sizeof(buffer), "STCFN%.3d", j);
       R_SetPatchNum(&hu_font[i], buffer);
     }
     else if (!raven && j < 97) {
-      sprintf(buffer, "STCFN%.3d", j);
+      snprintf(buffer, sizeof(buffer), "STCFN%.3d", j);
       R_SetPatchNum(&hu_font[i], buffer);
       //jff 2/23/98 make all font chars defined, useful or not
     }
     else if (raven && j < 91) {
-      sprintf(buffer, "FONTA%.2d", j - 32);
+      snprintf(buffer, sizeof(buffer), "FONTA%.2d", j - 32);
       R_SetPatchNum(&hu_font[i], buffer);
       //jff 2/23/98 make all font chars defined, useful or not
     }

--- a/prboom2/src/dsda/hud_components/command_display.c
+++ b/prboom2/src/dsda/hud_components/command_display.c
@@ -148,50 +148,50 @@ static void dsda_UpdateCommandText(dsda_command_t* command,
                                    dsda_text_t* component, dboolean playback) {
   int length;
 
-  length = sprintf(component->msg, "%s", display_command->color);
+  length = snprintf(component->msg, sizeof(component->msg), "%s", display_command->color);
 
   if (playback)
-    length += sprintf(component->msg + length, " PL  ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, " PL  ");
   else if (display_command->repeat)
-    length += sprintf(component->msg + length, "x%-3d ", display_command->repeat + 1);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "x%-3d ", display_command->repeat + 1);
   else
-    length += sprintf(component->msg + length, "     ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "     ");
 
   if (command->forwardmove > 0)
-    length += sprintf(component->msg + length, "MF%2d ", command->forwardmove);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "MF%2d ", command->forwardmove);
   else if (command->forwardmove < 0)
-    length += sprintf(component->msg + length, "MB%2d ", -command->forwardmove);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "MB%2d ", -command->forwardmove);
   else
-    length += sprintf(component->msg + length, "     ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "     ");
 
   if (command->sidemove > 0)
-    length += sprintf(component->msg + length, "SR%2d ", command->sidemove);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "SR%2d ", command->sidemove);
   else if (command->sidemove < 0)
-    length += sprintf(component->msg + length, "SL%2d ", -command->sidemove);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "SL%2d ", -command->sidemove);
   else
-    length += sprintf(component->msg + length, "     ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "     ");
 
   if (command->angleturn > 0)
-    length += sprintf(component->msg + length, "TL%2d ", command->angleturn);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "TL%2d ", command->angleturn);
   else if (command->angleturn < 0)
-    length += sprintf(component->msg + length, "TR%2d ", -command->angleturn);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "TR%2d ", -command->angleturn);
   else
-    length += sprintf(component->msg + length, "     ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "     ");
 
   if (command->attack)
-    length += sprintf(component->msg + length, "A");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "A");
   else
-    length += sprintf(component->msg + length, " ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, " ");
 
   if (command->use)
-    length += sprintf(component->msg + length, "U");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "U");
   else
-    length += sprintf(component->msg + length, " ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, " ");
 
   if (command->change)
-    length += sprintf(component->msg + length, "C%d", command->change);
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "C%d", command->change);
   else
-    length += sprintf(component->msg + length, "  ");
+    length += snprintf(component->msg + length, sizeof(component->msg) - length, "  ");
 
   dsda_RefreshHudText(component);
 }

--- a/prboom2/src/dsda/input.c
+++ b/prboom2/src/dsda/input.c
@@ -96,6 +96,8 @@ void dsda_InputTrackEvent(event_t* ev) {
     case ev_joystick:
       dsda_InputTrackButtons(joybuttons, MAX_JOY_BUTTONS, ev);
       break;
+    default:
+      break;
   }
 }
 
@@ -147,6 +149,8 @@ void dsda_InputTrackGameEvent(event_t* ev) {
       break;
     case ev_joystick:
       dsda_InputTrackGameButtons(joybuttons, MAX_JOY_BUTTONS, ev);
+      break;
+    default:
       break;
   }
 }

--- a/prboom2/src/dsda/mapinfo/legacy.c
+++ b/prboom2/src/dsda/mapinfo/legacy.c
@@ -342,7 +342,7 @@ int dsda_LegacyMusicIndexToLumpNum(int* lump, int music_index) {
 
   format = raven ? "%s" : "d_%s";
 
-  sprintf(name, format, S_music[music_index].name);
+  snprintf(name, sizeof(name), format, S_music[music_index].name);
 
   *lump = W_GetNumForName(name);
 

--- a/prboom2/src/dsda/palette.c
+++ b/prboom2/src/dsda/palette.c
@@ -82,7 +82,7 @@ void dsda_FreePlayPal(void) {
     }
 }
 
-static dboolean dsda_DuplicatePaletteEntry(const char *playpal, int i, int j) {
+static dboolean dsda_DuplicatePaletteEntry(const byte *playpal, int i, int j) {
   int colormap_i;
 
   if (
@@ -99,7 +99,7 @@ static dboolean dsda_DuplicatePaletteEntry(const char *playpal, int i, int j) {
   return true;
 }
 
-double dsda_PaletteEntryLightness(const char *playpal, int i) {
+double dsda_PaletteEntryLightness(const byte *playpal, int i) {
   double L;
   byte pal_r, pal_g, pal_b;
   double r, g, b;
@@ -148,7 +148,7 @@ void dsda_InitPlayPal(void) {
 
   for (playpal_i = 0; playpal_i < NUMPALETTES; ++playpal_i) {
     int lump;
-    const char *playpal;
+    const byte *playpal;
     int i, j, found = 0;
 
     lump = W_CheckNumForName(playpal_data[playpal_i].lump_name);

--- a/prboom2/src/dsda/palette.h
+++ b/prboom2/src/dsda/palette.h
@@ -50,7 +50,7 @@ typedef struct playpal_data_s {
   SDL_Color* colours;
 } dsda_playpal_t;
 
-double dsda_PaletteEntryLightness(const char *playpal, int i);
+double dsda_PaletteEntryLightness(const byte *playpal, int i);
 dsda_playpal_t* dsda_PlayPalData(void);
 void dsda_CyclePlayPal(void);
 void dsda_SetPlayPal(int index);

--- a/prboom2/src/dsda/split_tracker.c
+++ b/prboom2/src/dsda/split_tracker.c
@@ -182,20 +182,20 @@ static void dsda_LoadSplits(void) {
 
 void dsda_WriteSplits(void) {
   char* path;
-  byte  buffer[32 * 100];
-  byte* p = buffer;
+  char  buffer[22 + 72 * dsda_splits_count];
+  char* p = buffer;
   int i;
 
   if (!attempts)
     return;
-
   path = dsda_SplitTrackerPath();
 
-  p += sprintf(p, "%d %d\n", attempts, SPLIT_VERSION);
+  p += snprintf(p, 22, "%d %d\n", attempts, SPLIT_VERSION);
 
   for (i = 0; i < dsda_splits_count; ++i) {
-    p += sprintf(
-      p, "%i %i %i %i %i %i %i\n",
+    p += snprintf(
+      p, 72,
+      "%i %i %i %i %i %i %i\n",
       dsda_splits[i].episode,
       dsda_splits[i].map,
       dsda_splits[i].leveltime.best,

--- a/prboom2/src/dsda/split_tracker.c
+++ b/prboom2/src/dsda/split_tracker.c
@@ -22,6 +22,7 @@
 #include "m_file.h"
 #include "lprintf.h"
 #include "e6y.h"
+#include "z_zone.h"
 
 #include "dsda/args.h"
 #include "dsda/demo.h"
@@ -182,7 +183,7 @@ static void dsda_LoadSplits(void) {
 
 void dsda_WriteSplits(void) {
   char* path;
-  char  buffer[22 + 72 * dsda_splits_count];
+  char *buffer = Z_Malloc(22 + 72 * dsda_splits_count);
   char* p = buffer;
   int i;
 
@@ -208,6 +209,8 @@ void dsda_WriteSplits(void) {
 
   if (!M_WriteFile(path, buffer, p - buffer))
     I_Warn("dsda_WriteSplits: Failed to write splits file \"%s\". (%d)", path, errno);
+
+  Z_Free(buffer);
 }
 
 static void dsda_UpdateReferenceSplits(void) {

--- a/prboom2/src/dsda/utility.c
+++ b/prboom2/src/dsda/utility.c
@@ -96,7 +96,7 @@ void dsda_TranslateCheckSum(dsda_cksum_t* cksum) {
   unsigned int i;
 
   for (i = 0; i < 16; i++)
-    sprintf(&cksum->string[i * 2], "%02x", cksum->bytes[i]);
+    snprintf(&cksum->string[i * 2], 3, "%02x", cksum->bytes[i]);
   cksum->string[32] = '\0';
 }
 
@@ -174,23 +174,23 @@ void dsda_PrintCommandMovement(char* str, ticcmd_t* cmd) {
   str[0] = '\0';
 
   if (cmd->forwardmove > 0)
-    str += sprintf(str, "MF%2d ", cmd->forwardmove);
+    str += snprintf(str, 6, "MF%2d ", cmd->forwardmove);
   else if (cmd->forwardmove < 0)
-    str += sprintf(str, "MB%2d ", -cmd->forwardmove);
+    str += snprintf(str, 6, "MB%2d ", -cmd->forwardmove);
   else
-    str += sprintf(str, "     ");
+    str += snprintf(str, 6, "     ");
 
   if (cmd->sidemove > 0)
-    str += sprintf(str, "SR%2d ", cmd->sidemove);
+    str += snprintf(str, 6, "SR%2d ", cmd->sidemove);
   else if (cmd->sidemove < 0)
-    str += sprintf(str, "SL%2d ", -cmd->sidemove);
+    str += snprintf(str, 6, "SL%2d ", -cmd->sidemove);
   else
-    str += sprintf(str, "     ");
+    str += snprintf(str, 6, "     ");
 
   if (cmd->angleturn > 0)
-    str += sprintf(str, "TL%2d", cmd->angleturn >> 8);
+    str += snprintf(str, 6, "TL%2d", cmd->angleturn >> 8);
   else if (cmd->angleturn < 0)
-    str += sprintf(str, "TR%2d", -(cmd->angleturn >> 8));
+    str += snprintf(str, 6, "TR%2d", -(cmd->angleturn >> 8));
 }
 
 char* dsda_ConcatDir(const char* a, const char* b)

--- a/prboom2/src/e6y.c
+++ b/prboom2/src/e6y.c
@@ -585,7 +585,7 @@ void e6y_WriteStats(void)
 
   for (level=0;level<numlevels;level++)
   {
-    sprintf(str,
+    snprintf(str, sizeof(str),
       "%%s - %%%dd:%%05.2f (%%%dd:%%02d)  K: %%%dd/%%-%dd%%%lds  I: %%%dd/%%-%dd%%%lds  S: %%%dd/%%-%dd %%%lds\r\n",
       max.stat[TT_TIME],      max.stat[TT_TOTALTIME],
       max.stat[TT_ALLKILL],   max.stat[TT_TOTALKILL],   (long)allkills_len,

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -240,6 +240,8 @@ void F_StartFinale (void)
                        (gamemission == pack_plut) ? s_P4TEXT : s_C4TEXT;
         }
         break;
+      case indetermined:
+        break;
     }
   }
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -1711,6 +1711,9 @@ void G_Ticker (void)
     case GS_DEMOSCREEN:
       D_PageTicker();
       break;
+
+    case GS_DEFAULT:
+      break;
   }
 
   if (leveltime == entry_leveltime)
@@ -3928,7 +3931,7 @@ const byte* G_ReadDemoHeaderEx(const byte *demo_p, size_t size, unsigned int par
     {
       demo_tics_count = dsda_DemoTicsCount(p, demobuffer, demolength);
 
-      sprintf(demo_len_st, "\x1b\x35/%d:%02d",
+      snprintf(demo_len_st, sizeof(demo_len_st), "\x1b\x35/%d:%02d",
         demo_tics_count / TICRATE / 60,
         (demo_tics_count % (60 * TICRATE)) / TICRATE);
     }

--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -99,7 +99,7 @@ static void ShowOverflowWarning(overrun_list_t overflow, int fatal, const char *
 
     overflows[overflow].promted = true;
 
-    sprintf(buffer,
+    snprintf(buffer, sizeof(buffer),
       (fatal ? str1 : (EMULATE(overflow) ? str2 : str3)),
       name[overflow],
       "\nYou can change PrBoom behaviour for this overflow through in-game menu.",

--- a/prboom2/src/gl_sky.c
+++ b/prboom2/src/gl_sky.c
@@ -46,6 +46,7 @@
 #include <SDL.h>
 #include <math.h>
 
+#include "doomtype.h"
 #include "doomstat.h"
 #include "v_video.h"
 #include "gl_intern.h"
@@ -70,7 +71,7 @@ typedef struct
 
 typedef struct
 {
-  int id;
+  GLuint id;
   int rows, columns;
   int loopcount;
   GLSkyLoopDef *loops;

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -383,6 +383,8 @@ void MN_UpdateClass(int choice)
       SkillDef.menuitems[3].alttext = hexen_skill_mage[3];
       SkillDef.menuitems[4].alttext = hexen_skill_mage[4];
       break;
+    default:
+      break;
   }
 }
 

--- a/prboom2/src/info.c
+++ b/prboom2/src/info.c
@@ -46,8 +46,8 @@
 
 #include "info.h"
 
-void A_BetaSkullAttack(); // killough 10/98: beta lost souls attacked different
-void A_Stop();
+void A_BetaSkullAttack(mobj_t *actor); // killough 10/98: beta lost souls attacked different
+void A_Stop(mobj_t *actor);
 
 // ********************************************************************
 // Sprite names

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -75,23 +75,23 @@
 //
 //-----------------------------------------------------------------------------
 
-static void cheat_mus();
+static void cheat_mus(char buf[3]);
 static void cheat_choppers();
 static void cheat_god();
 static void cheat_fa();
 static void cheat_k();
 static void cheat_kfa();
 static void cheat_noclip();
-static void cheat_pw();
+static void cheat_pw(int pw);
 static void cheat_behold();
 static void cheat_clev0();
-static void cheat_clev();
+static void cheat_clev(char buf[3]);
 static void cheat_mypos();
 static void cheat_rate();
 static void cheat_comp0();
-static void cheat_comp();
+static void cheat_comp(char buf[3]);
 static void cheat_skill0();
-static void cheat_skill();
+static void cheat_skill(char buf[1]);
 static void cheat_friction();
 static void cheat_pushers();
 static void cheat_massacre();
@@ -103,11 +103,11 @@ static void cheat_hom();
 static void cheat_fast();
 static void cheat_tntkey();
 static void cheat_tntkeyx();
-static void cheat_tntkeyxx();
+static void cheat_tntkeyxx(int key);
 static void cheat_tntweap();
-static void cheat_tntweapx();
+static void cheat_tntweapx(char buf[3]);
 static void cheat_tntammo();
-static void cheat_tntammox();
+static void cheat_tntammox(char buf[1]);
 static void cheat_smart();
 static void cheat_pitch();
 static void cheat_megaarmour();
@@ -120,14 +120,14 @@ static void cheat_fly();
 static void cheat_reset_health();
 static void cheat_tome();
 static void cheat_chicken();
-static void cheat_artifact();
+static void cheat_artifact(char buf[3]);
 
 // hexen
 static void cheat_inventory();
 static void cheat_puzzle();
-static void cheat_class();
+static void cheat_class(char buf[2]);
 static void cheat_init();
-static void cheat_script();
+static void cheat_script(char buf[3]);
 
 //-----------------------------------------------------------------------------
 //
@@ -260,8 +260,7 @@ cheatseq_t cheat[] = {
 
 //-----------------------------------------------------------------------------
 
-static void cheat_mus(buf)
-char buf[3];
+static void cheat_mus(char buf[3])
 {
   int musnum, muslump;
   int epsd, map;
@@ -835,8 +834,7 @@ static void cheat_tntweap()
   dsda_AddMessage(gamemode == commercial ? "Weapon number 1-9" : "Weapon number 1-8");
 }
 
-static void cheat_tntweapx(buf)
-char buf[3];
+static void cheat_tntweapx(char buf[3])
 {
   int w = *buf - '1';
 
@@ -865,8 +863,7 @@ static void cheat_tntammo()
   dsda_AddMessage("Ammo 1-4, Backpack");
 }
 
-static void cheat_tntammox(buf)
-char buf[1];
+static void cheat_tntammox(char buf[1])
 {
   int a = *buf - '1';
   if (*buf == 'b')  // Ty 03/27/98 - strings *not* externalized

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1321,9 +1321,9 @@ void M_QuitDOOM(int choice)
   // or one at random, between 1 and maximum number.
   // Ty 03/27/98 - externalized DOSY as a string s_DOSY that's in the sprintf
   if (language != english)
-    sprintf(endstring,"%s\n\n%s",s_DOSY, *endmsg[0] );
+    snprintf(endstring, sizeof(endstring), "%s\n\n%s",s_DOSY, *endmsg[0] );
   else         // killough 1/18/98: fix endgame message calculation:
-    sprintf(endstring,"%s\n\n%s", *endmsg[gametic%(NUM_QUITMESSAGES-1)+1], s_DOSY);
+    snprintf(endstring, sizeof(endstring), "%s\n\n%s", *endmsg[gametic%(NUM_QUITMESSAGES-1)+1], s_DOSY);
 
   if (dsda_SkipQuitPrompt())
     M_QuitResponse(true);
@@ -1895,7 +1895,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
 
       value = dsda_IntConfig(s->config_id);
 
-      sprintf(menu_buffer, "%d", value);
+      snprintf(menu_buffer, sizeof(menu_buffer), "%d", value);
 
       if (flags & S_CRITEM)
       {
@@ -1942,7 +1942,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
       else
         format = "MB%d";
 
-      sprintf(menu_buffer + strlen(menu_buffer), format, input->mouseb + 1);
+      snprintf(menu_buffer + strlen(menu_buffer), sizeof(menu_buffer) - strlen(menu_buffer),format, input->mouseb + 1);
       any_input = true;
     }
 
@@ -1953,7 +1953,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
       else
         format = "%s";
 
-      sprintf(menu_buffer + strlen(menu_buffer), format,
+      snprintf(menu_buffer + strlen(menu_buffer), sizeof(menu_buffer) - strlen(menu_buffer), format,
               dsda_GameControllerButtonName(input->joyb));
       any_input = true;
     }
@@ -2061,9 +2061,9 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
     if (flags & S_STR)
     {
       if (setup_select && (s->m_flags & (S_HILITE | S_SELECT)))
-        sprintf(menu_buffer, "%s", entry_string_index);
+        snprintf(menu_buffer, sizeof(menu_buffer), "%s", entry_string_index);
       else
-        sprintf(menu_buffer, "%s", dsda_StringConfig(s->config_id));
+        snprintf(menu_buffer, sizeof(menu_buffer), "%s", dsda_StringConfig(s->config_id));
     }
     else
     {
@@ -2075,7 +2075,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
         value = dsda_IntConfig(s->config_id);
 
       if (s->selectstrings == NULL) {
-        sprintf(menu_buffer, "%d", value);
+        snprintf(menu_buffer, sizeof(menu_buffer), "%d", value);
       } else {
         strcpy(menu_buffer, s->selectstrings[value]);
       }
@@ -2090,7 +2090,7 @@ static void M_DrawSetting(const setup_menu_t* s, int y)
   if (flags & S_THERMO) {
     M_DrawThermo(x, y, 8, 16, dsda_IntConfig(s->config_id));
 
-    sprintf(menu_buffer, "%d", dsda_IntConfig(s->config_id));
+    snprintf(menu_buffer, sizeof(menu_buffer), "%d", dsda_IntConfig(s->config_id));
 
     if (s == current_setup_menu + set_menu_itemon && whichSkull && !setup_select)
       strcat(menu_buffer, " <");

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -811,6 +811,8 @@ void T_HexenPlatRaise(plat_t * plat)
                 SN_StartSequence((mobj_t *) & plat->sector->soundorg,
                                  SEQ_PLATFORM + plat->sector->seqType);
             }
+        default:
+            break;
     }
 }
 
@@ -887,6 +889,8 @@ int EV_DoHexenPlat(line_t * line, byte * args, plattype_e type, int amount)
                     plat->high = sec->floorheight;
                 plat->wait = args[2];
                 plat->status = P_Random(pr_hexen) & 1;
+                break;
+            default:
                 break;
         }
         P_AddActivePlat(plat);

--- a/prboom2/src/p_pspr.h
+++ b/prboom2/src/p_pspr.h
@@ -34,6 +34,8 @@
 #ifndef __P_PSPR__
 #define __P_PSPR__
 
+#include "p_mobj.h"
+
 /* Basic data types.
  * Needs fixed point, and BAM angles. */
 
@@ -98,49 +100,45 @@ void P_MovePsprites(struct player_s *curplayer);
 void P_DropWeapon(struct player_s *player);
 int P_AmmoPercent(struct player_s *player, int weapon);
 
-void A_Light0();
-void A_WeaponReady();
-void A_Lower();
-void A_Raise();
-void A_Punch();
-void A_ReFire();
-void A_FirePistol();
-void A_Light1();
-void A_FireShotgun();
-void A_Light2();
-void A_FireShotgun2();
-void A_CheckReload();
-void A_OpenShotgun2();
-void A_LoadShotgun2();
-void A_CloseShotgun2();
-void A_FireCGun();
-void A_GunFlash();
-void A_FireMissile();
-void A_Saw();
-void A_FirePlasma();
-void A_BFGsound();
-void A_FireBFG();
-void A_BFGSpray();
-void A_FireOldBFG();
+void A_Light0(struct player_s *player, pspdef_t *psp);
+void A_WeaponReady(struct player_s *player, pspdef_t *psp);
+void A_Lower(struct player_s *player, pspdef_t *psp);
+void A_Raise(struct player_s *player, pspdef_t *psp);
+void A_Punch(struct player_s *player, pspdef_t *psp);
+void A_ReFire(struct player_s *player, pspdef_t *psp);
+void A_FirePistol(struct player_s *player, pspdef_t *psp);
+void A_Light1(struct player_s *player, pspdef_t *psp);
+void A_FireShotgun(struct player_s *player, pspdef_t *psp);
+void A_Light2(struct player_s *player, pspdef_t *psp);
+void A_FireShotgun2(struct player_s *player, pspdef_t *psp);
+void A_CheckReload(struct player_s *player, pspdef_t *psp);
+void A_OpenShotgun2(struct player_s *player, pspdef_t *psp);
+void A_LoadShotgun2(struct player_s *player, pspdef_t *psp);
+void A_CloseShotgun2(struct player_s *player, pspdef_t *psp);
+void A_FireCGun(struct player_s *player, pspdef_t *psp);
+void A_GunFlash(struct player_s *player, pspdef_t *psp);
+void A_FireMissile(struct player_s *player, pspdef_t *psp);
+void A_Saw(struct player_s *player, pspdef_t *psp);
+void A_FirePlasma(struct player_s *player, pspdef_t *psp);
+void A_BFGsound(struct player_s *player, pspdef_t *psp);
+void A_FireBFG(struct player_s *player, pspdef_t *psp);
+void A_BFGSpray(mobj_t *mo);
+void A_FireOldBFG(struct player_s *player, pspdef_t *psp);
 
 // [XA] New mbf21 codepointers
 
-void A_WeaponProjectile();
-void A_WeaponBulletAttack();
-void A_WeaponMeleeAttack();
-void A_WeaponSound();
-void A_WeaponAlert();
-void A_WeaponJump();
-void A_ConsumeAmmo();
-void A_CheckAmmo();
-void A_RefireTo();
-void A_GunFlashTo();
+void A_WeaponProjectile(struct player_s *player, pspdef_t *psp);
+void A_WeaponBulletAttack(struct player_s *player, pspdef_t *psp);
+void A_WeaponMeleeAttack(struct player_s *player, pspdef_t *psp);
+void A_WeaponSound(struct player_s *player, pspdef_t *psp);
+void A_WeaponAlert(struct player_s *player, pspdef_t *psp);
+void A_WeaponJump(struct player_s *player, pspdef_t *psp);
+void A_ConsumeAmmo(struct player_s *player, pspdef_t *psp);
+void A_CheckAmmo(struct player_s *player, pspdef_t *psp);
+void A_RefireTo(struct player_s *player, pspdef_t *psp);
+void A_GunFlashTo(struct player_s *player, pspdef_t *psp);
 
 // heretic
-
-#include "p_mobj.h"
-
-struct player_s;
 
 void P_RepositionMace(mobj_t * mo);
 void P_ActivateBeak(struct player_s * player);

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -261,7 +261,7 @@ static void *calloc_IfSameLevel(void* p, size_t n1, size_t n2)
 // Checks a lump for a magic string to identify its type (e.g. extended nodes)
 //
 
-static dboolean CheckForIdentifier(int lumpnum, const byte *id, size_t length)
+static dboolean CheckForIdentifier(int lumpnum, const char *id, size_t length)
 {
   dboolean result = false;
 

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -325,6 +325,8 @@ static void R_DoAnInterpolation (int i, fixed_t smoothratio)
   case INTERP_SectorCeiling:
     gld_UpdateSplitData(((sector_t*)curipos[i].address));
     break;
+  default:
+    break;
   }
 }
 

--- a/prboom2/src/st_stuff.c
+++ b/prboom2/src/st_stuff.c
@@ -958,7 +958,7 @@ static void ST_loadGraphics(void)
   // Load the numbers, tall and short
   for (i=0;i<10;i++)
     {
-      sprintf(namebuf, "STTNUM%d", i);
+      snprintf(namebuf, sizeof(namebuf), "STTNUM%d", i);
       R_SetPatchNum(&tallnum[i],namebuf);
       snprintf(namebuf, sizeof(namebuf), "STYSNUM%d", i);
       R_SetPatchNum(&shortnum[i],namebuf);
@@ -970,7 +970,7 @@ static void ST_loadGraphics(void)
   // key cards
   for (i=0;i<DOOM_NUMCARDS+3;i++)  //jff 2/23/98 show both keys too
     {
-      sprintf(namebuf, "STKEYS%d", i);
+      snprintf(namebuf, sizeof(namebuf), "STKEYS%d", i);
       R_SetPatchNum(&keys[i], namebuf);
     }
 
@@ -984,7 +984,7 @@ static void ST_loadGraphics(void)
   // arms ownership widgets
   for (i=0;i<6;i++)
     {
-      sprintf(namebuf, "STGNUM%d", i+2);
+      snprintf(namebuf, sizeof(namebuf), "STGNUM%d", i+2);
 
       // gray #
       R_SetPatchNum(&arms[i][0], namebuf);
@@ -1005,18 +1005,18 @@ static void ST_loadGraphics(void)
       int j;
       for (j=0;j<ST_NUMSTRAIGHTFACES;j++)
         {
-          sprintf(namebuf, "STFST%d%d", i, j);
+          snprintf(namebuf, sizeof(namebuf), "STFST%d%d", i, j);
           R_SetPatchNum(&faces[facenum++], namebuf);
         }
-      sprintf(namebuf, "STFTR%d0", i);        // turn right
+      snprintf(namebuf, sizeof(namebuf), "STFTR%d0", i);        // turn right
       R_SetPatchNum(&faces[facenum++], namebuf);
-      sprintf(namebuf, "STFTL%d0", i);        // turn left
+      snprintf(namebuf, sizeof(namebuf), "STFTL%d0", i);        // turn left
       R_SetPatchNum(&faces[facenum++], namebuf);
-      sprintf(namebuf, "STFOUCH%d", i);       // ouch!
+      snprintf(namebuf, sizeof(namebuf), "STFOUCH%d", i);       // ouch!
       R_SetPatchNum(&faces[facenum++], namebuf);
-      sprintf(namebuf, "STFEVL%d", i);        // evil grin ;)
+      snprintf(namebuf, sizeof(namebuf), "STFEVL%d", i);        // evil grin ;)
       R_SetPatchNum(&faces[facenum++], namebuf);
-      sprintf(namebuf, "STFKILL%d", i);       // pissed off
+      snprintf(namebuf, sizeof(namebuf), "STFKILL%d", i);       // pissed off
       R_SetPatchNum(&faces[facenum++], namebuf);
     }
   R_SetPatchNum(&faces[facenum++], "STFGOD0");

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -426,7 +426,7 @@ int ParseUMapInfo(const unsigned char *buffer, size_t length, umapinfo_errorfunc
 				int ep, map;
 				G_ValidateMapName(parsed.mapname, &ep, &map);
 				map++;
-				sprintf(parsed.nextmap, "%s", VANILLA_MAP_LUMP_NAME(ep, map));
+				snprintf(parsed.nextmap, sizeof(parsed.nextmap), "%s", VANILLA_MAP_LUMP_NAME(ep, map));
 			}
 		}
 

--- a/prboom2/src/v_video.h
+++ b/prboom2/src/v_video.h
@@ -146,8 +146,7 @@ extern int          usegamma;
 // The available bit-depth modes
 typedef enum {
   VID_MODESW,
-  VID_MODEGL,
-  VID_MODEMAX
+  VID_MODEGL
 } video_mode_t;
 
 void V_InitMode(video_mode_t mode);

--- a/prboom2/src/wadtbl.c
+++ b/prboom2/src/wadtbl.c
@@ -98,7 +98,7 @@ void AddPWADTableLump(wadtbl_t *wadtbl, const char *name, const byte* data, size
   }
 }
 
-wadinfo_t *ReadPWADTable(char *buffer, size_t size)
+wadinfo_t *ReadPWADTable(byte *buffer, size_t size)
 {
   int i;
   unsigned int length;

--- a/prboom2/src/wadtbl.h
+++ b/prboom2/src/wadtbl.h
@@ -51,6 +51,6 @@ typedef struct
 void InitPWADTable(wadtbl_t *wadtbl);
 void FreePWADTable(wadtbl_t *wadtbl);
 void AddPWADTableLump(wadtbl_t *wadtbl, const char *name, const byte* data, size_t size);
-wadinfo_t *ReadPWADTable(char *buffer, size_t size);
+wadinfo_t *ReadPWADTable(byte *buffer, size_t size);
 
 #endif

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -406,9 +406,9 @@ static void WI_endNetgameStats(void);
 void WI_levelNameLump(int epis, int map, char* buf)
 {
   if (gamemode == commercial) {
-    sprintf(buf, "CWILV%2.2d", map);
+    snprintf(buf, 9, "CWILV%2.2d", map);
   } else {
-    sprintf(buf, "WILV%d%d", epis, map);
+    snprintf(buf, 9, "WILV%d%d", epis, map);
   }
 }
 
@@ -2100,7 +2100,7 @@ void WI_loadData(void)
   for (i=0;i<10;i++)
   {
     // numbers 0-9
-    sprintf(name, "WINUM%d", i);
+    snprintf(name, sizeof(name), "WINUM%d", i);
     R_SetPatchNum(&num[i], name);
   }
 }


### PR DESCRIPTION
There still remain warnings for the c++ `auto` types and `range-based loops`, as well as for some functions that are missing prototypes (like the `thinker_t .function`).

Im fine with not fixing these for now.