### PR TITLE
Warp mouse to the middle of the screen

### DIFF
--- a/prboom2/src/SDL/i_sshot.c
+++ b/prboom2/src/SDL/i_sshot.c
@@ -59,8 +59,8 @@ int renderH;
 
 void I_UpdateRenderSize(void)
 {
-  renderW = window_rect.w;
-  renderH = window_rect.h;
+  renderW = renderer_rect.w;
+  renderH = renderer_rect.h;
 }
 
 //

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1583,7 +1583,7 @@ void UpdateGrab(void)
     if (!currently_grabbed)
       ActivateMouse();
 
-    if (!demoplayback)
+    if (!demoplayback || walkcamera.type)
       SDL_WarpMouseInWindow(sdl_window, window_rect.w / 2, window_rect.h / 2);
   }
   else if (currently_grabbed)

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -123,9 +123,10 @@ SDL_Renderer *sdl_renderer;
 SDL_Texture *sdl_texture;
 static SDL_GLContext sdl_glcontext;
 unsigned int windowid = 0;
-SDL_Rect src_rect = { 0, 0, 0, 0 };
-SDL_Rect window_rect = { 0, 0, 0, 0 };
-SDL_Rect viewport_rect = { 0, 0, 0, 0 };
+SDL_Rect src_rect = { 0, 0, 0, 0 };       // Drawn pixels, independent of window size
+SDL_Rect window_rect = { 0, 0, 0, 0 };    // Physical window
+SDL_Rect renderer_rect = { 0, 0, 0, 0 };  // The window, but with HiDPI accounted
+SDL_Rect viewport_rect = { 0, 0, 0, 0 };  // The renderer, but without the black bars
 
 ////////////////////////////////////////////////////////////////////////////
 // Input code
@@ -1604,10 +1605,12 @@ static void ApplyWindowResize(SDL_Event *resize_event)
 
 void I_SetWindowRect()
 {
+  SDL_GetWindowSize(sdl_window, &window_rect.w, &window_rect.h);
+
   if (V_IsOpenGLMode())
-    SDL_GL_GetDrawableSize(sdl_window, &window_rect.w, &window_rect.h);
+    SDL_GL_GetDrawableSize(sdl_window, &renderer_rect.w, &renderer_rect.h);
   else
-    SDL_GetRendererOutputSize(sdl_renderer, &window_rect.w, &window_rect.h);
+    SDL_GetRendererOutputSize(sdl_renderer, &renderer_rect.w, &renderer_rect.h);
 }
 
 void I_SetViewportRect()
@@ -1615,19 +1618,19 @@ void I_SetViewportRect()
   float viewport_aspect = (float)SCREENWIDTH / (float)ACTUALHEIGHT;
 
   // Black bars on left and right of viewport
-  if (((float)window_rect.w / (float)window_rect.h) > viewport_aspect)
+  if (((float)renderer_rect.w / (float)renderer_rect.h) > viewport_aspect)
   {
-    viewport_rect.w = (int)((float)window_rect.h * viewport_aspect);
-    viewport_rect.h = window_rect.h;
-    viewport_rect.x = (window_rect.w - viewport_rect.w) >> 1;
+    viewport_rect.w = (int)((float)renderer_rect.h * viewport_aspect);
+    viewport_rect.h = renderer_rect.h;
+    viewport_rect.x = (renderer_rect.w - viewport_rect.w) >> 1;
     viewport_rect.y = 0;
   }
   // Either matching window's aspect ratio, or black bars on top and bottom (ie 21:9 on a 16:9 display)
   else
   {
-    viewport_rect.w = window_rect.w;
-    viewport_rect.h = (int)((float)window_rect.w / viewport_aspect);
+    viewport_rect.w = renderer_rect.w;
+    viewport_rect.h = (int)((float)renderer_rect.w / viewport_aspect);
     viewport_rect.x = 0;
-    viewport_rect.y = (window_rect.h - viewport_rect.h) >> 1;
+    viewport_rect.y = (renderer_rect.h - viewport_rect.h) >> 1;
   }
 }

--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -1577,15 +1577,16 @@ void UpdateGrab(void)
 
   grab = MouseShouldBeGrabbed();
 
-  if (grab && !currently_grabbed)
+  if (grab)
   {
-    ActivateMouse();
-  }
+    if (!currently_grabbed)
+      ActivateMouse();
 
-  if (!grab && currently_grabbed)
-  {
-    DeactivateMouse();
+    if (!demoplayback)
+      SDL_WarpMouseInWindow(sdl_window, window_rect.w / 2, window_rect.h / 2);
   }
+  else if (currently_grabbed)
+    DeactivateMouse();
 
   currently_grabbed = grab;
 }

--- a/prboom2/src/dsda/gl/render_scale.c
+++ b/prboom2/src/dsda/gl/render_scale.c
@@ -53,8 +53,8 @@ void dsda_GLSetRenderViewportParams() {
   //        each frame to prevent artifacts smearing on undrawn framebuffer area
   gl_letterbox_clear_required = viewport_rect.x + viewport_rect.y;
   if (gl_letterbox_clear_required) {
-    gl_clear_box_width = ((viewport_rect.y != 0) * window_rect.w) + viewport_rect.x;
-    gl_clear_box_height = ((viewport_rect.y == 0) * window_rect.h) + viewport_rect.y;
+    gl_clear_box_width = ((viewport_rect.y != 0) * renderer_rect.w) + viewport_rect.x;
+    gl_clear_box_height = ((viewport_rect.y == 0) * renderer_rect.h) + viewport_rect.y;
   }
 }
 
@@ -97,7 +97,7 @@ void dsda_GLLetterboxClear() {
   if (!gl_letterbox_clear_required)
     return;
 
-  glViewport(0, 0, window_rect.w, window_rect.h);
+  glViewport(0, 0, renderer_rect.w, renderer_rect.h);
   glEnable(GL_SCISSOR_TEST);
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
@@ -106,8 +106,8 @@ void dsda_GLLetterboxClear() {
   glClear(GL_COLOR_BUFFER_BIT);
 
   // Top or right box
-  glScissor(window_rect.w - gl_clear_box_width,
-            window_rect.h - gl_clear_box_height,
+  glScissor(renderer_rect.w - gl_clear_box_width,
+            renderer_rect.h - gl_clear_box_height,
             gl_clear_box_width, gl_clear_box_height);
   glClear(GL_COLOR_BUFFER_BIT);
 
@@ -141,9 +141,9 @@ void dsda_GLEndMeltRenderTexture() {
   glBegin(GL_TRIANGLE_STRIP);
   {
     glTexCoord2f(0.0f, 1.0f); glVertex2f(0.0f, 0.0f);
-    glTexCoord2f(0.0f, 0.0f); glVertex2f(0.0f, window_rect.h);
-    glTexCoord2f(1.0f, 1.0f); glVertex2f((float)window_rect.w, 0.0f);
-    glTexCoord2f(1.0f, 0.0f); glVertex2f((float)window_rect.w, (float)window_rect.h);
+    glTexCoord2f(0.0f, 0.0f); glVertex2f(0.0f, renderer_rect.h);
+    glTexCoord2f(1.0f, 1.0f); glVertex2f((float)renderer_rect.w, 0.0f);
+    glTexCoord2f(1.0f, 0.0f); glVertex2f((float)renderer_rect.w, (float)renderer_rect.h);
   }
   glEnd();
 
@@ -158,8 +158,8 @@ void dsda_GLFullscreenOrtho2D() {
   glLoadIdentity();
   glOrtho(
     (GLdouble) 0,
-    (GLdouble) window_rect.w,
-    (GLdouble) window_rect.h,
+    (GLdouble) renderer_rect.w,
+    (GLdouble) renderer_rect.h,
     (GLdouble) 0,
     (GLdouble) -1.0,
     (GLdouble) 1.0

--- a/prboom2/src/dsda/mouse.c
+++ b/prboom2/src/dsda/mouse.c
@@ -65,17 +65,12 @@ void dsda_GetMousePosition(int *x, int *y)
 {
   SDL_GetMouseState(x, y);
 
-  // SDL_GetMouseState doesnt account for HiDPI displays
-  {
-    int logical_w, logical_h;
-    SDL_GetWindowSize(sdl_window, &logical_w, &logical_h);
+  // Lets account for HiDPI displays since SDL_GetMouseState doesnt
+  *x = (int)(*x * (float)renderer_rect.w / (float)window_rect.w);
+  *y = (int)(*y * (float)renderer_rect.h / (float)window_rect.h);
 
-    *x = (int)(*x * (float)window_rect.w / (float)logical_w);
-    *y = (int)(*y * (float)window_rect.h / (float)logical_h);
-  }
-
-  // x and y currently have the mouse position in the window
-  // but we want the mouse position in the viewport
+  // x and y currently have the mouse position in the renderer_rect
+  // but we want the mouse position in the viewport_rect
   if (viewport_rect.x < *x && *x < (viewport_rect.w + viewport_rect.x) &&
       viewport_rect.y < *y && *y < (viewport_rect.h + viewport_rect.y))
   {

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -910,8 +910,8 @@ unsigned char *gld_ReadScreen(void)
 
   int src_row, dest_row, size, pixels_per_row;
 
-  pixels_per_row = window_rect.w * 3;
-  size = pixels_per_row * window_rect.h;
+  pixels_per_row = renderer_rect.w * 3;
+  size = pixels_per_row * renderer_rect.h;
   if (!scr || size > scr_size)
   {
     scr_size = size;
@@ -926,12 +926,12 @@ unsigned char *gld_ReadScreen(void)
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
     glFlush();
-    glReadPixels(0, 0, window_rect.w, window_rect.h, GL_RGB, GL_UNSIGNED_BYTE, scr);
+    glReadPixels(0, 0, renderer_rect.w, renderer_rect.h, GL_RGB, GL_UNSIGNED_BYTE, scr);
 
     glPixelStorei(GL_PACK_ALIGNMENT, pack_aligment);
 
     // GL textures are bottom up, so copy the rows in reverse to flip vertically
-    for (src_row = window_rect.h - 1, dest_row = 0; src_row >= 0; --src_row, ++dest_row)
+    for (src_row = renderer_rect.h - 1, dest_row = 0; src_row >= 0; --src_row, ++dest_row)
     {
       memcpy(&buffer[dest_row * pixels_per_row],
               &scr[src_row * pixels_per_row],
@@ -1114,9 +1114,9 @@ void gld_EndDrawScene(void)
     glBegin(GL_TRIANGLE_STRIP);
     {
       glTexCoord2f(0.0f, 1.0f); glVertex2f(0.0f, 0.0f);
-      glTexCoord2f(0.0f, 0.0f); glVertex2f(0.0f, window_rect.h);
-      glTexCoord2f(1.0f, 1.0f); glVertex2f((float)window_rect.w, 0.0f);
-      glTexCoord2f(1.0f, 0.0f); glVertex2f((float)window_rect.w, (float)window_rect.h);
+      glTexCoord2f(0.0f, 0.0f); glVertex2f(0.0f, renderer_rect.h);
+      glTexCoord2f(1.0f, 1.0f); glVertex2f((float)renderer_rect.w, 0.0f);
+      glTexCoord2f(1.0f, 0.0f); glVertex2f((float)renderer_rect.w, (float)renderer_rect.h);
     }
     glEnd();
 

--- a/prboom2/src/i_video.h
+++ b/prboom2/src/i_video.h
@@ -47,6 +47,7 @@
 extern SDL_Window *sdl_window;
 extern SDL_Renderer *sdl_renderer;
 
+extern SDL_Rect renderer_rect;
 extern SDL_Rect window_rect;
 extern SDL_Rect viewport_rect;
 


### PR DESCRIPTION
Fixes https://github.com/kraflab/dsda-doom/issues/754

> SDL_WarpMouseInWindow()
This function generates a mouse motion event if relative mode is not enabled. If relative mode is enabled, you can force mouse events for the warp by setting the [SDL_HINT_MOUSE_RELATIVE_WARP_MOTION](https://wiki.libsdl.org/SDL2/SDL_HINT_MOUSE_RELATIVE_WARP_MOTION) hint.

Relative mode is enabled when the mouse is grabbed, so Im guessing this is fine.