### PR TITLE
Fix zokumbsp seg angle manipulation (horizon line effect) in software renderring

### DIFF
--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -36,6 +36,7 @@
 #include <zlib.h>
 
 #include "doomstat.h"
+#include "doomtype.h"
 #include "m_bbox.h"
 #include "g_game.h"
 #include "w_wad.h"
@@ -3288,6 +3289,18 @@ static void P_RemoveSlimeTrails(void)         // killough 10/98
   Z_Free(hit);
 }
 
+// [crispy] fix long wall wobble
+static angle_t anglediff(angle_t a, angle_t b)
+{
+  if (b > a)
+    return anglediff(b, a);
+
+  if (a - b < ANG180)
+    return a - b;
+  else // [crispy] wrap around
+    return b - a;
+}
+
 static void R_CalcSegsLength(void)
 {
   int i;
@@ -3301,6 +3314,12 @@ static void R_CalcSegsLength(void)
     li->halflength = (uint32_t)(length / 2.0);
     // [crispy] re-calculate angle used for rendering
     li->pangle = R_PointToAngleEx2(li->v1->px, li->v1->py, li->v2->px, li->v2->py);
+    // [crispy] more than just a little adjustment?
+    // back to the original angle then
+    if (anglediff(li->pangle, li->angle) > ANG60/2)
+    {
+      li->pangle = li->angle;
+    }
   }
 }
 

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -206,8 +206,8 @@ void R_FixWiggle(sector_t *sec)
 
 static fixed_t R_ScaleFromGlobalAngle(angle_t visangle)
 {
-  int anglea = ANG90 + (visangle - viewangle);
-  int angleb = ANG90 + (visangle - rw_normalangle);
+  angle_t anglea = ANG90 + (visangle - viewangle);
+  angle_t angleb = ANG90 + (visangle - rw_normalangle);
   int den = FixedMul(rw_distance, finesine[anglea >> ANGLETOFINESHIFT]);
   // proff 11/06/98: Changed for high-res
   fixed_t num = FixedMul(projectiony, finesine[angleb >> ANGLETOFINESHIFT]);


### PR DESCRIPTION
<details>
<summary>Test WAD MAP01 before</summary>
<img width="1920" height="1080" alt="doom64" src="https://github.com/user-attachments/assets/862c336e-4952-44f4-81c3-cd54391d56b6" />
</details>

<details>
<summary>Sprinkled Doom Test WAD MAP01 before</summary>
<img width="1920" height="1080" alt="doom65" src="https://github.com/user-attachments/assets/24fd787a-f1b4-457b-b6a9-1703acbcafea" />

</details>

<details>
<summary>Legacy Of Rust MAP10 before</summary>
<img width="1920" height="1080" alt="doom53" src="https://github.com/user-attachments/assets/25c4a564-5f4f-45a5-baaa-081243f2f76c" />
</details>


<details>
<summary>CCSS06 MAP26 before</summary>
<img width="1920" height="1080" alt="doom63" src="https://github.com/user-attachments/assets/06a6d630-1ae5-4831-b49a-9b1d1b685ffa" />
</details>

================

<details>
<summary>Test WAD MAP01 after</summary>
<img width="1920" height="1080" alt="doom59" src="https://github.com/user-attachments/assets/7484cd1d-d217-440e-b555-c816a5ed76a3" />
</details>

<details>
<summary>Sprinkled Doom Test WAD MAP01 after</summary>
<img width="1920" height="1080" alt="doom66" src="https://github.com/user-attachments/assets/30a40b94-1746-4b07-9fa0-8fb3384f586f" />

</details>

<details>
<summary>Legacy Of Rust MAP10 after</summary>
<img width="1920" height="1080" alt="doom58" src="https://github.com/user-attachments/assets/91e821f4-15db-400b-9150-be8f774b1f76" />
</details>

<details>
<summary>CCSS06 MAP26 after</summary>
<img width="1920" height="1080" alt="doom61" src="https://github.com/user-attachments/assets/ecff968a-cdd5-4a68-8e88-0484538fcc38" />
</details>