### PR TITLE
Fix "Pistol Start" Temporary Modifier to Actually Update

### DIFF
--- a/prboom2/src/dsda/skill_info.c
+++ b/prboom2/src/dsda/skill_info.c
@@ -246,12 +246,13 @@ void dsda_RefreshPistolStart(void)
 {
   dboolean pistol_start_conflict = dsda_IntConfig(dsda_config_always_pistol_start) && !dsda_IntConfig(dsda_config_pistol_start);
 
+  // Fix pistolstart option "conflict"
   if (allow_incompatibility || in_game)
     if (pistol_start_conflict)
-    {
       dsda_UpdateIntConfig(dsda_config_always_pistol_start, false, true);
-      dsda_ResetGameModifiers();
-    }
+
+  // Refresh pistolstart status
+  dsda_ResetGameModifiers();
 }
 
 // if "Always Pistol Start" is enabled, enable "Pistol Start" (avoid impossible condition)
@@ -259,12 +260,13 @@ void dsda_RefreshAlwaysPistolStart(void)
 {
   dboolean pistol_start_conflict = dsda_IntConfig(dsda_config_always_pistol_start) && !dsda_IntConfig(dsda_config_pistol_start);
 
+  // Fix pistolstart option "conflict"
   if (allow_incompatibility || in_game)
     if (pistol_start_conflict)
-    {
       dsda_UpdateIntConfig(dsda_config_pistol_start, true, true);
-      dsda_ResetGameModifiers();
-    }
+
+  // Refresh pistolstart status
+  dsda_ResetGameModifiers();
 }
 
 // During demo recording/playback only use args, else use cfgs


### PR DESCRIPTION
A fix to #724

Pistol start wouldn't update when changing the menu option, because of some incorrect logic (on my part).
- Previous logic only updated pistolstart when there was a conflict between "Pistol Start" and "Always Pistol Start"

To be honest, pretty annoyed as this faulty behaviour has been in Nyan for 1-2 months now.