### PR TITLE
Add support for widescreen RAW Screen format

### DIFF
--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -202,6 +202,7 @@ void F_DemonScroll(void)
 {
   static int yval = 0;
   static int nextscroll = 0;
+  int lump_width = W_LumpLength(W_CheckNumForName("FINAL2")) / 200;
 
   if (finalecount < 70)
   {
@@ -210,7 +211,7 @@ void F_DemonScroll(void)
   }
   else if (yval < 200)
   {
-    V_DrawRawScreenSection("FINAL2", (200 - yval) * 320, 0, yval);
+    V_DrawRawScreenSection("FINAL2", (200 - yval) * lump_width, 0, yval);
     V_DrawRawScreenSection("FINAL1", 0, yval, 200 - yval);
     if (finalecount >= nextscroll)
     {

--- a/prboom2/src/r_patch.c
+++ b/prboom2/src/r_patch.c
@@ -324,20 +324,20 @@ static void FillEmptySpace(rpatch_t *patch)
 //
 //==========================================================================
 
-static dboolean CheckIfPatch(int lump)
+dboolean R_IsPatchLump(int lumpnum)
 {
   int size;
   int width, height;
   const patch_t * patch;
   dboolean result;
 
-  size = W_LumpLength(lump);
+  size = W_LumpLength(lumpnum);
 
   // minimum length of a valid Doom patch
   if (size < 13)
     return false;
 
-  patch = (const patch_t *)W_LumpByNum(lump);
+  patch = (const patch_t *)W_LumpByNum(lumpnum);
 
   width = LittleShort(patch->width);
   height = LittleShort(patch->height);
@@ -399,7 +399,7 @@ static void createPatch(int id) {
     I_Error("createPatch: %i >= numlumps", id);
 #endif
 
-  if (!CheckIfPatch(patchNum))
+  if (!R_IsPatchLump(patchNum))
   {
     I_Error("createPatch: Unknown patch format %s.",
       (patchNum < numlumps ? lumpinfo[patchNum].name : NULL));

--- a/prboom2/src/r_patch.h
+++ b/prboom2/src/r_patch.h
@@ -87,6 +87,8 @@ const rpatch_t *R_PatchByNum(int id);
 
 const rpatch_t *R_TextureCompositePatchByNum(int id);
 
+dboolean R_IsPatchLump(int lumpnum);
+
 // Size query funcs
 int R_NumPatchWidth(int lump) ;
 int R_NumPatchHeight(int lump);

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1607,7 +1607,7 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
       x_pos = x_offset + x;
 
       // Don't draw pixels outside screen
-      if ((x_pos < 0) || (x_pos > SCREENWIDTH))
+      if ((x_pos < 0) || (x_pos > SCREENWIDTH - width))
         continue;
       
       V_FillRect(0, x_pos, y, width, height, *raw);

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1532,8 +1532,6 @@ int V_FillHeightVPT(int scrn, int y, int height, byte color, enum patch_translat
 
 // heretic
 
-#define HERETIC_RAW_SCREEN_SIZE 64000
-
 // heretic_note: is something already implemented to handle this?
 void V_DrawRawScreen(const char *lump_name)
 {
@@ -1546,6 +1544,8 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
   float x_factor = 0, y_factor = 0;
   int x_offset, y_offset;
   const byte* raw;
+  int lump_num = W_CheckNumForName(lump_name);
+  int lump_width = W_LumpLength(lump_num) / 200;
 
   // e6y: wide-res
   // NOTE: the size isn't quite right on all resolutions,
@@ -1555,17 +1555,13 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
   V_ClearBorder();
 
   // custom widescreen assets are a different format
+  if (R_IsPatchLump(lump_num))
   {
-    int lump;
-
-    lump = W_CheckNumForName(lump_name);
-    if (W_LumpLength(lump) != HERETIC_RAW_SCREEN_SIZE)
-    {
-      V_DrawNamePatchFS(0, 0, 0, lump_name, CR_DEFAULT, VPT_STRETCH);
-      return;
-    }
+    V_DrawNamePatchFS(0, 0, 0, lump_name, CR_DEFAULT, VPT_STRETCH);
+    return;
   }
 
+  // aspect ratio correction
   switch (render_stretch_hud) {
     case patch_stretch_not_adjusted:
       x_factor = (float)SCREENWIDTH / 320;
@@ -1585,30 +1581,36 @@ void V_DrawRawScreenSection(const char *lump_name, int source_offset, int dest_y
       break;
   }
 
-  x_offset = (int)((SCREENWIDTH - (x_factor * 320)) / 2);
-  y_offset = (int)((dest_y_offset * y_factor) - (source_offset * y_factor / 320));
+  x_offset = (int)((SCREENWIDTH - (x_factor * lump_width)) / 2);
+  y_offset = (int)((dest_y_offset * y_factor) - (source_offset * y_factor / lump_width));
 
   // TODO: create a V_FillRaw alias and call that instead of the gld_ func directly,
   // though that means there needs to be a software version too (that's ideally a
   // bit more efficient than the current code's thousands-of-little-boxes approach)
   if (V_IsOpenGLMode()) {
-    gld_FillRawName(lump_name, x_offset, y_offset, 320, 200, 320 * x_factor, 200 * y_factor, VPT_STRETCH_REAL);
+    gld_FillRawName(lump_name, x_offset, y_offset, lump_width, 200, lump_width * x_factor, 200 * y_factor, VPT_STRETCH_REAL);
     return;
   }
 
   raw = (const byte *)W_LumpByName(lump_name) + source_offset;
 
   for (j = dest_y_offset; j < dest_y_offset + dest_y_limit; ++j)
-    for (i = 0; i < 320; ++i, ++raw)
+    for (i = 0; i < lump_width; ++i, ++raw)
     {
-      int x, y, width, height;
+      int x, y, width, height, x_pos;
 
       x = (int)(i * x_factor);
       y = (int)(j * y_factor);
       width = (int)((i + 1) * x_factor) - x;
       height = (int)((j + 1) * y_factor) - y;
 
-      V_FillRect(0, x_offset + x, y, width, height, *raw);
+      x_pos = x_offset + x;
+
+      // Don't draw pixels outside screen
+      if ((x_pos < 0) || (x_pos > SCREENWIDTH))
+        continue;
+      
+      V_FillRect(0, x_pos, y, width, height, *raw);
     }
 }
 


### PR DESCRIPTION
This is currently a draft.
The main issue I'm having is that there are some garbage pixels on the left side of the screen.

New "Heretic + Hexen" IWADs use widescreen RAW format graphics.
I'd like to support these, as well as any PWADs in the future that use the same widescreen RAW format.