### PR TITLE
CMake: actually apply -Wno-format-truncation.

### DIFF
--- a/prboom2/cmake/DsdaTargetFeatures.cmake
+++ b/prboom2/cmake/DsdaTargetFeatures.cmake
@@ -30,14 +30,14 @@ function(dsda_internal_setup_warnings_gnu result_var)
     -Wdeclaration-after-statement
     -Wbad-function-cast
   )
-  set(GNU_WARNINGS_SET ${GNU_WARNINGS} ${GNU_C_WARNINGS})
-
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU"
     OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
     OR (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 17)
   )
-    list(APPEND GNU_WARNINGS_SET "-Wno-format-truncation")
+    list(APPEND GNU_WARNINGS "-Wno-format-truncation")
   endif()
+
+  set(GNU_WARNINGS_SET ${GNU_WARNINGS} ${GNU_C_WARNINGS})
 
   include(CheckCCompilerFlag)
   check_c_compiler_flag("${GNU_WARNINGS_SET}" DSDA_SUPPORTS_GNU_WARNINGS)


### PR DESCRIPTION
The check I added in 376fecc366676f4acf42c274ac64b141a90f304a incorrectly added the warning to the list of flags to check, and not to the list of warnings to be used.

Thanks to @andrikpowell for letting me know about the issue!