### PR TITLE
CMake: Always copy pwad next to the executable

### DIFF
--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -553,6 +553,11 @@ function(AddGameExecutable TARGET SOURCES)
     )
 
     add_dependencies(${TARGET} dsda-doom-wad)
+    add_custom_command(TARGET ${TARGET}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E echo "Copying ${WAD_DATA_PATH} to $<TARGET_FILE_DIR:dsda-doom>"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${WAD_DATA_PATH} $<TARGET_FILE_DIR:dsda-doom>
+    )
 
     if(MSVC)
         set_target_properties(${TARGET} PROPERTIES
@@ -560,7 +565,6 @@ function(AddGameExecutable TARGET SOURCES)
         )
         add_custom_command(TARGET ${TARGET} POST_BUILD
             COMMAND "mt.exe" -manifest \"${CMAKE_CURRENT_SOURCE_DIR}\\..\\ICONS\\dsda-doom.exe.manifest\" -outputresource:\"$<TARGET_FILE:dsda-doom>\"\;\#1
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${WAD_DATA_PATH} $<TARGET_FILE_DIR:dsda-doom>
         )
     elseif(WIN32)
         set_target_properties(${TARGET} PROPERTIES


### PR DESCRIPTION
Copying the pwad next to the executable is not only needed on MSVC. More generally, all multi-config generators (Visual Studio, Xcode, Ninja Multi-Config) need this `POST_BUILD` command for the executable to work from the build directory without manually specifying the pwad.

On single-config platform the command is a no-op, as such it can be run unconditionally.

