### PR TITLE
config.h: Remove unused HAVE_LIBSDL2_MIXER define

### DIFF
--- a/prboom2/cmake/config.h.cin
+++ b/prboom2/cmake/config.h.cin
@@ -22,8 +22,6 @@
 #cmakedefine HAVE_DIRENT_H
 
 #cmakedefine HAVE_LIBSDL2_IMAGE
-#cmakedefine HAVE_LIBSDL2_MIXER
-
 #cmakedefine HAVE_LIBMAD
 #cmakedefine HAVE_LIBFLUIDSYNTH
 #cmakedefine HAVE_LIBXMP


### PR DESCRIPTION
SDL2_mixer is a mandatory dependency and this definition is no longer used in the code.