### PR TITLE
fix framerate when dumping video to avi container

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -825,7 +825,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_cap_muxcommand] = {
     "cap_muxcommand", dsda_config_cap_muxcommand,
-    CONF_STRING("ffmpeg -i temp_v.nut -i temp_a.nut -c copy -y %f")
+    CONF_STRING("ffmpeg -i temp_v.nut -i temp_a.nut -r %r -c copy -y %f")
   },
   [dsda_config_cap_tempfile1] = {
     "cap_tempfile1", dsda_config_cap_tempfile1,


### PR DESCRIPTION
https://ffmpeg.org/ffmpeg.html#Video-Options

> `-r[:stream_specifier] fps (input/output,per-stream)`
> As an output option:
> - video encoding
> Duplicate or drop frames right before encoding them to achieve constant output frame rate fps.
> - video streamcopy
> Indicate to the muxer that fps is the stream frame rate. No data is dropped or duplicated in this case. This may produce invalid files if fps does not match the actual stream frame rate as determined by packet timestamps.

When framerate is not set for the muxer, due to limitations of the AVI container it assumes some default framerate of 600.000 when VFW importer is used to process that video, resulting in lots of imaginary "duplicate frames".

Why does VFW matter? Because it's fast and you can import directly into avisynth, while an ffmpeg-based importer takes forever to index video AND THEN audio for high resolution footage. But why does avisynth matter? Because it's what we've been using for all these years over at tasvieos to encode TASes, and it's usually easy to be compatible with it for emulators (and anything else that dumps video).

Obviously this entire change could be replaced with just shipping custom config or providing users with docs on how to fix their AVI dumping with this and other source ports. But I thought it'd be nice to both document and implement the proper fix for future generations, even if nobody else is using AVI anymore.

I tested dumping to MKV and it didn't cause any difference (not that I expect it to).