### PR TITLE
CMake: Avoid CMAKE_FIND_REQUIRED

### DIFF
--- a/prboom2/cmake/DsdaDependencies.cmake
+++ b/prboom2/cmake/DsdaDependencies.cmake
@@ -1,12 +1,7 @@
 include_guard()
 
 if(STRICT_FIND)
-  set(dsda_strict_keyword)
-  if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.1)
-    set(CMAKE_FIND_REQUIRED ON)
-  else()
-    set(dsda_strict_keyword REQUIRED)
-  endif()
+  set(dsda_strict_keyword REQUIRED)
 endif()
 
 add_library(dsda_dependencies INTERFACE IMPORTED)


### PR DESCRIPTION
When using vcpkg, the toolchain wraps `find_package`. Some packages (notably `zlib` in this case) use this to insert an additional script before calling CMake's `find_package`. Enabling `CMAKE_FIND_REQUIRED` may lead to an error under vcpkg's `*-release` triplets (see https://github.com/microsoft/vcpkg/issues/46924).

So, let's just always use the keyword approach.