### PR TITLE
highlight non-countable pickup items on automap

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2488,15 +2488,22 @@ static void AM_drawThings(void)
         angle = 0x40000000;
       }
 
+      int color = mapcolor_p->sprt;
+
+      if (t->flags & MF_FRIEND && !t->player)
+        color = mapcolor_p->frnd;
+      /* cph 2006/07/30 - Show count-as-kills in red. */
+      else if ((t->flags & (MF_COUNTKILL | MF_CORPSE)) == MF_COUNTKILL)
+        color = mapcolor_p->enemy;
+      /* bbm 2/28/03 Show countable items in yellow. */
+      else if (t->flags & MF_COUNTITEM)
+        color = mapcolor_p->item;
+      else if (t->flags & MF_SPECIAL)
+        color = mapcolor_p->pickup;
+
       //jff 1/5/98 end added code for keys
       //jff previously entire code
-      AM_drawLineCharacter(lineguy, lineguylines, scale, angle,
-        t->flags & MF_FRIEND && !t->player ? mapcolor_p->frnd :
-        /* cph 2006/07/30 - Show count-as-kills in red. */
-        ((t->flags & (MF_COUNTKILL | MF_CORPSE)) == MF_COUNTKILL) ? mapcolor_p->enemy :
-        /* bbm 2/28/03 Show countable items in yellow. */
-        t->flags & MF_COUNTITEM ? mapcolor_p->item : mapcolor_p->sprt,
-        p.x, p.y);
+      AM_drawLineCharacter(lineguy, lineguylines, scale, angle, color, p.x, p.y);
       t = t->snext;
     }
    }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2413,6 +2413,7 @@ static void AM_drawThings(void)
     t = sectors[i].thinglist;
     while (t) // for all things in that sector
     {
+      int color;
       mpoint_t p;
       angle_t angle;
       fixed_t scale;
@@ -2443,7 +2444,7 @@ static void AM_drawThings(void)
       //jff 1/5/98 case over doomednum of thing being drawn
       if (mapcolor_p->rkey || mapcolor_p->ykey || mapcolor_p->bkey)
       {
-        int color = -1;
+        color = -1;
 
         if (heretic)
         {
@@ -2488,7 +2489,7 @@ static void AM_drawThings(void)
         angle = 0x40000000;
       }
 
-      int color = mapcolor_p->sprt;
+      color = mapcolor_p->sprt;
 
       if (t->flags & MF_FRIEND && !t->player)
         color = mapcolor_p->frnd;

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -74,6 +74,7 @@ typedef struct
   int plyr[8];
   int trail_1;
   int trail_2;
+  int pickup;
 } mapcolor_t;
 
 typedef struct map_point_s

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -576,7 +576,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_mapcolor_sprt] = {
     "mapcolor_sprt", dsda_config_mapcolor_sprt,
-    CONF_COLOR(208), &mapcolor.sprt
+    CONF_COLOR(88), &mapcolor.sprt
   },
   [dsda_config_mapcolor_item] = {
     "mapcolor_item", dsda_config_mapcolor_item,

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -576,7 +576,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_mapcolor_sprt] = {
     "mapcolor_sprt", dsda_config_mapcolor_sprt,
-    CONF_COLOR(112), &mapcolor.sprt
+    CONF_COLOR(208), &mapcolor.sprt
   },
   [dsda_config_mapcolor_item] = {
     "mapcolor_item", dsda_config_mapcolor_item,
@@ -609,6 +609,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
   [dsda_config_mapcolor_trail_2] = {
     "mapcolor_trail_2", dsda_config_mapcolor_trail_2,
     CONF_COLOR(100), &mapcolor.trail_2
+  },
+  [dsda_config_mapcolor_pickup] = {
+    "mapcolor_pickup", dsda_config_mapcolor_pickup,
+    CONF_COLOR(112), &mapcolor.pickup
   },
   [dsda_config_gl_skymode] = {
     "gl_skymode", dsda_config_gl_skymode,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -120,6 +120,7 @@ typedef enum {
   dsda_config_mapcolor_frnd,
   dsda_config_mapcolor_trail_1,
   dsda_config_mapcolor_trail_2,
+  dsda_config_mapcolor_pickup,
   dsda_config_gl_skymode,
   dsda_config_gl_render_multisampling,
   dsda_config_gl_render_fov,

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -226,6 +226,7 @@ static dsda_option_t option_list[] = {
   { "mapcolor_hair", NULL, 0, 255, dsda_config_mapcolor_hair },
   { "mapcolor_sngl", NULL, 0, 255, dsda_config_mapcolor_sngl },
   { "mapcolor_me", NULL, 0, 255, dsda_config_mapcolor_me },
+  { "mapcolor_pickup", NULL, 0, 255, dsda_config_mapcolor_pickup },
   { 0 }
 };
 

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3025,6 +3025,7 @@ setup_menu_t auto_colors_settings[] =  // 2st AutoMap Settings screen
   {"computer map unseen line"       ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_unsn},
   {"line w/no floor/ceiling changes",S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_flat},
   {"general sprite"                 ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_sprt},
+  {"pickup sprite"                  ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_pickup},
   {"countable enemy sprite"         ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_enemy},      // cph 2006/06/30
   {"countable item sprite"          ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_item},       // mead 3/4/2003
   {"crosshair"                      ,S_COLOR ,m_conf,AU_X, dsda_config_mapcolor_hair},


### PR DESCRIPTION
regular sprite color switched to white because those sprites are not useful in gameplay. green that they were using is now the pickup color, because those are valuable in gameplay.

<img width="640" height="480" alt="изображение" src="https://github.com/user-attachments/assets/28c32ebe-451a-4e1d-b652-41684c8cb987" />

<img width="640" height="480" alt="изображение" src="https://github.com/user-attachments/assets/85f2d13d-538f-42b8-8754-e76ac2613d9d" />
