### PR TITLE
Specify Homebrew dependencies with a Brewfile

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -121,24 +121,7 @@ jobs:
 
       - name: Install Dependencies (macOS)
         if: runner.os == 'macOS'
-        run: |
-          brew update
-          env HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 \
-            brew install --overwrite \
-              python \
-              ninja \
-              pkg-config \
-              libxmp \
-              fluid-synth \
-              libvorbis \
-              libzip \
-              mad \
-              portmidi \
-              sdl2 \
-              sdl2_image \
-              sdl2_mixer \
-              libsndfile \
-              dylibbundler
+        run: brew bundle
 
       - name: Generate vcpkg cache key
         if: ${{ matrix.config.vcpkg }}

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,19 @@
+# Build tools
+brew "cmake"
+brew "ninja"
+brew "pkgconf"
+
+# Library dependencies
+brew "fluid-synth"
+brew "libsndfile"
+brew "libvorbis"
+brew "libxmp"
+brew "libzip"
+brew "mad"
+brew "portmidi"
+brew "sdl2"
+brew "sdl2_image"
+brew "sdl2_mixer"
+
+# Packaging tools
+brew "dylibbundler"


### PR DESCRIPTION
This PR adds a `Brewfile` at the top of the repository to handle Homebrew dependencies more conveniently.

This has the advantage of:
- Having all the macOS dependencies listed in a single location, instead of having it duplicated in the build guide and CI.
- Installing everything in a single command without listing every packages (`brew bundle`).
- For CI, this fixes warnings about trying to install the dependencies already pre-installed on the runner.

---

I have also updated the macOS build guide, so it recommends `brew bundle` to install dependencies. Also took the opportunity to update the option name since `ENABLE_LTO` was removed, and to recommend using `cpack` to create a package instead of manually baking a release.