### PR TITLE
Fix remaining clang warnings

### DIFF
--- a/prboom2/cmake/DsdaTargetFeatures.cmake
+++ b/prboom2/cmake/DsdaTargetFeatures.cmake
@@ -29,12 +29,20 @@ function(dsda_internal_setup_warnings_gnu result_var)
     -Wno-pointer-sign
     -Wdeclaration-after-statement
     -Wbad-function-cast
+    -Wno-strict-prototypes
   )
   if(CMAKE_C_COMPILER_ID STREQUAL "GNU"
     OR (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 18)
     OR (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 17)
   )
     list(APPEND GNU_WARNINGS "-Wno-format-truncation")
+  endif()
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    list(APPEND GNU_WARNINGS
+      "-Wno-tautological-constant-out-of-range-compare"
+      "-Wno-tautological-unsigned-enum-zero-compare"
+      "-Wno-misleading-indentation"
+    )
   endif()
 
   set(GNU_WARNINGS_SET ${GNU_WARNINGS} ${GNU_C_WARNINGS})

--- a/prboom2/src/CMakeLists.txt
+++ b/prboom2/src/CMakeLists.txt
@@ -537,6 +537,11 @@ function(AddGameExecutable TARGET SOURCES)
     dsda_target_enable_fast_math(${TARGET})
     dsda_target_use_config_h(${TARGET})
 
+    target_compile_features(${TARGET}
+        PRIVATE
+        cxx_std_11
+    )
+
     target_include_directories(${TARGET}
         PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/prboom2/src/MUSIC/midifile.c
+++ b/prboom2/src/MUSIC/midifile.c
@@ -57,15 +57,17 @@ typedef unsigned char byte;
 #define ntohs
 #else // WORDS_BIGENDIAN
 
+#include <stdint.h>
+
 #define ntohl(x) \
-        (/*(long int)*/((((unsigned long int)(x) & 0x000000ffU) << 24) | \
-                             (((unsigned long int)(x) & 0x0000ff00U) <<  8) | \
-                             (((unsigned long int)(x) & 0x00ff0000U) >>  8) | \
-                             (((unsigned long int)(x) & 0xff000000U) >> 24)))
+        ((((uint32_t)(x) & 0x000000ffU) << 24) | \
+          (((uint32_t)(x) & 0x0000ff00U) <<  8) | \
+          (((uint32_t)(x) & 0x00ff0000U) >>  8) | \
+          (((uint32_t)(x) & 0xff000000U) >> 24))
 
 #define ntohs(x) \
-        (/*(short int)*/((((unsigned short int)(x) & 0x00ff) << 8) | \
-                              (((unsigned short int)(x) & 0xff00) >> 8)))
+        ((((uint16_t)(x) & 0x00ff) << 8) | \
+         (((uint16_t)(x) & 0xff00) >> 8))
 #endif // WORDS_BIGENDIAN
 #endif // ntohl
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -3151,6 +3151,7 @@ void G_WriteDemoTiccmd (ticcmd_t* cmd)
 {
   char buf[10];
   char *p = buf;
+  const byte* data_p = (byte*)buf;
 
   if (compatibility_level == tasdoom_compatibility)
   {
@@ -3183,8 +3184,7 @@ void G_WriteDemoTiccmd (ticcmd_t* cmd)
 
   dsda_WriteTicToDemo(buf, p - buf);
 
-  p = buf; // make SURE it is exactly the same
-  G_ReadOneTick(cmd, (const byte **) &p);
+  G_ReadOneTick(cmd, &data_p);
 }
 
 // These functions are used to read and write game-specific options in demos


### PR DESCRIPTION
This fixes the last set of warnings on clang toolchains.

On older compilers, `-Wc++11-extensions` would show up when building C++ sources. This is fixed by setting the `cxx_std_11` compile feature.

In two instances, Clang complains about redundant (tautological) checks:
- In [src/r_data.c:660](https://github.com/kraflab/dsda-doom/blob/755bbdfb5b0bb47f637a3ca6f6185a8b10d2964c/prboom2/src/r_data.c#L660), `item < 0` may trigger the warning if the compiler makes the enum unsigned. Which we have no control over before C23.
- In [src/scanner.cpp:471](https://github.com/kraflab/dsda-doom/blob/755bbdfb5b0bb47f637a3ca6f6185a8b10d2964c/prboom2/src/scanner.cpp#L471C42-L471C67), `this->token == TK_NoToken` may trigger the warning if the compiler has `char` unsigned.

`-Wno-strict-prototypes` is applied to avoid warnings with function pointers in `cheatseq_s`, `thinker_s`, `state_t`, and `thinkInfo_t`.

---

This was tested with:
- AppleClang 17
- AppleClang 15 (CI)
- LLVM 20 (macOS and Fedora)