### PR TITLE
Fix WeaponBob Demo Desync

### DIFF
--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -52,7 +52,6 @@
 #include "dsda.h"
 #include "dsda/aim.h"
 #include "dsda/excmd.h"
-#include "dsda/settings.h"
 
 #define LOWERSPEED   (FRACUNIT*6)
 #define RAISESPEED   (FRACUNIT*6)
@@ -629,11 +628,10 @@ void A_WeaponReady(player_t *player, pspdef_t *psp)
   // bob the weapon based on movement speed
   if (!player->morphTics)
   {
-    fixed_t bob = player->bob * dsda_WeaponBob() / 4;
     int angle = (128 * leveltime) & FINEMASK;
-    psp->sx = FRACUNIT + FixedMul(bob, finecosine[angle]);
+    psp->sx = FRACUNIT + FixedMul(player->bob, finecosine[angle]);
     angle &= FINEANGLES / 2 - 1;
-    psp->sy = WEAPONTOP + FixedMul(bob, finesine[angle]);
+    psp->sy = WEAPONTOP + FixedMul(player->bob, finesine[angle]);
   }
 }
 

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1102,6 +1102,11 @@ static void R_DrawPSprite (pspdef_t *psp)
       // Interpolate bobbing for animated weapons (Chainsaw)
       R_ApplyWeaponBob(&psp_sx, true, &psp_sy, true);
     }
+    else if (psp->state->action == A_WeaponReady && dsda_WeaponBob() < 4)
+    {
+      // Always apply Weaponbob when using bobbing increments
+      R_ApplyWeaponBob(&psp_sx, true, &psp_sy, true);
+    }
   }
 
   {


### PR DESCRIPTION
Fixes #747

Ugh was kinda hoping for the previous PR to be significantly reviewed last time, cuz I was iffy about the code... but regardless here is a fix.

In order to enable various WeaponBob increments, we need to always apply `R_ApplyWeaponBob` (I'll admit that DSDA's way of dealing with weaponbob confused me when I first made the PR).

So funny enough my chainsaw jittery fix is required to obey WeaponBob increments.