### PR TITLE
Add support for non-power-of-2 textures

### DIFF
--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -106,8 +106,8 @@ int       *texturetranslation;
 //
 
 const byte *R_GetTextureColumn(const rpatch_t *texpatch, int col) {
-  const uint width = texpatch->width;
-  const uint mask = texpatch->widthmask;
+  const int width = texpatch->width;
+  const unsigned int mask = texpatch->widthmask;
 
   while (col < 0)
     col += width;

--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -106,9 +106,16 @@ int       *texturetranslation;
 //
 
 const byte *R_GetTextureColumn(const rpatch_t *texpatch, int col) {
+  const uint width = texpatch->width;
+  const uint mask = texpatch->widthmask;
+
   while (col < 0)
-    col += texpatch->width;
-  col &= texpatch->widthmask;
+    col += width;
+
+  if (mask + 1 == width)
+    col &= mask;
+  else
+    col %= width;
 
   return texpatch->columns[col].pixels;
 }


### PR DESCRIPTION
Test WAD: [clamptest.zip](https://github.com/user-attachments/files/21604338/clamptest.zip)
(missing floor texture is an unrelated feature)

Software, on `master`:
<img width="1920" height="1080" alt="doom29" src="https://github.com/user-attachments/assets/7e3e6059-15ce-4ef3-a36a-625c6201bb92" />

Software, this branch:
<img width="1920" height="1080" alt="doom30" src="https://github.com/user-attachments/assets/87996997-1b91-4549-a51f-8de90fce5af0" />

OpenGL, either branch:
<img width="1920" height="1080" alt="doom31" src="https://github.com/user-attachments/assets/3a262638-a892-4869-a36a-dcc324360f5b" />
