### PR TITLE
Minor tweaks to the codebase

### DIFF
--- a/prboom2/src/MUSIC/flplayer.c
+++ b/prboom2/src/MUSIC/flplayer.c
@@ -438,8 +438,8 @@ static void fl_writesamples_ex (short *dest, int nsamp)
   if (nsamp * 2 > fbuff_siz)
   {
     float *newfbuff = (float*)realloc (fbuff, nsamp * 2 * sizeof (float));
-	if (!newfbuff) return;
-	fbuff = newfbuff;
+    if (!newfbuff) return;
+    fbuff = newfbuff;
     fbuff_siz = nsamp * 2;
   }
 
@@ -448,7 +448,7 @@ static void fl_writesamples_ex (short *dest, int nsamp)
   for (i = 0; i < nsamp * 2; i++)
   {
     // data is NOT already clipped
-	  float f = fbuff[i];
+    float f = fbuff[i];
     if (f > 1.0f)
       f = 1.0f;
     if (f < -1.0f)

--- a/prboom2/src/SDL/i_sndfile.h
+++ b/prboom2/src/SDL/i_sndfile.h
@@ -19,6 +19,6 @@
 #include "SDL_audio.h"
 
 void *Load_SNDFile(const void *data, SDL_AudioSpec *sample, void **sampledata,
-				   Uint32 *samplelen);
+                   Uint32 *samplelen);
 
 #endif

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -736,7 +736,7 @@ void D_SetPage(const char* name, int tics, int music)
 
 static void D_DrawTitle1(const char *name)
 {
-  D_SetPage(name, TICRATE * 170 / 35, mus_intro);
+  D_SetPage(name, TICRATE * 170 / 35, mus_intro); // 35 * 170 / 35, is that correct math?
 }
 
 static void D_DrawTitle2(const char *name)

--- a/prboom2/src/dsda.c
+++ b/prboom2/src/dsda.c
@@ -222,17 +222,17 @@ void dsda_DisplayNotifications(void) {
 }
 
 void dsda_DecomposeILTime(dsda_level_time_t* level_time) {
-  level_time->m = dsda_last_leveltime / 35 / 60;
-  level_time->s = (dsda_last_leveltime % (60 * 35)) / 35;
-  level_time->t = round(100.f * (dsda_last_leveltime % 35) / 35);
+  level_time->m = dsda_last_leveltime / TICRATE / 60;
+  level_time->s = (dsda_last_leveltime % (60 * TICRATE)) / TICRATE;
+  level_time->t = round(100.f * (dsda_last_leveltime % TICRATE) / TICRATE);
 }
 
 void dsda_DecomposeMovieTime(dsda_movie_time_t* total_time) {
   extern int totalleveltimes;
 
-  total_time->h = totalleveltimes / 35 / 60 / 60;
-  total_time->m = (totalleveltimes % (60 * 60 * 35)) / 35 / 60;
-  total_time->s = (totalleveltimes % (60 * 35)) / 35;
+  total_time->h = totalleveltimes / TICRATE / 60 / 60;
+  total_time->m = (totalleveltimes % (60 * 60 * TICRATE)) / TICRATE / 60;
+  total_time->s = (totalleveltimes % (60 * TICRATE)) / TICRATE;
 }
 
 void dsda_DisplayNotification(const char* msg) {

--- a/prboom2/src/dsda/ambient.cpp
+++ b/prboom2/src/dsda/ambient.cpp
@@ -68,7 +68,7 @@ void dsda_UpdateAmbientSource(ambient_source_t* source) {
 
   // looping
   if (source->data.min_tics < 0) {
-    source->wait_tics = 35;
+    source->wait_tics = TICRATE;
 
     if (!source->data.attenuation) {
       S_AdjustVolume(source->data.volume);
@@ -146,13 +146,13 @@ static void dsda_ParseAmbient(Scanner &scanner) {
   }
   else if (scanner.StringMatch("random")) {
     scanner.MustGetFloat();
-    amb_sfx.min_tics = 35 * scanner.decimal;
+    amb_sfx.min_tics = TICRATE * scanner.decimal;
     scanner.MustGetFloat();
-    amb_sfx.max_tics = 35 * scanner.decimal;
+    amb_sfx.max_tics = TICRATE * scanner.decimal;
   }
   else if (scanner.StringMatch("periodic")) {
     scanner.MustGetFloat();
-    amb_sfx.min_tics = 35 * scanner.decimal;
+    amb_sfx.min_tics = TICRATE * scanner.decimal;
     amb_sfx.max_tics = amb_sfx.min_tics;
   }
 

--- a/prboom2/src/dsda/endoom.c
+++ b/prboom2/src/dsda/endoom.c
@@ -193,7 +193,7 @@ static const char* cp437_to_utf8[256] = {
   "\xc3\xb9",
   "\xc3\xbf",
   "\xc3\x96",
-  "\xc3\x9c	",
+  "\xc3\x9c\t",
   "\xc2\xa2",
   "\xc2\xa3",
   "\xc2\xa5",

--- a/prboom2/src/dsda/hud_components/composite_time.c
+++ b/prboom2/src/dsda/hud_components/composite_time.c
@@ -43,11 +43,11 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
       "%s%s%d:%02d %s%d:%05.2f ",
       local->label,
       dsda_TextColor(dsda_tc_exhud_total_time),
-      total_time / 35 / 60,
-      (total_time % (60 * 35)) / 35,
+      total_time / TICRATE / 60,
+      (total_time % (60 * TICRATE)) / TICRATE,
       dsda_TextColor(dsda_tc_exhud_level_time),
-      leveltime / 35 / 60,
-      (float) (leveltime % (60 * 35)) / 35
+      leveltime / TICRATE / 60,
+      (float) (leveltime % (60 * TICRATE)) / TICRATE
     );
   else
     length = snprintf(
@@ -56,8 +56,8 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
       "%s%s%d:%05.2f ",
       local->label,
       dsda_TextColor(dsda_tc_exhud_level_time),
-      leveltime / 35 / 60,
-      (float) (leveltime % (60 * 35)) / 35
+      leveltime / TICRATE / 60,
+      (float) (leveltime % (60 * TICRATE)) / TICRATE
     );
 
   if (dsda_reborn && (demorecording || demoplayback)) {
@@ -68,8 +68,8 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
       max_size - length,
       "%s%d:%02d ",
       dsda_TextColor(dsda_tc_exhud_demo_length),
-      demo_tic / 35 / 60,
-      (demo_tic % (60 * 35)) / 35
+      demo_tic / TICRATE / 60,
+      (demo_tic % (60 * TICRATE)) / TICRATE
     );
   }
 }

--- a/prboom2/src/dsda/hud_components/event_split.c
+++ b/prboom2/src/dsda/hud_components/event_split.c
@@ -68,8 +68,8 @@ void dsda_AddSplit(dsda_split_class_t split_class, int lifetime) {
   ticks = lifetime;
 
   // To match the timer, we use the leveltime value at the end of the frame
-  minutes = (leveltime + 1) / 35 / 60;
-  seconds = (float)((leveltime + 1) % (60 * 35)) / 35;
+  minutes = (leveltime + 1) / TICRATE / 60;
+  seconds = (float)((leveltime + 1) % (60 * TICRATE)) / TICRATE;
   snprintf(
     local->component.msg, sizeof(local->component.msg), "%s%d:%05.2f - %s",
     dsda_TextColor(dsda_tc_exhud_event_split),

--- a/prboom2/src/dsda/hud_components/fps.c
+++ b/prboom2/src/dsda/hud_components/fps.c
@@ -32,8 +32,8 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
     str,
     max_size,
     "%s%4d",
-    dsda_render_stats_fps < 35 ? dsda_TextColor(dsda_tc_exhud_fps_bad) :
-                                 dsda_TextColor(dsda_tc_exhud_fps_fine),
+    dsda_render_stats_fps < TICRATE ? dsda_TextColor(dsda_tc_exhud_fps_bad) :
+                                      dsda_TextColor(dsda_tc_exhud_fps_fine),
     dsda_render_stats_fps
   );
 }

--- a/prboom2/src/dsda/hud_components/level_splits.c
+++ b/prboom2/src/dsda/hud_components/level_splits.c
@@ -56,14 +56,14 @@ static void dsda_UpdateIntermissionTime(dsda_split_t* split) {
       snprintf(
         delta, sizeof(delta),
         " (%s%d:%05.2f)",
-        sign, diff / 35 / 60, (float)(diff % (60 * 35)) / 35
+        sign, diff / TICRATE / 60, (float)(diff % (60 * TICRATE)) / TICRATE
       );
     }
     else {
       snprintf(
         delta, sizeof(delta),
         " (%s%04.2f)",
-        sign, (float)(diff % (60 * 35)) / 35
+        sign, (float)(diff % (60 * TICRATE)) / TICRATE
       );
     }
   }
@@ -72,8 +72,8 @@ static void dsda_UpdateIntermissionTime(dsda_split_t* split) {
     local->time_component.msg,
     sizeof(local->time_component.msg),
     "%s%d:%05.2f",
-    color, leveltime / 35 / 60,
-    (float)(leveltime % (60 * 35)) / 35
+    color, leveltime / TICRATE / 60,
+    (float)(leveltime % (60 * TICRATE)) / TICRATE
   );
 
   strcat(local->time_component.msg, delta);
@@ -92,7 +92,7 @@ static void dsda_UpdateIntermissionTotal(dsda_split_t* split) {
     const char* sign;
     int diff;
 
-    diff = dsda_SplitComparisonDelta(&split->totalleveltimes) / 35;
+    diff = dsda_SplitComparisonDelta(&split->totalleveltimes) / TICRATE;
     sign = diff >= 0 ? "+" : "-";
     color = diff >= 0 ? dsda_TextColor(dsda_tc_inter_split_normal) :
                         dsda_TextColor(dsda_tc_inter_split_good);
@@ -118,8 +118,8 @@ static void dsda_UpdateIntermissionTotal(dsda_split_t* split) {
     local->total_component.msg,
     sizeof(local->total_component.msg),
     "%s%d:%02d",
-    color, totalleveltimes / 35 / 60,
-    (totalleveltimes / 35) % 60
+    color, totalleveltimes / TICRATE / 60,
+    (totalleveltimes / TICRATE) % 60
   );
 
   strcat(local->total_component.msg, delta);

--- a/prboom2/src/dsda/hud_components/map_time.c
+++ b/prboom2/src/dsda/hud_components/map_time.c
@@ -35,8 +35,8 @@ static void dsda_UpdateComponentText(char* str, size_t max_size) {
                totalleveltimes + leveltime;
   level_time = leveltime;
 
-  total_time /= 35;
-  level_time /= 35;
+  total_time /= TICRATE;
+  level_time /= TICRATE;
 
   length = snprintf(
     str,

--- a/prboom2/src/dsda/hud_components/render_stats.c
+++ b/prboom2/src/dsda/hud_components/render_stats.c
@@ -35,8 +35,8 @@ static void dsda_UpdateCurrentComponentText(char* str, size_t max_size) {
     str, max_size,
     "%sFPS %s%4d %sSEGS %s%4d %sPLANES %s%4d %sSPRITES %s%4d",
     dsda_TextColor(dsda_tc_exhud_render_label),
-    dsda_render_stats_fps < 35 ? dsda_TextColor(dsda_tc_exhud_render_bad) :
-                                 dsda_TextColor(dsda_tc_exhud_render_good),
+    dsda_render_stats_fps < TICRATE ? dsda_TextColor(dsda_tc_exhud_render_bad) :
+                                      dsda_TextColor(dsda_tc_exhud_render_good),
     dsda_render_stats_fps,
     dsda_TextColor(dsda_tc_exhud_render_label),
     dsda_render_stats.drawsegs > 256 ? dsda_TextColor(dsda_tc_exhud_render_bad) :

--- a/prboom2/src/dsda/key_frame.c
+++ b/prboom2/src/dsda/key_frame.c
@@ -296,7 +296,7 @@ void dsda_RestoreKeyFrame(dsda_key_frame_t* key_frame, dboolean skip_wipe) {
 
   dsda_RestoreCommandHistory();
 
-  restore_key_frame_index = (totalleveltimes + leveltime) / (35 * autoKeyFrameInterval());
+  restore_key_frame_index = (totalleveltimes + leveltime) / (TICRATE * autoKeyFrameInterval());
 
   G_AfterLoad();
 
@@ -384,7 +384,7 @@ void dsda_UpdateAutoKeyFrames(void) {
   ) return;
 
   current_time = totalleveltimes + leveltime;
-  interval_tics = 35 * autoKeyFrameInterval();
+  interval_tics = TICRATE * autoKeyFrameInterval();
 
   // Automatically save a key frame each interval
   if (current_time % interval_tics == 0) {

--- a/prboom2/src/dsda/render_stats.c
+++ b/prboom2/src/dsda/render_stats.c
@@ -19,6 +19,7 @@
 #include "dsda/utility.h"
 
 #include "render_stats.h"
+#include "doomdef.h"
 
 static dsda_render_stats_t frame_stats;
 static dsda_render_stats_t interval_stats;
@@ -26,7 +27,7 @@ static int frame_count;
 
 dsda_render_stats_t dsda_render_stats;
 dsda_render_stats_t dsda_render_stats_max;
-int dsda_render_stats_fps = 35;
+int dsda_render_stats_fps = TICRATE;
 
 static void dsda_UpdateMaxValues(dsda_render_stats_t* x, dsda_render_stats_t* y) {
   if (x->visplanes < y->visplanes)

--- a/prboom2/src/dsda/text_file.c
+++ b/prboom2/src/dsda/text_file.c
@@ -104,16 +104,16 @@ static char* dsda_TextFileTime(void) {
       text_file_time,
       16,
       "%d:%05.2f",
-      dsda_last_leveltime / 35 / 60,
-      (float)(dsda_last_leveltime % (60 * 35)) / 35
+      dsda_last_leveltime / TICRATE / 60,
+      (float)(dsda_last_leveltime % (60 * TICRATE)) / TICRATE
     );
   else
     snprintf(
       text_file_time,
       16,
       "%d:%02d",
-      totalleveltimes / 35 / 60,
-      (totalleveltimes / 35) % 60
+      totalleveltimes / TICRATE / 60,
+      (totalleveltimes / TICRATE) % 60
     );
 
   return text_file_time;

--- a/prboom2/src/dsda/time.c
+++ b/prboom2/src/dsda/time.c
@@ -25,6 +25,7 @@
 #include "dsda/configuration.h"
 
 #include "time.h"
+#include "doomdef.h"
 
 // clock_gettime implementation for msvc
 // NOTE: Only supports CLOCK_MONOTONIC
@@ -120,8 +121,6 @@ void dsda_LimitFPS(void) {
     dsda_Throttle(dsda_timer_fps, target_time);
   }
 }
-
-#define TICRATE 35
 
 int dsda_GameSpeed(void);
 

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2168,7 +2168,7 @@ void G_DoCompleted (void)
   if (hexen)
     totalleveltimes = players[consoleplayer].worldTimer;
   else
-    totalleveltimes += leveltime - leveltime % 35;
+    totalleveltimes += leveltime - leveltime % TICRATE;
   ++levels_completed;
 
   gameaction = ga_nothing;
@@ -4279,7 +4279,7 @@ static dboolean InventoryMoveLeft(void)
         return true;
     }
 
-    inventoryTics = 5 * 35;
+    inventoryTics = 5 * TICRATE;
     if (!inventory)
     {
         inventory = true;
@@ -4320,7 +4320,7 @@ static dboolean InventoryMoveRight(void)
         return true;
     }
 
-    inventoryTics = 5 * 35;
+    inventoryTics = 5 * TICRATE;
     if (!inventory)
     {
         inventory = true;

--- a/prboom2/src/g_overflow.c
+++ b/prboom2/src/g_overflow.c
@@ -295,7 +295,7 @@ void SpechitOverrun(spechit_overrun_param_t *params)
 
         default:
           fprintf(stderr, "SpechitOverrun: Warning: unable to emulate"
-                          "an overrun where numspechit=%i\n",
+                          " an overrun where numspechit=%i\n",
                            numspechit);
           break;
         }

--- a/prboom2/src/gl_opengl.c
+++ b/prboom2/src/gl_opengl.c
@@ -287,29 +287,29 @@ void gld_InitOpenGL(void)
                           isExtensionSupported ("GL_ARB_shading_language_100");
   if (gl_arb_shader_objects)
   {
-		GLEXT_glDeleteObjectARB        = SDL_GL_GetProcAddress("glDeleteObjectARB");
-		GLEXT_glGetHandleARB           = SDL_GL_GetProcAddress("glGetHandleARB");
-		GLEXT_glDetachObjectARB        = SDL_GL_GetProcAddress("glDetachObjectARB");
-		GLEXT_glCreateShaderObjectARB  = SDL_GL_GetProcAddress("glCreateShaderObjectARB");
-		GLEXT_glShaderSourceARB        = SDL_GL_GetProcAddress("glShaderSourceARB");
-		GLEXT_glCompileShaderARB       = SDL_GL_GetProcAddress("glCompileShaderARB");
-		GLEXT_glCreateProgramObjectARB = SDL_GL_GetProcAddress("glCreateProgramObjectARB");
-		GLEXT_glAttachObjectARB        = SDL_GL_GetProcAddress("glAttachObjectARB");
-		GLEXT_glLinkProgramARB         = SDL_GL_GetProcAddress("glLinkProgramARB");
-		GLEXT_glUseProgramObjectARB    = SDL_GL_GetProcAddress("glUseProgramObjectARB");
-		GLEXT_glValidateProgramARB     = SDL_GL_GetProcAddress("glValidateProgramARB");
+    GLEXT_glDeleteObjectARB        = SDL_GL_GetProcAddress("glDeleteObjectARB");
+    GLEXT_glGetHandleARB           = SDL_GL_GetProcAddress("glGetHandleARB");
+    GLEXT_glDetachObjectARB        = SDL_GL_GetProcAddress("glDetachObjectARB");
+    GLEXT_glCreateShaderObjectARB  = SDL_GL_GetProcAddress("glCreateShaderObjectARB");
+    GLEXT_glShaderSourceARB        = SDL_GL_GetProcAddress("glShaderSourceARB");
+    GLEXT_glCompileShaderARB       = SDL_GL_GetProcAddress("glCompileShaderARB");
+    GLEXT_glCreateProgramObjectARB = SDL_GL_GetProcAddress("glCreateProgramObjectARB");
+    GLEXT_glAttachObjectARB        = SDL_GL_GetProcAddress("glAttachObjectARB");
+    GLEXT_glLinkProgramARB         = SDL_GL_GetProcAddress("glLinkProgramARB");
+    GLEXT_glUseProgramObjectARB    = SDL_GL_GetProcAddress("glUseProgramObjectARB");
+    GLEXT_glValidateProgramARB     = SDL_GL_GetProcAddress("glValidateProgramARB");
 
-		GLEXT_glUniform1fARB = SDL_GL_GetProcAddress("glUniform1fARB");
-		GLEXT_glUniform2fARB = SDL_GL_GetProcAddress("glUniform2fARB");
-		GLEXT_glUniform1iARB = SDL_GL_GetProcAddress("glUniform1iARB");
+    GLEXT_glUniform1fARB = SDL_GL_GetProcAddress("glUniform1fARB");
+    GLEXT_glUniform2fARB = SDL_GL_GetProcAddress("glUniform2fARB");
+    GLEXT_glUniform1iARB = SDL_GL_GetProcAddress("glUniform1iARB");
 
-		GLEXT_glGetObjectParameterfvARB = SDL_GL_GetProcAddress("glGetObjectParameterfvARB");
-		GLEXT_glGetObjectParameterivARB = SDL_GL_GetProcAddress("glGetObjectParameterivARB");
-		GLEXT_glGetInfoLogARB           = SDL_GL_GetProcAddress("glGetInfoLogARB");
-		GLEXT_glGetAttachedObjectsARB   = SDL_GL_GetProcAddress("glGetAttachedObjectsARB");
-		GLEXT_glGetUniformLocationARB   = SDL_GL_GetProcAddress("glGetUniformLocationARB");
-		GLEXT_glGetActiveUniformARB     = SDL_GL_GetProcAddress("glGetActiveUniformARB");
-		GLEXT_glGetUniformfvARB         = SDL_GL_GetProcAddress("glGetUniformfvARB");
+    GLEXT_glGetObjectParameterfvARB = SDL_GL_GetProcAddress("glGetObjectParameterfvARB");
+    GLEXT_glGetObjectParameterivARB = SDL_GL_GetProcAddress("glGetObjectParameterivARB");
+    GLEXT_glGetInfoLogARB           = SDL_GL_GetProcAddress("glGetInfoLogARB");
+    GLEXT_glGetAttachedObjectsARB   = SDL_GL_GetProcAddress("glGetAttachedObjectsARB");
+    GLEXT_glGetUniformLocationARB   = SDL_GL_GetProcAddress("glGetUniformLocationARB");
+    GLEXT_glGetActiveUniformARB     = SDL_GL_GetProcAddress("glGetActiveUniformARB");
+    GLEXT_glGetUniformfvARB         = SDL_GL_GetProcAddress("glGetUniformfvARB");
 
     if (!GLEXT_glDeleteObjectARB || !GLEXT_glGetHandleARB ||
         !GLEXT_glDetachObjectARB || !GLEXT_glCreateShaderObjectARB ||

--- a/prboom2/src/heretic/in_lude.c
+++ b/prboom2/src/heretic/in_lude.c
@@ -284,7 +284,7 @@ void IN_InitStats(void)
     if (!netgame)
     {
         gametype = SINGLE;
-        count = leveltime / 35;
+        count = leveltime / TICRATE;
         hours = count / 3600;
         count -= hours * 3600;
         minutes = count / 60;
@@ -292,7 +292,7 @@ void IN_InitStats(void)
         seconds = count;
 
         // [crispy] Show total time on intermission
-        count = wbs->totaltimes / 35;
+        count = wbs->totaltimes / TICRATE;
         totalHours = count / 3600;
         count -= totalHours * 3600;
         totalMinutes = count / 60;

--- a/prboom2/src/heretic/mn_menu.c
+++ b/prboom2/src/heretic/mn_menu.c
@@ -104,10 +104,10 @@ extern void M_SaveGame(int choice);
 //
 /////////////////////////////
 
-enum { infoempty1, info1_end } info_e1;
-enum { infoempty2, info2_end } info_e2;
-enum { infoempty3, info3_end } info_e3;
-enum { infoempty4, info4_end } info_e4;
+enum info_e1 { infoempty1, info1_end };
+enum info_e2 { infoempty2, info2_end };
+enum info_e3 { infoempty3, info3_end };
+enum info_e4 { infoempty4, info4_end };
 
 menuitem_t InfoMenu1[] = { {1,"",MN_Info2,0} };
 menuitem_t InfoMenu2[] = { {1,"",MN_Info3,0} };
@@ -190,28 +190,24 @@ void MN_DrawAd (void)
   ravenlump = (heretic && (gamemode == shareware)) ? "ORDER" : "CREDIT";
   M_ChangeMenu(NULL, mnact_full);
   V_DrawRawScreen(ravenlump);
-  return;
 }
 
 void MN_DrawHelp1 (void)
 {
   M_ChangeMenu(NULL, mnact_full);
   V_DrawRawScreen("HELP1");
-  return;
 }
 
 void MN_DrawHelp2 (void)
 {
   M_ChangeMenu(NULL, mnact_full);
   V_DrawRawScreen("HELP2");
-  return;
 }
 
 void MN_DrawCredits (void)
 {
   M_ChangeMenu(NULL, mnact_full);
   V_DrawRawScreen("CREDIT");
-  return;
 }
 
 /////////////////////////////
@@ -220,7 +216,7 @@ void MN_DrawCredits (void)
 //
 /////////////////////////////
 
-enum
+enum rmain_e
 {
   rnewgame = 0,
   roptions,
@@ -228,7 +224,7 @@ enum
   rinfo,
   rquitdoom,
   rmain_end
-} rmain_e;
+};
 
 menuitem_t RavenMainMenu[]=
 {
@@ -246,12 +242,12 @@ menuitem_t RavenMainMenu[]=
 //
 /////////////////////////////
 
-enum
+enum saveload_e
 {
   rloadgame,
   rsavegame,
   rsaveload_end
-} saveload_e;
+};
 
 menuitem_t SaveLoadMenu[]=
 {

--- a/prboom2/src/hexen/a_action.c
+++ b/prboom2/src/hexen/a_action.c
@@ -144,7 +144,7 @@ void A_PotteryCheck(mobj_t * actor)
     {
         pmo = players[consoleplayer].mo;
         if (P_CheckSight(actor, pmo)
-	  && (abs((int)R_PointToAngle2(pmo->x, pmo->y, actor->x, actor->y)
+          && (abs((int)R_PointToAngle2(pmo->x, pmo->y, actor->x, actor->y)
            - (int)pmo->angle) <= ANG45))
         {                       // Previous state (pottery bit waiting state)
             P_SetMobjState(actor, actor->state - &states[0] - 1);

--- a/prboom2/src/hexen/p_acs.c
+++ b/prboom2/src/hexen/p_acs.c
@@ -453,7 +453,7 @@ static void StartOpenACS(int number, int infoIndex, int offset)
     script->number = number;
 
     // World objects are allotted 1 second for initialization
-    script->delayCount = 35;
+    script->delayCount = TICRATE;
 
     script->infoIndex = infoIndex;
     script->ip = offset;
@@ -472,7 +472,7 @@ void P_CheckACSStore(void)
             P_StartACS(store->script, 0, store->args, NULL, NULL, 0);
             if (NewScript)
             {
-                NewScript->delayCount = 35;
+                NewScript->delayCount = TICRATE;
             }
             store->map = -1;
         }

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -290,11 +290,11 @@ static void P_LightningFlash(void)
         {
             if (P_Random(pr_hexen) < 128 && !(leveltime & 32))
             {
-                NextLightningFlash = ((P_Random(pr_hexen) & 7) + 2) * 35;
+                NextLightningFlash = ((P_Random(pr_hexen) & 7) + 2) * TICRATE;
             }
             else
             {
-                NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * 35;
+                NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * TICRATE;
             }
         }
     }
@@ -337,7 +337,7 @@ void P_InitLightning(void)
         return;
     }
     LightningLightLevels = (int *) Z_MallocLevel(secCount * sizeof(int));
-    NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * 35;  // don't flash at level start
+    NextLightningFlash = ((P_Random(pr_hexen) & 15) + 5) * TICRATE;  // don't flash at level start
 }
 
 void P_InitFTAnims(void)

--- a/prboom2/src/m_fixed.h
+++ b/prboom2/src/m_fixed.h
@@ -115,7 +115,7 @@ inline static CONSTFUNC fixed_t FixedMod(fixed_t a, fixed_t b)
 
 static CONSTFUNC fixed_t Scale(fixed_t a, fixed_t b, fixed_t c)
 {
-	return (fixed_t)(((int64_t)a*b)/c);
+  return (fixed_t)(((int64_t)a*b)/c);
 }
 
 #endif

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3729,8 +3729,8 @@ static void M_ResetLevelTable(void)
 static void M_PrintTime(dsda_string_t* m_text, int tics)
 {
   dsda_StringPrintF(m_text, "%d:%05.2f",
-                    tics / 35 / 60,
-                    (float) (tics % (60 * 35)) / 35);
+                    tics / TICRATE / 60,
+                    (float) (tics % (60 * TICRATE)) / TICRATE);
 }
 
 static int wad_stats_summary_page;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -382,7 +382,7 @@ void T_VerticalHexenDoor(vldoor_t *door)
             break;
           case DREV_CLOSE30THENOPEN:
             door->direction = 0;
-            door->topcountdown = 35 * 30;
+            door->topcountdown = TICRATE * 30;
             break;
           default:
             break;
@@ -837,7 +837,7 @@ void P_SpawnDoorCloseIn30 (sector_t* sec)
   door->direction = 0;
   door->type = g_door_normal;
   door->speed = VDOORSPEED;
-  door->topcountdown = 30 * 35;
+  door->topcountdown = 30 * TICRATE;
   door->line = NULL; // jff 1/31/98 remember line that triggered us
   door->lighttag = 0; /* killough 10/98: no lighting changes */
 }
@@ -872,7 +872,7 @@ void P_SpawnDoorRaiseIn5Mins
   door->topheight = P_FindLowestCeilingSurrounding(sec);
   door->topheight -= 4*FRACUNIT;
   door->topwait = VDOORWAIT;
-  door->topcountdown = 5 * 60 * 35;
+  door->topcountdown = 5 * 60 * TICRATE;
   door->line = NULL; // jff 1/31/98 remember line that triggered us
   door->lighttag = 0; /* killough 10/98: no lighting changes */
 }

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3897,7 +3897,7 @@ dboolean P_UpdateChicken(mobj_t * actor, int tics)
         mo->flags = oldChicken.flags;
         mo->health = oldChicken.health;
         P_SetTarget(&mo->target, oldChicken.target);
-        mo->special1.i = 5 * 35;  // Next try in 5 seconds
+        mo->special1.i = 5 * TICRATE;  // Next try in 5 seconds
         mo->special2.i = moType;
         dsda_WatchMorph(mo);
         return (false);
@@ -4332,9 +4332,9 @@ void A_MinotaurDecide(mobj_t * actor)
         actor->momy = FixedMul(g_mntr_charge_speed, finesine[angle]);
         // Charge duration
         if (hexen)
-          actor->special_args[4] = 35 / 2;
+          actor->special_args[4] = TICRATE / 2;
         else
-          actor->special1.i = 35 / 2;
+          actor->special1.i = TICRATE / 2;
     }
     else if (target->z == target->floorz
              && dist < 9 * 64 * FRACUNIT && P_Random(pr_heretic) < g_mntr_fire_rng)
@@ -4783,7 +4783,7 @@ void A_SpawnTeleGlitter2(mobj_t * actor)
 
 void A_AccTeleGlitter(mobj_t * actor)
 {
-    if (++actor->health > 35)
+    if (++actor->health > TICRATE)
     {
         actor->momz += actor->momz / 2;
     }
@@ -5376,7 +5376,7 @@ dboolean P_UpdateMorphedMonster(mobj_t * actor, int tics)
         mo->health = oldMonster.health;
         P_SetTarget(&mo->target, oldMonster.target);
         mo->special = oldMonster.special;
-        mo->special1.i = 5 * 35;  // Next try in 5 seconds
+        mo->special1.i = 5 * TICRATE;  // Next try in 5 seconds
         mo->special2.i = moType;
         mo->tid = oldMonster.tid;
         memcpy(mo->special_args, oldMonster.special_args, SPECIAL_ARGS_SIZE);
@@ -7480,7 +7480,7 @@ void A_IceGuyMissileExplode(mobj_t * actor)
 #define SORCBALL_SPEED_ROTATIONS 	5
 #define SORC_DEFENSE_TIME			255
 #define SORC_DEFENSE_HEIGHT			45
-#define BOUNCE_TIME_UNIT			(35/2)
+#define BOUNCE_TIME_UNIT			(TICRATE/2)
 #define SORCFX4_RAPIDFIRE_TIME		(6*3)   // 3 seconds
 #define SORCFX4_SPREAD_ANGLE		20
 
@@ -7848,7 +7848,7 @@ void A_SorcOffense2(mobj_t * actor)
     mo = P_SpawnMissileAngle(parent, HEXEN_MT_SORCFX4, ang1, 0);
     if (mo)
     {
-        mo->special2.i = 35 * 5 / 2;      // 5 seconds
+        mo->special2.i = TICRATE * 5 / 2;      // 5 seconds
         dist = P_AproxDistance(dest->x - mo->x, dest->y - mo->y);
         dist = dist / mo->info->speed;
         if (dist < 1)
@@ -8261,7 +8261,7 @@ void A_CheckFloor(mobj_t * actor)
 //      250-254         For use in respective control scripts
 //      255             For use in death script (spawn spots)
 //===========================================================================
-#define KORAX_SPIRIT_LIFETIME	(5*(35/5))      // 5 seconds
+#define KORAX_SPIRIT_LIFETIME	(5*(TICRATE/5))      // 5 seconds
 #define KORAX_COMMAND_HEIGHT	(120*FRACUNIT)
 #define KORAX_COMMAND_OFFSET	(27*FRACUNIT)
 

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -2403,8 +2403,8 @@ static void P_SpawnPlaneWaggle(sector_t *sector, int height, int speed,
   waggle->accDelta = speed << 10;
   waggle->scale = 0;
   waggle->targetScale = height << 10;
-  waggle->scaleDelta = waggle->targetScale / (35 + ((3 * 35) * height) / 255);
-  waggle->ticker = timer ? timer * 35 : -1;
+  waggle->scaleDelta = waggle->targetScale / (TICRATE + ((3 * TICRATE) * height) / 255);
+  waggle->ticker = timer ? timer * TICRATE : -1;
   waggle->state = WGLSTATE_EXPAND;
   P_AddThinker(&waggle->thinker);
 }

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -1196,7 +1196,7 @@ int EV_DoZDoomElevator(line_t *line, elevator_e type, fixed_t speed, fixed_t hei
     P_SpawnElevator(sec, line, type, speed, height);
   }
 
-	return rtn;
+  return rtn;
 }
 
 int EV_DoElevator

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -1048,7 +1048,7 @@ int P_SpawnDonut(int secnum, line_t *line, fixed_t pillarspeed, fixed_t slimespe
       if (DonutOverrun(&s3_floorheight, &s3_floorpic))
       {
         lprintf(LO_WARN, "EV_DoDonut: Emulated with floorheight %d, floor pic %d.\n",
-          s3_floorheight >> 16, s3_floorpic);
+          s3_floorheight >> FRACBITS, s3_floorpic);
       }
       else
       {

--- a/prboom2/src/p_genlin.c
+++ b/prboom2/src/p_genlin.c
@@ -529,16 +529,16 @@ int EV_DoGenLift
     switch(Dely)
     {
       case 0:
-        plat->wait = 1*35;
+        plat->wait = 1*TICRATE;
         break;
       case 1:
-        plat->wait = PLATWAIT*35;
+        plat->wait = PLATWAIT*TICRATE;
         break;
       case 2:
-        plat->wait = 5*35;
+        plat->wait = 5*TICRATE;
         break;
       case 3:
-        plat->wait = 10*35;
+        plat->wait = 10*TICRATE;
         break;
     }
 
@@ -951,7 +951,7 @@ int EV_DoGenDoor
     {
       default:
       case 0:
-        door->topwait = 35;
+        door->topwait = TICRATE;
         break;
       case 1:
         door->topwait = VDOORWAIT;

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -1822,7 +1822,7 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
 
 #include "p_user.h"
 
-#define CHICKENTICS (40*35)
+#define CHICKENTICS (40*TICRATE)
 
 void A_RestoreArtifact(mobj_t * arti)
 {

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -3498,10 +3498,10 @@ void P_CreateSecNodeList(mobj_t* thing,fixed_t x,fixed_t y)
 /* cphipps 2004/08/30 -
  * Must clear tmthing at tic end, as it might contain a pointer to a removed thinker, or the level might have ended/been ended and we clear the objects it was pointing too. Hopefully we don't need to carry this between tics for sync. */
 void P_MapStart(void) {
-	if (tmthing) I_Error("P_MapStart: tmthing set!");
+  if (tmthing) I_Error("P_MapStart: tmthing set!");
 }
 void P_MapEnd(void) {
-	tmthing = NULL;
+  tmthing = NULL;
 }
 
 // heretic

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1042,7 +1042,7 @@ floater:
      * incorrectly reverse it, so we might still need this for demo sync
      */
     if (mo->flags & MF_SKULLFLY &&
-	     compatibility_level <= doom2_19_compatibility)
+       compatibility_level <= doom2_19_compatibility)
       mo->momz = -mo->momz; // the skull slammed into something
 
     if (mo->info->crashstate && (mo->flags & MF_CORPSE) && !(mo->flags2 & MF2_ICEDAMAGE))
@@ -1510,7 +1510,7 @@ static PUREFUNC int P_FindDoomedNum(unsigned type)
 }
 
 dboolean P_SpawnProjectile(short thing_id, mobj_t *source, int spawn_num, angle_t angle,
-	                         fixed_t speed, fixed_t vspeed, short dest_id, mobj_t *forcedest,
+                           fixed_t speed, fixed_t vspeed, short dest_id, mobj_t *forcedest,
                            int gravity, short new_thing_id)
 {
   int type;

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1431,7 +1431,7 @@ void P_MobjThinker (mobj_t* mobj)
 
     mobj->movecount++;
 
-    if (mobj->movecount < skill_info.respawn_time * 35)
+    if (mobj->movecount < skill_info.respawn_time * TICRATE)
       return;
 
     if (leveltime & 31)
@@ -1980,7 +1980,7 @@ void P_RespawnSpecials (void)
 
   // wait at least 30 seconds
 
-  if (leveltime - itemrespawntime[iquetail] < 30*35)
+  if (leveltime - itemrespawntime[iquetail] < 30*TICRATE)
     return;
 
   mthing = &itemrespawnque[iquetail];

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -569,7 +569,7 @@ fixed_t P_MobjGravity(mobj_t* mo);
 dboolean P_SpawnThing(short thing_id, mobj_t *source, int type,
                       angle_t angle, dboolean fog, short new_thing_id);
 dboolean P_SpawnProjectile(short thing_id, mobj_t *source, int spawn_num, angle_t angle,
-	                         fixed_t speed, fixed_t vspeed, short dest_id, mobj_t *forcedest,
+                           fixed_t speed, fixed_t vspeed, short dest_id, mobj_t *forcedest,
                            int gravity, short new_thing_id);
 
 #endif

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -557,7 +557,7 @@ int EV_DoPlat
           plat->low = sec->floorheight;
 
         plat->high = sec->floorheight;
-        plat->wait = 35*PLATWAIT;
+        plat->wait = TICRATE*PLATWAIT;
         plat->status = down;
         S_StartSectorSound(sec, g_sfx_pstart);
         break;
@@ -570,7 +570,7 @@ int EV_DoPlat
           plat->low = sec->floorheight;
 
         plat->high = sec->floorheight;
-        plat->wait = 35*PLATWAIT;
+        plat->wait = TICRATE*PLATWAIT;
         plat->status = down;
         S_StartSectorSound(sec, sfx_pstart);
         break;
@@ -587,7 +587,7 @@ int EV_DoPlat
         if (plat->high < sec->floorheight)
           plat->high = sec->floorheight;
 
-        plat->wait = 35*PLATWAIT;
+        plat->wait = TICRATE*PLATWAIT;
         plat->status = P_Random(pr_plats)&1;
 
         S_StartSectorSound(sec, g_sfx_pstart);
@@ -595,7 +595,7 @@ int EV_DoPlat
 
       case toggleUpDn: //jff 3/14/98 add new type to support instant toggle
         plat->speed = PLATSPEED;  //not used
-        plat->wait = 35*PLATWAIT; //not used
+        plat->wait = TICRATE*PLATWAIT; //not used
         plat->crush = DOOM_CRUSH; //jff 3/14/98 crush anything in the way
 
         // set up toggling between ceiling, floor inclusive

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -1559,7 +1559,7 @@ void P_MovePsprites(player_t *player)
 #include "p_maputl.h"
 
 #define MAGIC_JUNK 1234
-#define FLAME_THROWER_TICS 10*35
+#define FLAME_THROWER_TICS (10*TICRATE)
 
 #define MAX_MACE_SPOTS 8
 

--- a/prboom2/src/p_sight.c
+++ b/prboom2/src/p_sight.c
@@ -612,8 +612,8 @@ dboolean P_CrossSubsector_PrBoom(int num)
       /* cph 2006/07/15 - oops, we missed this in 2.4.0 & .1;
        *  use P_InterceptVector2 for those compat levels only. */
       fixed_t frac = (compatibility_level == prboom_5_compatibility || compatibility_level == prboom_6_compatibility) ?
-		      P_InterceptVector2(&los.strace, &divl) :
-		      P_InterceptVector(&los.strace, &divl);
+        P_InterceptVector2(&los.strace, &divl) :
+        P_InterceptVector(&los.strace, &divl);
 
       if (front->floorheight != back->floorheight)
       {

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -4731,11 +4731,11 @@ int AmbSndSeq4[] = {            // SlowFootSteps
 };
 int AmbSndSeq5[] = {            // Heartbeat
     afxcmd_play, heretic_sfx_amb5,
-    afxcmd_delay, 35,
+    afxcmd_delay, TICRATE,
     afxcmd_play, heretic_sfx_amb5,
-    afxcmd_delay, 35,
+    afxcmd_delay, TICRATE,
     afxcmd_play, heretic_sfx_amb5,
-    afxcmd_delay, 35,
+    afxcmd_delay, TICRATE,
     afxcmd_play, heretic_sfx_amb5,
     afxcmd_end
 };
@@ -5809,7 +5809,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
       break;
     case zl_door_close_wait_open:
       buttonSuccess = EV_DoZDoomDoor(genCdO, line, mo, args[0],
-                                     args[1], args[2] * 35 / 8, 0, args[3], false, 0);
+                                     args[1], args[2] * TICRATE / 8, 0, args[3], false, 0);
       break;
     case zl_door_wait_raise:
       buttonSuccess = EV_DoZDoomDoor(waitRaiseDoor, line, mo, args[0],
@@ -5859,7 +5859,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
         }
 
         buttonSuccess = EV_DoZDoomDoor(type, line, mo, tag, args[1],
-                                       args[3] * 35 / 8, args[4], lightTag, boomgen, 0);
+                                       args[3] * TICRATE / 8, args[4], lightTag, boomgen, 0);
       }
       break;
     case zl_pillar_build:
@@ -6483,7 +6483,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
         }
 
         buttonSuccess = EV_DoZDoomPlat(args[0], line, type, args[4] * 8,
-                                       P_ArgToSpeed(args[1]), args[2] * 35 / 8, 0, 0);
+                                       P_ArgToSpeed(args[1]), args[2] * TICRATE / 8, 0, 0);
       }
       break;
     case zl_line_set_blocking:

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -1264,7 +1264,7 @@ dboolean P_UseSpecialLine
 ( mobj_t* thing,
   line_t* line,
   int   side,
-	dboolean noplayercheck);
+  dboolean noplayercheck);
 
 void P_PlayerInSpecialSector
 ( player_t* player );

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -69,6 +69,7 @@
 
 // p_lights
 
+// relative to TICRATE
 #define GLOWSPEED       8
 #define STROBEBRIGHT    5
 #define FASTDARK        15

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -1174,7 +1174,7 @@ dboolean P_UndoPlayerChicken(player_t * player)
         mo->flags = oldFlags;
         mo->flags2 = oldFlags2;
         player->mo = mo;
-        player->chickenTics = 2 * 35;
+        player->chickenTics = 2 * TICRATE;
         return (false);
     }
     playerNum = P_GetPlayerNum(player);
@@ -1859,7 +1859,7 @@ dboolean P_UndoPlayerMorph(player_t * player)
         mo->flags = oldFlags;
         mo->flags2 = oldFlags2;
         player->mo = mo;
-        player->morphTics = 2 * 35;
+        player->morphTics = 2 * TICRATE;
         return (false);
     }
     if (player->pclass == PCLASS_FIGHTER)

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -726,8 +726,8 @@ void R_ExecuteSetViewSize (void)
 
   skyiscale = (200 << FRACBITS) / SCREENHEIGHT;
 
-	// [RH] Sky height fix for screens not 200 (or 240) pixels tall
-	R_InitSkyMap();
+  // [RH] Sky height fix for screens not 200 (or 240) pixels tall
+  R_InitSkyMap();
 
   // thing clipping
   for (i=0 ; i<viewwidth ; i++)

--- a/prboom2/src/r_segs.c
+++ b/prboom2/src/r_segs.c
@@ -1012,9 +1012,9 @@ void R_StoreWallRange(const int start, const int stop)
        * a possibility, otherwise the floor marking would overwrite the ceiling
        * marking, resulting in HOM. */
       if (markceiling && ceilingplane == floorplane)
-	      floorplane = R_DupPlane (floorplane, rw_x, rw_stopx-1);
+        floorplane = R_DupPlane (floorplane, rw_x, rw_stopx-1);
       else
-	      floorplane = R_CheckPlane (floorplane, rw_x, rw_stopx-1);
+        floorplane = R_CheckPlane (floorplane, rw_x, rw_stopx-1);
     }
     else
     {

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -980,28 +980,28 @@ void R_AddAllAliveMonstersSprites(void)
 // [crispy] apply bobbing (or centering) to the player's weapon sprite
 static void R_ApplyWeaponBob (fixed_t *sx, dboolean bobx, fixed_t *sy, dboolean boby)
 {
-	const angle_t angle = (128 * leveltime) & FINEMASK;
-	fixed_t bob = viewplayer->bob * dsda_WeaponBob() / 4;
+  const angle_t angle = (128 * leveltime) & FINEMASK;
+  fixed_t bob = viewplayer->bob * dsda_WeaponBob() / 4;
 
-	if (sx)
-	{
-		*sx = FRACUNIT;
+  if (sx)
+  {
+    *sx = FRACUNIT;
 
-		if (bobx)
-		{
-			 *sx += FixedMul(bob, finecosine[angle]);
-		}
-	}
+    if (bobx)
+    {
+       *sx += FixedMul(bob, finecosine[angle]);
+    }
+  }
 
-	if (sy)
-	{
-		*sy = 32 * FRACUNIT; // [crispy] WEAPONTOP
+  if (sy)
+  {
+    *sy = 32 * FRACUNIT; // [crispy] WEAPONTOP
 
-		if (boby)
-		{
-			*sy += FixedMul(bob, finesine[angle & (FINEANGLES / 2 - 1)]);
-		}
-	}
+    if (boby)
+    {
+      *sy += FixedMul(bob, finesine[angle & (FINEANGLES / 2 - 1)]);
+    }
+  }
 }
 
 //

--- a/prboom2/src/scanner.cpp
+++ b/prboom2/src/scanner.cpp
@@ -51,7 +51,7 @@ const char* const Scanner::TokenNames[TK_NumSpecialTokens] =
 	"Logical Or",
 	"Equals",
 	"Not Equals",
-	"Greater Than or Equals"
+	"Greater Than or Equals",
 	"Less Than or Equals",
 	"Left Shift",
 	"Right Shift"

--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -228,7 +228,7 @@ static void W_AddFile(wadfile_info_t *wadfile)
           lump_p->li_namespace = ns_global;              // killough 4/17/98
         }
         strncpy (lump_p->name, fileinfo->name, 8);
-	lump_p->source = wadfile->src;                    // Ty 08/29/98
+        lump_p->source = wadfile->src;                    // Ty 08/29/98
       }
 
     Z_Free(fileinfo2free);      // killough

--- a/prboom2/src/win_opendir.c
+++ b/prboom2/src/win_opendir.c
@@ -57,7 +57,6 @@ DIR *opendir(const _TCHAR *szPath)
    DIR *nd;
    unsigned int rc;
    _TCHAR szFullPath[MAX_PATH];
-	
    errno = 0;
    
    if(!szPath)
@@ -110,9 +109,9 @@ DIR *opendir(const _TCHAR *szPath)
    /* Add on a slash if the path does not end with one. */
    if(nd->dd_name[0] != _T('\0')
       && _tcsrchr(nd->dd_name, _T('/'))  != nd->dd_name
-					    + _tcslen(nd->dd_name) - 1
+         + _tcslen(nd->dd_name) - 1
       && _tcsrchr(nd->dd_name, _T('\\')) != nd->dd_name
-      					    + _tcslen(nd->dd_name) - 1)
+         + _tcslen(nd->dd_name) - 1)
    {
       _tcscat(nd->dd_name, SLASH);
    }

--- a/prboom2/src/xs_Float.h
+++ b/prboom2/src/xs_Float.h
@@ -61,7 +61,7 @@ finline int xs_CRoundToInt(real64 val)
 	uval.val = val + 6755399441055744.0;
 	return uval.ival[_xs_iman_];
 #else
-    return int(floor(val+.5));
+	return int(floor(val+.5));
 #endif
 }
 

--- a/udb/DSDADoom_DoomUDMF.cfg
+++ b/udb/DSDADoom_DoomUDMF.cfg
@@ -49,37 +49,37 @@ sidedefcompressionignoresaction = true;
 // Texture sources
 textures
 {
-  include("Includes\\Doom_misc.cfg", "textures");
+	include("Includes\\Doom_misc.cfg", "textures");
 }
 
 // Patch sources
 patches
 {
-  include("Includes\\Doom_misc.cfg", "patches");
+	include("Includes\\Doom_misc.cfg", "patches");
 }
 
 // Sprite sources
 sprites
 {
-  include("Includes\\Doom_misc.cfg", "sprites");
+	include("Includes\\Doom_misc.cfg", "sprites");
 }
 
 // Flat sources
 flats
 {
-  include("Includes\\Doom_misc.cfg", "flats");
+	include("Includes\\Doom_misc.cfg", "flats");
 }
 
 // Colormap sources
 colormaps
 {
-  include("Includes\\Boom_misc.cfg", "colormaps");
+	include("Includes\\Boom_misc.cfg", "colormaps");
 }
 
 // Generalized sector types
 gen_sectortypes
 {
-  include("Includes\\ZDoom_generalized.cfg", "gen_sectortypes");
+	include("Includes\\ZDoom_generalized.cfg", "gen_sectortypes");
 }
 
 damagetypes = "";
@@ -87,8 +87,8 @@ internalsoundnames = "";
 
 compatibility
 {
-  fixnegativepatchoffsets = true;
-  fixmaskedpatchoffsets = true;
+	fixnegativepatchoffsets = true;
+	fixmaskedpatchoffsets = true;
 }
 
 // The format interface handles the map data format
@@ -122,7 +122,7 @@ lowerunpeggedflag = "dontpegbottom";
 defaultlinedefactivation = "playercross"; //mxd. Used when translating a map to UDMF
 
 // Door making
-makedooraction = 202;	// See linedeftypes
+makedooraction = 202; // See linedeftypes
 makedoorflags { playeruse; repeatspecial; }
 makedoorarg0 = 0;
 makedoorarg1 = 16;
@@ -133,7 +133,7 @@ makedoorarg4 = 0;
 // SECTOR FLAGS
 sectorflags
 {
-  silent = "Silent";
+	silent = "Silent";
 	hidden = "Not shown on textured automap";
 	damagehazard = "Strife damage model";
 	noattack = "Monsters in this sector do not attack";
@@ -142,7 +142,7 @@ sectorflags
 // SECTOR TYPES
 sectortypes
 {
-  0 = "None";
+	0 = "None";
 	1 = "Light Phased";
 	2 = "Light Sequence Start";
 	3 = "Light Sequence Special 1";
@@ -180,7 +180,7 @@ sectortypes
 	83 = "Damage -8% health (no protection)";
 	84 = "Scroll east + -2 or -5% health (no protection)";
 	85 = "Damage Sludge -4% health";
-  104 = "sLight_Strobe_Hurt";
+	104 = "sLight_Strobe_Hurt";
 	105 = "Delayed damage weak (hazardcount +2/16 per second)";
 	115 = "Instant death";
 	116 = "Delayed damage strong (hazardcount +4/16 per second)";
@@ -238,7 +238,7 @@ include("Includes\\DSDADoom_misc.cfg");
 // LINEDEF TYPES
 linedeftypes
 {
-  include("Includes\\DSDADoom_linedefs.cfg");
+	include("Includes\\DSDADoom_linedefs.cfg");
 }
 
 // Settings common to Doom games
@@ -259,5 +259,5 @@ thingtypes
 // Dehacked data
 dehacked
 {
-  include("Includes\\Dehacked_Doom.cfg");
+	include("Includes\\Dehacked_Doom.cfg");
 }

--- a/udb/Includes/DSDADoom_linedefs.cfg
+++ b/udb/Includes/DSDADoom_linedefs.cfg
@@ -8,2694 +8,2694 @@ misc
 
 polyobj
 {
-  include("Hexen_linedefs.cfg", "polyobj");
+	include("Hexen_linedefs.cfg", "polyobj");
 
-  6 = null; // Polyobj_MoveTimes8
-  93 = null; // Polyobj_OR_MoveTimes8
+	6 = null; // Polyobj_MoveTimes8
+	93 = null; // Polyobj_OR_MoveTimes8
 
-  59
-  {
-    title = "Polyobject Move to Spot (override)";
-    id = "Polyobj_OR_MoveToSpot";
-    arg0
-    {
-      title = "Polyobject Number";
-      type = 25;
-    }
-    arg1
-    {
-      title = "Speed (mu. per octic)";
-      type = 11;
-      enum = "stair_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Target MapSpot Tag";
-      type = 14;
-      targetclasses = "MapSpot,MapSpotGravity";
-    }
-  }
+	59
+	{
+		title = "Polyobject Move to Spot (override)";
+		id = "Polyobj_OR_MoveToSpot";
+		arg0
+		{
+			title = "Polyobject Number";
+			type = 25;
+		}
+		arg1
+		{
+			title = "Speed (mu. per octic)";
+			type = 11;
+			enum = "stair_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Target MapSpot Tag";
+			type = 14;
+			targetclasses = "MapSpot,MapSpotGravity";
+		}
+	}
 
-  86
-  {
-    title = "Polyobject Move to Spot";
-    id = "Polyobj_MoveToSpot";
-    arg0
-    {
-      title = "Polyobject Number";
-      type = 25;
-    }
-    arg1
-    {
-      title = "Speed (mu. per octic)";
-      type = 11;
-      enum = "stair_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Target MapSpot Tag";
-      type = 14;
-      targetclasses = "MapSpot,MapSpotGravity";
-    }
-  }
+	86
+	{
+		title = "Polyobject Move to Spot";
+		id = "Polyobj_MoveToSpot";
+		arg0
+		{
+			title = "Polyobject Number";
+			type = 25;
+		}
+		arg1
+		{
+			title = "Speed (mu. per octic)";
+			type = 11;
+			enum = "stair_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Target MapSpot Tag";
+			type = 14;
+			targetclasses = "MapSpot,MapSpotGravity";
+		}
+	}
 
-  87
-  {
-    title = "Polyobject Stop";
-    id = "Polyobj_Stop";
-    arg0
-    {
-      title = "Polyobject Number";
-      type = 25;
-    }
-  }
+	87
+	{
+		title = "Polyobject Stop";
+		id = "Polyobj_Stop";
+		arg0
+		{
+			title = "Polyobject Number";
+			type = 25;
+		}
+	}
 
-  88
-  {
-    title = "Polyobject Move to";
-    id = "Polyobj_MoveTo";
-    arg0
-    {
-      title = "Polyobject Number";
-      type = 25;
-    }
-    arg1
-    {
-      title = "Speed (mu. per octic)";
-      type = 11;
-      enum = "stair_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Target X Pos";
-    }
-    arg3
-    {
-      title = "Target Y Pos";
-    }
-  }
+	88
+	{
+		title = "Polyobject Move to";
+		id = "Polyobj_MoveTo";
+		arg0
+		{
+			title = "Polyobject Number";
+			type = 25;
+		}
+		arg1
+		{
+			title = "Speed (mu. per octic)";
+			type = 11;
+			enum = "stair_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Target X Pos";
+		}
+		arg3
+		{
+			title = "Target Y Pos";
+		}
+	}
 
-  89
-  {
-    title = "Polyobject Move to (override)";
-    id = "Polyobj_OR_MoveTo";
-    arg0
-    {
-      title = "Polyobject Number";
-      type = 25;
-    }
-    arg1
-    {
-      title = "Speed (mu. per octic)";
-      type = 11;
-      enum = "stair_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Target X Pos";
-    }
-    arg3
-    {
-      title = "Target Y Pos";
-    }
-  }
+	89
+	{
+		title = "Polyobject Move to (override)";
+		id = "Polyobj_OR_MoveTo";
+		arg0
+		{
+			title = "Polyobject Number";
+			type = 25;
+		}
+		arg1
+		{
+			title = "Speed (mu. per octic)";
+			type = 11;
+			enum = "stair_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Target X Pos";
+		}
+		arg3
+		{
+			title = "Target Y Pos";
+		}
+	}
 }
 
 line
 {
-  title = "Line";
+	title = "Line";
 
-  55
-  {
-    title = "Line Set Blocking";
-    id = "Line_SetBlocking";
+	55
+	{
+		title = "Line Set Blocking";
+		id = "Line_SetBlocking";
 
-    arg0
-    {
-      title = "Target Line Tag";
-      type = 15;
-    }
-    arg1
-    {
-      title = "Set Flags";
-      type = 12;
-      enum = "linesetblockingflags";
-    }
-    arg2
-    {
-      title = "Clear Flags";
-      type = 12;
-      enum = "linesetblockingflags";
-    }
-  }
+		arg0
+		{
+			title = "Target Line Tag";
+			type = 15;
+		}
+		arg1
+		{
+			title = "Set Flags";
+			type = 12;
+			enum = "linesetblockingflags";
+		}
+		arg2
+		{
+			title = "Clear Flags";
+			type = 12;
+			enum = "linesetblockingflags";
+		}
+	}
 }
 
 door
 {
-  include("Hexen_linedefs.cfg", "door");
+	include("Hexen_linedefs.cfg", "door");
 
-  202
-  {
-    title = "Door Generic";
-    id = "Generic_Door";
+	202
+	{
+		title = "Door Generic";
+		id = "Generic_Door";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "flat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Type";
-      type = 26;
-      enum
-      {
-        0 = "Open Close";
-        1 = "Open Stay";
-        2 = "Close Open";
-        3 = "Close Stay";
-      }
-      flags
-      {
-        64 = "No retrigger";
-        128 = "Tag is light tag";
-      }
-    }
-    arg3
-    {
-      title = "Delay";
-      type = 11;
-      enum = "generic_door_delays";
-      default = 34;
-    }
-    arg4
-    {
-      title = "Lock";
-      type = 11;
-      enum = "keys";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "flat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Type";
+			type = 26;
+			enum
+			{
+				0 = "Open Close";
+				1 = "Open Stay";
+				2 = "Close Open";
+				3 = "Close Stay";
+			}
+			flags
+			{
+				64 = "No retrigger";
+				128 = "Tag is light tag";
+			}
+		}
+		arg3
+		{
+			title = "Delay";
+			type = 11;
+			enum = "generic_door_delays";
+			default = 34;
+		}
+		arg4
+		{
+			title = "Lock";
+			type = 11;
+			enum = "keys";
+		}
+	}
 
-  249
-  {
-    title = "Door Close Wait Open";
-    id = "Door_CloseWaitOpen";
+	249
+	{
+		title = "Door Close Wait Open";
+		id = "Door_CloseWaitOpen";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "flat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Delay";
-      type = 11;
-      enum = "generic_door_delays";
-      default = 34;
-    }
-    arg3
-    {
-      title = "Light Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "flat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Delay";
+			type = 11;
+			enum = "generic_door_delays";
+			default = 34;
+		}
+		arg3
+		{
+			title = "Light Tag";
+			type = 13;
+		}
+	}
 }
 
 floor
 {
-  include("Hexen_linedefs.cfg", "floor");
+	include("Hexen_linedefs.cfg", "floor");
 
-  35 = null; // Floor_RaiseByValueTimes8
-  36 = null; // Floor_LowerByValueTimes8
-  68 = null; // Floor_MoveToValueTimes8
+	35 = null; // Floor_RaiseByValueTimes8
+	36 = null; // Floor_LowerByValueTimes8
+	68 = null; // Floor_MoveToValueTimes8
 
-  28	// Floor Crusher Start
-  {
-    arg3
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+	28 // Floor Crusher Start
+	{
+		arg3
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  37
-  {
-    title = "Floor Move to Value";
-    id = "Floor_MoveToValue";
+	37
+	{
+		title = "Floor Move to Value";
+		id = "Floor_MoveToValue";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Target Height";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Target Height";
+		}
+	}
 
-  138
-  {
-    title = "Floor Waggle";
-    id = "Floor_Waggle";
+	138
+	{
+		title = "Floor Waggle";
+		id = "Floor_Waggle";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Amplitude";
-    }
-    arg2
-    {
-      title = "Frequency";
-    }
-    arg3
-    {
-      title = "Phase Offset (0-63)";
-    }
-    arg4
-    {
-      title = "Duration";
-      type = 11;
-      enum = "delay_seconds";
-      default = 5;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Amplitude";
+		}
+		arg2
+		{
+			title = "Frequency";
+		}
+		arg3
+		{
+			title = "Phase Offset (0-63)";
+		}
+		arg4
+		{
+			title = "Duration";
+			type = 11;
+			enum = "delay_seconds";
+			default = 5;
+		}
+	}
 
-  200
-  {
-    title = "Floor Generic Change";
-    id = "Generic_Floor";
+	200
+	{
+		title = "Floor Generic Change";
+		id = "Generic_Floor";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Movement Amount";
-    }
-    arg3
-    {
-      title = "Target";
-      type = 11;
-      enum
-      {
-        0 = "Move by Movement Amount";
-        1 = "Highest neighboring floor";
-        2 = "Lowest neighboring floor";
-        3 = "Nearest neighboring floor";
-        4 = "Lowest neighboring ceiling";
-        5 = "Sector ceiling";
-        6 = "Move by the height of sector's shortest lower texture";
-      }
-    }
-    arg4
-    {
-      title = "Flags";
-      type = 26;
-      enum
-      {
-        0 = "Don't copy anything";
-        1 = "Copy floor texture, remove sector special";
-        2 = "Copy floor texture";
-        3 = "Copy floor texture and special";
-      }
-      flags
-      {
-        4 = "Use numeric model if set, trigger model if not";
-        8 = "Raise floor if set, lower it if not";
-        16 = "Inflict crushing damage";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Movement Amount";
+		}
+		arg3
+		{
+			title = "Target";
+			type = 11;
+			enum
+			{
+				0 = "Move by Movement Amount";
+				1 = "Highest neighboring floor";
+				2 = "Lowest neighboring floor";
+				3 = "Nearest neighboring floor";
+				4 = "Lowest neighboring ceiling";
+				5 = "Sector ceiling";
+				6 = "Move by the height of sector's shortest lower texture";
+			}
+		}
+		arg4
+		{
+			title = "Flags";
+			type = 26;
+			enum
+			{
+				0 = "Don't copy anything";
+				1 = "Copy floor texture, remove sector special";
+				2 = "Copy floor texture";
+				3 = "Copy floor texture and special";
+			}
+			flags
+			{
+				4 = "Use numeric model if set, trigger model if not";
+				8 = "Raise floor if set, lower it if not";
+				16 = "Inflict crushing damage";
+			}
+		}
+	}
 
-  235
-  {
-    title = "Transfer Floor and Special from Back Side";
-    id = "Floor_TransferTrigger";
+	235
+	{
+		title = "Transfer Floor and Special from Back Side";
+		id = "Floor_TransferTrigger";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 
-  236
-  {
-    title = "Transfer Floor and Special using Numeric Change Model";
-    id = "Floor_TransferNumeric";
+	236
+	{
+		title = "Transfer Floor and Special using Numeric Change Model";
+		id = "Floor_TransferNumeric";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 
-  238
-  {
-    title = "Floor Raise to Lowest Ceiling";
-    id = "Floor_RaiseToLowestCeiling";
+	238
+	{
+		title = "Floor Raise to Lowest Ceiling";
+		id = "Floor_RaiseToLowestCeiling";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  239
-  {
-    title = "Floor Raise by TxTy";
-    id = "Floor_RaiseByValueTxTy";
+	239
+	{
+		title = "Floor Raise by TxTy";
+		id = "Floor_RaiseByValueTxTy";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raise by";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raise by";
+		}
+	}
 
-  240
-  {
-    title = "Floor Raise by Texture";
-    id = "Floor_RaiseByTexture";
+	240
+	{
+		title = "Floor Raise by Texture";
+		id = "Floor_RaiseByTexture";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  241
-  {
-    title = "Floor Lower to Lowest TxTy";
-    id = "Floor_LowerToLowestTxTy";
+	241
+	{
+		title = "Floor Lower to Lowest TxTy";
+		id = "Floor_LowerToLowestTxTy";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
 
-    errorchecker
-    {
-      floorlowertolowest = true;
-    }
-  }
+		errorchecker
+		{
+			floorlowertolowest = true;
+		}
+	}
 
-  242
-  {
-    title = "Floor Lower to Highest Floor";
-    id = "Floor_LowerToHighest";
+	242
+	{
+		title = "Floor Lower to Highest Floor";
+		id = "Floor_LowerToHighest";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Adjust Target Height";
-    }
-    arg3
-    {
-      title = "Force Adjust";
-      type = 11;
-      enum = "noyes";
-    }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Adjust Target Height";
+		}
+		arg3
+		{
+			title = "Force Adjust";
+			type = 11;
+			enum = "noyes";
+		}
 
-    errorchecker
-    {
-      floorraisetohighest = true;
-    }
-  }
+		errorchecker
+		{
+			floorraisetohighest = true;
+		}
+	}
 
-  250
-  {
-    title = "Floor Donut";
-    id = "Floor_Donut";
+	250
+	{
+		title = "Floor Donut";
+		id = "Floor_Donut";
 
-    arg0
-    {
-      title = "Center Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Pillar Lower Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Stairs Raise Speed";
-      type = 11;
-      enum = "stair_speeds";
-      default = 4;
-    }
-  }
+		arg0
+		{
+			title = "Center Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Pillar Lower Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Stairs Raise Speed";
+			type = 11;
+			enum = "stair_speeds";
+			default = 4;
+		}
+	}
 
-  251
-  {
-    title = "Floor and Ceiling Lower and Raise";
-    id = "FloorAndCeiling_LowerRaise";
+	251
+	{
+		title = "Floor and Ceiling Lower and Raise";
+		id = "FloorAndCeiling_LowerRaise";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Floor Lowering Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Ceiling Raising Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Emulate Boom Bug";
-      type = 11;
-      enum
-      {
-        0 = "No";
-        1998 = "Yes";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Floor Lowering Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Ceiling Raising Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Emulate Boom Bug";
+			type = 11;
+			enum
+			{
+				0 = "No";
+				1998 = "Yes";
+			}
+		}
+	}
 }
 
 stairs
 {
-  include("Hexen_linedefs.cfg", "stairs");
+	include("Hexen_linedefs.cfg", "stairs");
 
-  204
-  {
-    title = "Stairs Generic Build";
-    id = "Generic_Stairs";
+	204
+	{
+		title = "Stairs Generic Build";
+		id = "Generic_Stairs";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "stair_speeds";
-      default = 4;
-    }
-    arg2
-    {
-      title = "Step Height";
-    }
-    arg3
-    {
-      title = "Options";
-      type = 12;
-      enum
-      {
-        1 = "Upwards";
-        2 = "Ignore Floor Texture";
-      }
-    }
-    arg4
-    {
-      title = "Reset Delay";
-      type = 11;
-      enum = "reset_tics";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "stair_speeds";
+			default = 4;
+		}
+		arg2
+		{
+			title = "Step Height";
+		}
+		arg3
+		{
+			title = "Options";
+			type = 12;
+			enum
+			{
+				1 = "Upwards";
+				2 = "Ignore Floor Texture";
+			}
+		}
+		arg4
+		{
+			title = "Reset Delay";
+			type = 11;
+			enum = "reset_tics";
+		}
+	}
 
-  217
-  {
-    title = "Stairs Build up (Doom mode)";
-    id = "Stairs_BuildUpDoom";
+	217
+	{
+		title = "Stairs Build up (Doom mode)";
+		id = "Stairs_BuildUpDoom";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "stair_speeds";
-      default = 4;
-    }
-    arg2
-    {
-      title = "Step Height";
-    }
-    arg3
-    {
-      title = "Build Step Delay";
-      type = 11;
-      enum = "delay_tics";
-      default = 35;
-    }
-    arg4
-    {
-      title = "Reset Delay";
-      type = 11;
-      enum = "reset_tics";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "stair_speeds";
+			default = 4;
+		}
+		arg2
+		{
+			title = "Step Height";
+		}
+		arg3
+		{
+			title = "Build Step Delay";
+			type = 11;
+			enum = "delay_tics";
+			default = 35;
+		}
+		arg4
+		{
+			title = "Reset Delay";
+			type = 11;
+			enum = "reset_tics";
+		}
+	}
 }
 
 pillar
 {
-  include("Hexen_linedefs.cfg", "pillar");
+	include("Hexen_linedefs.cfg", "pillar");
 
-  94	// Pillar_BuildAndCrush
-  {
-    arg3
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+	94 // Pillar_BuildAndCrush
+	{
+		arg3
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 }
 
 forcefield
 {
-  title = "Forcefield";
+	title = "Forcefield";
 
-  33
-  {
-    title = "Forcefield Set";
-    id = "ForceField";
-    requiresactivation = false;
-  }
+	33
+	{
+		title = "Forcefield Set";
+		id = "ForceField";
+		requiresactivation = false;
+	}
 
-  34
-  {
-    title = "Forcefield Remove";
-    id = "ClearForceField";
+	34
+	{
+		title = "Forcefield Remove";
+		id = "ClearForceField";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 }
 
 ceiling
 {
-  include("Hexen_linedefs.cfg", "ceiling");
+	include("Hexen_linedefs.cfg", "ceiling");
 
-  69 = null; // Ceiling_MoveToValueTimes8
+	69 = null; // Ceiling_MoveToValueTimes8
 
-  38
-  {
-    title = "Ceiling Waggle";
-    id = "Ceiling_Waggle";
+	38
+	{
+		title = "Ceiling Waggle";
+		id = "Ceiling_Waggle";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Amplitude (in 1/8 mu.)";
-      default = 128;
-    }
-    arg2
-    {
-      title = "Frequency";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Phase Offset (0-63)";
-    }
-    arg4
-    {
-      title = "Duration";
-      type = 11;
-      enum = "delay_seconds";
-      default = 5;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Amplitude (in 1/8 mu.)";
+			default = 128;
+		}
+		arg2
+		{
+			title = "Frequency";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Phase Offset (0-63)";
+		}
+		arg4
+		{
+			title = "Duration";
+			type = 11;
+			enum = "delay_seconds";
+			default = 5;
+		}
+	}
 
-  42	// Ceiling Crusher Start
-  {
-    arg3
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+	42 // Ceiling Crusher Start
+	{
+		arg3
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  43	// Ceiling Crush Once
-  {
-    arg3
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+	43 // Ceiling Crush Once
+	{
+		arg3
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  97
-  {
-    title = "Ceiling Lower And Crush Dist";
-    id = "Ceiling_LowerAndCrushDist";
+	97
+	{
+		title = "Ceiling Lower And Crush Dist";
+		id = "Ceiling_LowerAndCrushDist";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
 
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
 
-    }
+		}
 
-    arg2
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
+		arg2
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
 
-    arg3
-    {
-      title = "Lip";
-    }
+		arg3
+		{
+			title = "Lip";
+		}
 
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  104
-  {
-    title = "Ceiling Crush And Raise Dist";
-    id = "Ceiling_CrushAndRaiseSilentDist";
+	104
+	{
+		title = "Ceiling Crush And Raise Dist";
+		id = "Ceiling_CrushAndRaiseSilentDist";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
 
-    arg1
-    {
-      title = "Lip";
-    }
+		arg1
+		{
+			title = "Lip";
+		}
 
-    arg2
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
+		arg2
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
 
-    arg3
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
+		arg3
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
 
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  45	// Ceiling Crush Once and Open
-  {
-    arg3
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+	45 // Ceiling Crush Once and Open
+	{
+		arg3
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  47
-  {
-    title = "Ceiling Move to Value";
-    id = "Ceiling_MoveToValue";
+	47
+	{
+		title = "Ceiling Move to Value";
+		id = "Ceiling_MoveToValue";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Target Height";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Target Height";
+		}
+	}
 
-  169
-  {
-    title = "Ceiling Generic Crush (Hexen mode)";
-    id = "Generic_Crusher2";
+	169
+	{
+		title = "Ceiling Generic Crush (Hexen mode)";
+		id = "Generic_Crusher2";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Lower Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raise Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Silent";
-      type = 11;
-      enum = "noyes";
-    }
-    arg4
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Lower Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raise Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Silent";
+			type = 11;
+			enum = "noyes";
+		}
+		arg4
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+	}
 
-  192
-  {
-    title = "Ceiling Lower to Highest Floor";
-    id = "Ceiling_LowerToHighestFloor";
+	192
+	{
+		title = "Ceiling Lower to Highest Floor";
+		id = "Ceiling_LowerToHighestFloor";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  193
-  {
-    title = "Ceiling Lower Instantly by Value * 8";
-    id = "Ceiling_LowerInstant";
+	193
+	{
+		title = "Ceiling Lower Instantly by Value * 8";
+		id = "Ceiling_LowerInstant";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg2
-    {
-      title = "Lower by (* 8)";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg2
+		{
+			title = "Lower by (* 8)";
+		}
+	}
 
-  194
-  {
-    title = "Ceiling Raise Instantly by Value * 8";
-    id = "Ceiling_RaiseInstant";
+	194
+	{
+		title = "Ceiling Raise Instantly by Value * 8";
+		id = "Ceiling_RaiseInstant";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg2
-    {
-      title = "Raise by (* 8)";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg2
+		{
+			title = "Raise by (* 8)";
+		}
+	}
 
-  195
-  {
-    title = "Ceiling Crush Once and Open A";
-    id = "Ceiling_CrushRaiseAndStayA";
+	195
+	{
+		title = "Ceiling Crush Once and Open A";
+		id = "Ceiling_CrushRaiseAndStayA";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Lower Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raise Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Lower Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raise Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
 
-  }
+	}
 
-  196
-  {
-    title = "Ceiling Crush Start A";
-    id = "Ceiling_CrushAndRaiseA";
+	196
+	{
+		title = "Ceiling Crush Start A";
+		id = "Ceiling_CrushAndRaiseA";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Lower Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raise Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Lower Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raise Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  197
-  {
-    title = "Ceiling Crush Start A (silent)";
-    id = "Ceiling_CrushAndRaiseSilentA";
+	197
+	{
+		title = "Ceiling Crush Start A (silent)";
+		id = "Ceiling_CrushAndRaiseSilentA";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Lower Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raise Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Lower Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raise Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 
-  201
-  {
-    title = "Ceiling Generic Change";
-    id = "Generic_Ceiling";
+	201
+	{
+		title = "Ceiling Generic Change";
+		id = "Generic_Ceiling";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Movement Amount";
-    }
-    arg3
-    {
-      title = "Target";
-      type = 11;
-      enum
-      {
-        0 = "Move by Movement Amount";
-        1 = "Highest neighboring ceiling";
-        2 = "Lowest neighboring ceiling";
-        3 = "Nearest neighboring ceiling";
-        4 = "Highest neighboring floor";
-        5 = "Sector floor";
-        6 = "Move by the height of sector's shortest upper texture";
-      }
-    }
-    arg4
-    {
-      title = "Flags";
-      type = 26;
-      enum
-      {
-        0 = "Don't copy anything";
-        1 = "Copy ceiling texture, remove sector special";
-        2 = "Copy ceiling texture";
-        3 = "Copy ceiling texture and special";
-      }
-      flags
-      {
-        4 = "Use numeric model if set, trigger model if not";
-        8 = "Raise ceiling if set, lower it if not";
-        16 = "Inflict crushing damage";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Movement Amount";
+		}
+		arg3
+		{
+			title = "Target";
+			type = 11;
+			enum
+			{
+				0 = "Move by Movement Amount";
+				1 = "Highest neighboring ceiling";
+				2 = "Lowest neighboring ceiling";
+				3 = "Nearest neighboring ceiling";
+				4 = "Highest neighboring floor";
+				5 = "Sector floor";
+				6 = "Move by the height of sector's shortest upper texture";
+			}
+		}
+		arg4
+		{
+			title = "Flags";
+			type = 26;
+			enum
+			{
+				0 = "Don't copy anything";
+				1 = "Copy ceiling texture, remove sector special";
+				2 = "Copy ceiling texture";
+				3 = "Copy ceiling texture and special";
+			}
+			flags
+			{
+				4 = "Use numeric model if set, trigger model if not";
+				8 = "Raise ceiling if set, lower it if not";
+				16 = "Inflict crushing damage";
+			}
+		}
+	}
 
-  205
-  {
-    title = "Ceiling Generic Crush (Doom mode)";
-    id = "Generic_Crusher";
+	205
+	{
+		title = "Ceiling Generic Crush (Doom mode)";
+		id = "Generic_Crusher";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Lowering Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raising Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Silent";
-      type = 11;
-      enum = "noyes";
-    }
-    arg4
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Lowering Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raising Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Silent";
+			type = 11;
+			enum = "noyes";
+		}
+		arg4
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+	}
 
-  252
-  {
-    title = "Ceiling Raise to Nearest Ceiling";
-    id = "Ceiling_RaiseToNearest";
+	252
+	{
+		title = "Ceiling Raise to Nearest Ceiling";
+		id = "Ceiling_RaiseToNearest";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  253
-  {
-    title = "Ceiling Lower to Lowest Ceiling";
-    id = "Ceiling_LowerToLowest";
+	253
+	{
+		title = "Ceiling Lower to Lowest Ceiling";
+		id = "Ceiling_LowerToLowest";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  254
-  {
-    title = "Ceiling Lower to Floor";
-    id = "Ceiling_LowerToFloor";
+	254
+	{
+		title = "Ceiling Lower to Floor";
+		id = "Ceiling_LowerToFloor";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  255
-  {
-    title = "Ceiling Crush Once and Open A (silent)";
-    id = "Ceiling_CrushRaiseAndStaySilA";
+	255
+	{
+		title = "Ceiling Crush Once and Open A (silent)";
+		id = "Ceiling_CrushRaiseAndStaySilA";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Lowering Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raising Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg3
-    {
-      title = "Crush Damage";
-      default = 100;
-    }
-    arg4
-    {
-      title = "Crush Mode";
-      type = 11;
-      enum = "crush_mode";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Lowering Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raising Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg3
+		{
+			title = "Crush Damage";
+			default = 100;
+		}
+		arg4
+		{
+			title = "Crush Mode";
+			type = 11;
+			enum = "crush_mode";
+		}
+	}
 }
 
 transfer
 {
-  title = "Transfer";
+	title = "Transfer";
 
-  209
-  {
-    title = "Transfer Heights";
-    id = "Transfer_Heights";
-    requiresactivation = false;
+	209
+	{
+		title = "Transfer Heights";
+		id = "Transfer_Heights";
+		requiresactivation = false;
 
-    errorchecker
-    {
-      ignoreuppertexture = true;
-      ignoremiddletexture = true;
-      ignorelowertexture = true;
-    }
+		errorchecker
+		{
+			ignoreuppertexture = true;
+			ignoremiddletexture = true;
+			ignorelowertexture = true;
+		}
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 }
 
 platform
 {
-  include("Hexen_linedefs.cfg", "platform");
+	include("Hexen_linedefs.cfg", "platform");
 
-  172
-  {
-    title = "Platform Raise to Nearest Wait Lower";
-    id = "Plat_UpNearestWaitDownStay";
+	172
+	{
+		title = "Platform Raise to Nearest Wait Lower";
+		id = "Plat_UpNearestWaitDownStay";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Reverse Delay (tics)";
-      type = 11;
-      enum = "delay_tics";
-      default = 35;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Reverse Delay (tics)";
+			type = 11;
+			enum = "delay_tics";
+			default = 35;
+		}
+	}
 
-  203
-  {
-    title = "Platform Generic Change";
-    id = "Generic_Lift";
+	203
+	{
+		title = "Platform Generic Change";
+		id = "Generic_Lift";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Reverse Delay (octics)";
-      type = 11;
-      enum = "delay_octics";
-      default = 24;
-    }
-    arg3
-    {
-      title = "Type";
-      type = 11;
-      enum = "generic_lift_types";
-    }
-    arg4
-    {
-      title = "Movement Amount";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Reverse Delay (octics)";
+			type = 11;
+			enum = "delay_octics";
+			default = 24;
+		}
+		arg3
+		{
+			title = "Type";
+			type = 11;
+			enum = "generic_lift_types";
+		}
+		arg4
+		{
+			title = "Movement Amount";
+		}
+	}
 
-  206
-  {
-    title = "Platform Lower Wait Raise (lip)";
-    id = "Plat_DownWaitUpStayLip";
+	206
+	{
+		title = "Platform Lower Wait Raise (lip)";
+		id = "Plat_DownWaitUpStayLip";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Reverse Delay (tics)";
-      type = 11;
-      enum = "delay_tics";
-      default = 35;
-    }
-    arg3
-    {
-      title = "Lip Amount";
-    }
-    arg4
-    {
-      title = "Sound Type";
-      type = 11;
-      enum = "plat_sound";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Reverse Delay (tics)";
+			type = 11;
+			enum = "delay_tics";
+			default = 35;
+		}
+		arg3
+		{
+			title = "Lip Amount";
+		}
+		arg4
+		{
+			title = "Sound Type";
+			type = 11;
+			enum = "plat_sound";
+		}
+	}
 
-  207
-  {
-    title = "Platform Perpetual Move (lip)";
-    id = "Plat_PerpetualRaiseLip";
+	207
+	{
+		title = "Platform Perpetual Move (lip)";
+		id = "Plat_PerpetualRaiseLip";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Reverse Delay (tics)";
-      type = 11;
-      enum = "delay_tics";
-      default = 35;
-    }
-    arg3
-    {
-      title = "Lip Amount";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Reverse Delay (tics)";
+			type = 11;
+			enum = "delay_tics";
+			default = 35;
+		}
+		arg3
+		{
+			title = "Lip Amount";
+		}
+	}
 
-  228
-  {
-    title = "Platform Raise Tx0";
-    id = "Plat_RaiseAndStayTx0";
+	228
+	{
+		title = "Platform Raise Tx0";
+		id = "Plat_RaiseAndStayTx0";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Lockout Mode";
-      type = 11;
-      enum
-      {
-        0 = "Lockout in Heretic only";
-        1 = "Don't lockout";
-        2 = "Lockout in all games";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Lockout Mode";
+			type = 11;
+			enum
+			{
+				0 = "Lockout in Heretic only";
+				1 = "Don't lockout";
+				2 = "Lockout in all games";
+			}
+		}
+	}
 
-  230
-  {
-    title = "Platform Raise by Value Tx (* 8)";
-    id = "Plat_UpByValueStayTx";
+	230
+	{
+		title = "Platform Raise by Value Tx (* 8)";
+		id = "Plat_UpByValueStayTx";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-    arg2
-    {
-      title = "Raise by (* 8)";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+		arg2
+		{
+			title = "Raise by (* 8)";
+		}
+	}
 
-  231
-  {
-    title = "Platform Toggle Ceiling";
-    id = "Plat_ToggleCeiling";
+	231
+	{
+		title = "Platform Toggle Ceiling";
+		id = "Plat_ToggleCeiling";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 }
 
 teleport
 {
-  include("Hexen_linedefs.cfg", "teleport");
+	include("Hexen_linedefs.cfg", "teleport");
 
-  39
-  {
-    title = "Teleport to Pain State (silent)";
-    id = "Teleport_ZombieChanger";
+	39
+	{
+		title = "Teleport to Pain State (silent)";
+		id = "Teleport_ZombieChanger";
 
-    arg0
-    {
-      title = "Target Teleport Dest. Tag";
-      type = 14;
-      targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
-    }
-    arg1
-    {
-      title = "Target Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Target Teleport Dest. Tag";
+			type = 14;
+			targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
+		}
+		arg1
+		{
+			title = "Target Sector Tag";
+			type = 13;
+		}
+	}
 
-  70	// Teleport
-  {
-    arg2
-    {
-      title = "Source Fog";
-      type = 11;
-      enum = "yesno";
-    }
-  }
+	70 // Teleport
+	{
+		arg2
+		{
+			title = "Source Fog";
+			type = 11;
+			enum = "yesno";
+		}
+	}
 
-  71	// Teleport_NoFog
-  {
-    arg1
-    {
-      title = "Teleport Dest. angle usage";
-      type = 11;
-      enum
-      {
-        0 = "Don't change angle and velocity (Hexen-compat)";
-        1 = "Always use the teleport exit's angle (Strife-compat)";
-        2 = "Adjust relatively to the teleport exit's angle, but in the wrong direction (Boom-compat)";
-        3 = "Adjust relatively to the teleport exit's angle (Boom-fixed)";
-      }
-    }
-    arg3
-    {
-      title = "Keep rel. Height";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+	71 // Teleport_NoFog
+	{
+		arg1
+		{
+			title = "Teleport Dest. angle usage";
+			type = 11;
+			enum
+			{
+				0 = "Don't change angle and velocity (Hexen-compat)";
+				1 = "Always use the teleport exit's angle (Strife-compat)";
+				2 = "Adjust relatively to the teleport exit's angle, but in the wrong direction (Boom-compat)";
+				3 = "Adjust relatively to the teleport exit's angle (Boom-fixed)";
+			}
+		}
+		arg3
+		{
+			title = "Keep rel. Height";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 
-  74	// Teleport_NewMap
-  {
-    arg2
-    {
-      title = "Keep Orientation";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+	74 // Teleport_NewMap
+	{
+		arg2
+		{
+			title = "Keep Orientation";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 
-  76
-  {
-    title = "Teleport Other";
-    id = "TeleportOther";
+	76
+	{
+		title = "Teleport Other";
+		id = "TeleportOther";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Target MapSpot Tag";
-      type = 14;
-      targetclasses = "MapSpot,MapSpotGravity";
-    }
-    arg2
-    {
-      title = "Fog";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Target MapSpot Tag";
+			type = 14;
+			targetclasses = "MapSpot,MapSpotGravity";
+		}
+		arg2
+		{
+			title = "Fog";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 
-  77
-  {
-    title = "Teleport Group";
-    id = "TeleportGroup";
+	77
+	{
+		title = "Teleport Group";
+		id = "TeleportGroup";
 
-    arg0
-    {
-      title = "Thing Tag";
-      tooltip = "The TID of the actor(s) to teleport.\nIf 0, teleports the activator only.";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Source Teleport Dest. Tag";
-      type = 14;
-      targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
-    }
-    arg2
-    {
-      title = "Target Teleport Dest. Tag";
-      type = 14;
-      targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
-    }
-    arg3
-    {
-      title = "Move Source";
-      type = 11;
-      enum = "noyes";
-    }
-    arg4
-    {
-      title = "Fog";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			tooltip = "The TID of the actor(s) to teleport.\nIf 0, teleports the activator only.";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Source Teleport Dest. Tag";
+			type = 14;
+			targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
+		}
+		arg2
+		{
+			title = "Target Teleport Dest. Tag";
+			type = 14;
+			targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
+		}
+		arg3
+		{
+			title = "Move Source";
+			type = 11;
+			enum = "noyes";
+		}
+		arg4
+		{
+			title = "Fog";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 
-  78
-  {
-    title = "Teleport in Sector";
-    id = "TeleportInSector";
+	78
+	{
+		title = "Teleport in Sector";
+		id = "TeleportInSector";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Source Tag";
-      tooltip = "The spot relative to which to teleport.";
-      type = 14;
-    }
-    arg2
-    {
-      title = "Target Teleport Dest. Tag";
-      type = 14;
-      targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
-    }
-    arg3
-    {
-      title = "Fog";
-      type = 11;
-      enum = "noyes";
-    }
-    arg4
-    {
-      title = "Group Thing Tag";
-      tooltip = "The TID of the thing(s) to teleport.\nIf 0, teleports all actors in the sector";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Source Tag";
+			tooltip = "The spot relative to which to teleport.";
+			type = 14;
+		}
+		arg2
+		{
+			title = "Target Teleport Dest. Tag";
+			type = 14;
+			targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
+		}
+		arg3
+		{
+			title = "Fog";
+			type = 11;
+			enum = "noyes";
+		}
+		arg4
+		{
+			title = "Group Thing Tag";
+			tooltip = "The TID of the thing(s) to teleport.\nIf 0, teleports all actors in the sector";
+			type = 14;
+		}
+	}
 
-  154
-  {
-    title = "Teleport (no Stop)";
-    id = "Teleport_NoStop";
+	154
+	{
+		title = "Teleport (no Stop)";
+		id = "Teleport_NoStop";
 
-    arg0
-    {
-      title = "Target Teleport Dest. Tag";
-      type = 14;
-      targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
-    }
-    arg1
-    {
-      title = "Target Sector Tag";
-      type = 13;
-    }
-    arg2
-    {
-      title = "Fog";
-      type = 11;
-      enum = "yesno";
-    }
-  }
+		arg0
+		{
+			title = "Target Teleport Dest. Tag";
+			type = 14;
+			targetclasses = "TeleportDest,TeleportDest2,TeleportDest3";
+		}
+		arg1
+		{
+			title = "Target Sector Tag";
+			type = 13;
+		}
+		arg2
+		{
+			title = "Fog";
+			type = 11;
+			enum = "yesno";
+		}
+	}
 
-  215
-  {
-    title = "Teleport to Line";
-    id = "Teleport_Line";
+	215
+	{
+		title = "Teleport to Line";
+		id = "Teleport_Line";
 
-    arg1
-    {
-      title = "Target Line Tag";
-      type = 15;
-    }
-    arg2
-    {
-      title = "Reverse Angle";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+		arg1
+		{
+			title = "Target Line Tag";
+			type = 15;
+		}
+		arg2
+		{
+			title = "Reverse Angle";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 }
 
 thing
 {
-  include("Hexen_linedefs.cfg", "thing");
+	include("Hexen_linedefs.cfg", "thing");
 
-  17
-  {
-    title = "Thing Raise";
-    id = "Thing_Raise";
+	17
+	{
+		title = "Thing Raise";
+		id = "Thing_Raise";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+	}
 
-  19
-  {
-    title = "Thing Stop";
-    id = "Thing_Stop";
+	19
+	{
+		title = "Thing Stop";
+		id = "Thing_Stop";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+	}
 
-  72 // ThrustThing
-  {
-    arg3
-    {
-      title = "Target Thing Tag";
-      type = 14;
-    }
-  }
+	72 // ThrustThing
+	{
+		arg3
+		{
+			title = "Target Thing Tag";
+			type = 14;
+		}
+	}
 
-  73 // DamageThing
-  {
-    arg1
-    {
-      title = "Death";
-      type = 11;
-      enum = "death_types";
-    }
-  }
+	73 // DamageThing
+	{
+		arg1
+		{
+			title = "Death";
+			type = 11;
+			enum = "death_types";
+		}
+	}
 
-  119
-  {
-    title = "Damage Thing by Tag";
-    id = "Thing_Damage";
+	119
+	{
+		title = "Damage Thing by Tag";
+		id = "Thing_Damage";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Damage";
-      default = 100;
-    }
-    arg2
-    {
-      title = "Death";
-      type = 11;
-      enum = "death_types";
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Damage";
+			default = 100;
+		}
+		arg2
+		{
+			title = "Death";
+			type = 11;
+			enum = "death_types";
+		}
+	}
 
-  125
-  {
-    title = "Move Thing";
-    id = "Thing_Move";
+	125
+	{
+		title = "Move Thing";
+		id = "Thing_Move";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Target Thing Tag";
-      type = 14;
-    }
-    arg2
-    {
-      title = "Fog";
-      type = 11;
-      enum = "yesno";
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Target Thing Tag";
+			type = 14;
+		}
+		arg2
+		{
+			title = "Fog";
+			type = 11;
+			enum = "yesno";
+		}
+	}
 
-  127
-  {
-    title = "Thing Set Special";
-    id = "Thing_SetSpecial";
+	127
+	{
+		title = "Thing Set Special";
+		id = "Thing_SetSpecial";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Special";
-      type = 4;
-    }
-    arg2
-    {
-      title = "Arg 1";
-    }
-    arg3
-    {
-      title = "Arg 2";
-    }
-    arg4
-    {
-      title = "Arg 3";
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Special";
+			type = 4;
+		}
+		arg2
+		{
+			title = "Arg 1";
+		}
+		arg3
+		{
+			title = "Arg 2";
+		}
+		arg4
+		{
+			title = "Arg 3";
+		}
+	}
 
-  128
-  {
-    title = "Thing Thrust Z";
-    id = "ThrustThingZ";
+	128
+	{
+		title = "Thing Thrust Z";
+		id = "ThrustThingZ";
 
-    arg0
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Force";
-    }
-    arg2
-    {
-      title = "Down/Up";
-      type = 11;
-      enum = "updown";
-    }
-    arg3
-    {
-      title = "Set/Add";
-      type = 11;
-      enum = "setadd";
-    }
-  }
+		arg0
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Force";
+		}
+		arg2
+		{
+			title = "Down/Up";
+			type = 11;
+			enum = "updown";
+		}
+		arg3
+		{
+			title = "Set/Add";
+			type = 11;
+			enum = "setadd";
+		}
+	}
 
-  135	// Thing_Spawn
-  {
-    arg3
-    {
-      title = "New Thing Tag";
-      type = 14;
-    }
-  }
+	135 // Thing_Spawn
+	{
+		arg3
+		{
+			title = "New Thing Tag";
+			type = 14;
+		}
+	}
 
-  137	// Thing_SpawnNoFog
-  {
-    arg3
-    {
-      title = "New Thing Tag";
-      type = 14;
-    }
-  }
+	137 // Thing_SpawnNoFog
+	{
+		arg3
+		{
+			title = "New Thing Tag";
+			type = 14;
+		}
+	}
 
-  139
-  {
-    title = "Spawn Thing Facing";
-    id = "Thing_SpawnFacing";
+	139
+	{
+		title = "Spawn Thing Facing";
+		id = "Thing_SpawnFacing";
 
-    arg0
-    {
-      title = "Mapspot Tag";
-      type = 14;
-      targetclasses = "MapSpot,MapSpotGravity";
-    }
-    arg1
-    {
-      title = "Spawn Thing";
-      type = 11;
-      enum = "spawnthing";
-    }
-    arg2
-    {
-      title = "Fog";
-      type = 11;
-      enum = "yesno";
-    }
-    arg3
-    {
-      title = "New Thing Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Mapspot Tag";
+			type = 14;
+			targetclasses = "MapSpot,MapSpotGravity";
+		}
+		arg1
+		{
+			title = "Spawn Thing";
+			type = 11;
+			enum = "spawnthing";
+		}
+		arg2
+		{
+			title = "Fog";
+			type = 11;
+			enum = "yesno";
+		}
+		arg3
+		{
+			title = "New Thing Tag";
+			type = 14;
+		}
+	}
 
-  175
-  {
-    title = "Spawn Projectile (Intercept)";
-    id = "Thing_ProjectileIntercept";
+	175
+	{
+		title = "Spawn Projectile (Intercept)";
+		id = "Thing_ProjectileIntercept";
 
-    arg0
-    {
-      title = "Mapspot Tag";
-      type = 14;
-      targetclasses = "MapSpot,MapSpotGravity";
-    }
-    arg1
-    {
-      title = "Projectile Type";
-      type = 11;
-      enum = "spawn_projectile";
-    }
-    arg2
-    {
-      title = "Speed";
-    }
-    arg3
-    {
-      title = "Target Thing Tag";
-      type = 14;
-    }
-    arg4
-    {
-      title = "New Thing Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Mapspot Tag";
+			type = 14;
+			targetclasses = "MapSpot,MapSpotGravity";
+		}
+		arg1
+		{
+			title = "Projectile Type";
+			type = 11;
+			enum = "spawn_projectile";
+		}
+		arg2
+		{
+			title = "Speed";
+		}
+		arg3
+		{
+			title = "Target Thing Tag";
+			type = 14;
+		}
+		arg4
+		{
+			title = "New Thing Tag";
+			type = 14;
+		}
+	}
 
-  176
-  {
-    title = "Change Thing Tag";
-    id = "Thing_ChangeTID";
+	176
+	{
+		title = "Change Thing Tag";
+		id = "Thing_ChangeTID";
 
-    arg0
-    {
-      title = "Old Thing Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "New Thing Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Old Thing Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "New Thing Tag";
+			type = 14;
+		}
+	}
 
-  177
-  {
-    title = "Thing Hate";
-    id = "Thing_Hate";
+	177
+	{
+		title = "Thing Hate";
+		id = "Thing_Hate";
 
-    arg0
-    {
-      title = "Hater Tag";
-      type = 14;
-    }
-    arg1
-    {
-      title = "Hatee Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Hater Tag";
+			type = 14;
+		}
+		arg1
+		{
+			title = "Hatee Tag";
+			type = 14;
+		}
+	}
 
-  178
-  {
-    title = "Spawn Aimed Projectile";
-    id = "Thing_ProjectileAimed";
+	178
+	{
+		title = "Spawn Aimed Projectile";
+		id = "Thing_ProjectileAimed";
 
-    arg0
-    {
-      title = "Mapspot Tag";
-      type = 14;
-      targetclasses = "MapSpot,MapSpotGravity";
-    }
-    arg1
-    {
-      title = "Projectile Type";
-      type = 11;
-      enum = "spawn_projectile";
-    }
-    arg2
-    {
-      title = "Speed";
-    }
-    arg3
-    {
-      title = "Target Thing Tag";
-      type = 14;
-    }
-    arg4
-    {
-      title = "New Thing Tag";
-      type = 14;
-    }
-  }
+		arg0
+		{
+			title = "Mapspot Tag";
+			type = 14;
+			targetclasses = "MapSpot,MapSpotGravity";
+		}
+		arg1
+		{
+			title = "Projectile Type";
+			type = 11;
+			enum = "spawn_projectile";
+		}
+		arg2
+		{
+			title = "Speed";
+		}
+		arg3
+		{
+			title = "Target Thing Tag";
+			type = 14;
+		}
+		arg4
+		{
+			title = "New Thing Tag";
+			type = 14;
+		}
+	}
 
-  248
-  {
-    title = "Heal Thing";
-    id = "HealThing";
+	248
+	{
+		title = "Heal Thing";
+		id = "HealThing";
 
-    arg0
-    {
-      title = "Heal Amount";
-    }
-  }
+		arg0
+		{
+			title = "Heal Amount";
+		}
+	}
 }
 
 end
 {
-  include("Hexen_linedefs.cfg", "end");
+	include("Hexen_linedefs.cfg", "end");
 
-  243
-  {
-    title = "End Normal";
-    id = "Exit_Normal";
+	243
+	{
+		title = "End Normal";
+		id = "Exit_Normal";
 
-    arg0
-    {
-      title = "Position";
-    }
-  }
+		arg0
+		{
+			title = "Position";
+		}
+	}
 
-  244
-  {
-    title = "End Secret";
-    id = "Exit_Secret";
+	244
+	{
+		title = "End Secret";
+		id = "Exit_Secret";
 
-    arg0
-    {
-      title = "Position";
-    }
-  }
+		arg0
+		{
+			title = "Position";
+		}
+	}
 }
 
 scroll
 {
-  title = "Scroll";
+	title = "Scroll";
 
-  52
-  {
-    title = "Scroll Wall";
-    id = "Scroll_Wall";
-    requiresactivation = false;
+	52
+	{
+		title = "Scroll Wall";
+		id = "Scroll_Wall";
+		requiresactivation = false;
 
-    arg0
-    {
-      title = "Line Tag";
-      type = 15;
-    }
-    arg1
-    {
-      title = "Horizontal speed";
-    }
-    arg2
-    {
-      title = "Vertical speed";
-    }
-    arg3
-    {
-      title = "Side";
-      type = 11;
-      enum = "frontback";
-    }
-    arg4
-    {
-      title = "Flags";
-      type = 12;
-      enum
-      {
-        1 = "Scroll upper";
-        2 = "Scroll middle";
-        4 = "Scroll lower";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Line Tag";
+			type = 15;
+		}
+		arg1
+		{
+			title = "Horizontal speed";
+		}
+		arg2
+		{
+			title = "Vertical speed";
+		}
+		arg3
+		{
+			title = "Side";
+			type = 11;
+			enum = "frontback";
+		}
+		arg4
+		{
+			title = "Flags";
+			type = 12;
+			enum
+			{
+				1 = "Scroll upper";
+				2 = "Scroll middle";
+				4 = "Scroll lower";
+			}
+		}
+	}
 
-  222
-  {
-    title = "Scroll Texture Model";
-    id = "Scroll_Texture_Model";
-    requiresactivation = false;
+	222
+	{
+		title = "Scroll Texture Model";
+		id = "Scroll_Texture_Model";
+		requiresactivation = false;
 
-    arg1
-    {
-      title = "Options";
-      type = 12;
-      enum
-      {
-        1 = "Displacement";
-        2 = "Accelerative";
-      }
-    }
-  }
+		arg1
+		{
+			title = "Options";
+			type = 12;
+			enum
+			{
+				1 = "Displacement";
+				2 = "Accelerative";
+			}
+		}
+	}
 
-  223
-  {
-    title = "Scroll Floor";
-    id = "Scroll_Floor";
-    requiresactivation = false;
+	223
+	{
+		title = "Scroll Floor";
+		id = "Scroll_Floor";
+		requiresactivation = false;
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Options";
-      type = 12;
-      enum
-      {
-        1 = "Displacement";
-        2 = "Accelerative";
-        4 = "Scroll by linedef dx/dy";
-      }
-    }
-    arg2
-    {
-      title = "Scroll";
-      type = 11;
-      enum
-      {
-        0 = "Texture only";
-        1 = "Things only";
-        2 = "Both";
-      }
-    }
-    arg3
-    {
-      title = "Horizontal Speed";
-      default = 128;
-      type = 11;
-      enum = "sector_scroll_speeds_x";
-    }
-    arg4
-    {
-      title = "Vertical Speed";
-      default = 128;
-      type = 11;
-      enum = "sector_scroll_speeds_y";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Options";
+			type = 12;
+			enum
+			{
+				1 = "Displacement";
+				2 = "Accelerative";
+				4 = "Scroll by linedef dx/dy";
+			}
+		}
+		arg2
+		{
+			title = "Scroll";
+			type = 11;
+			enum
+			{
+				0 = "Texture only";
+				1 = "Things only";
+				2 = "Both";
+			}
+		}
+		arg3
+		{
+			title = "Horizontal Speed";
+			default = 128;
+			type = 11;
+			enum = "sector_scroll_speeds_x";
+		}
+		arg4
+		{
+			title = "Vertical Speed";
+			default = 128;
+			type = 11;
+			enum = "sector_scroll_speeds_y";
+		}
+	}
 
-  224
-  {
-    title = "Scroll Ceiling";
-    id = "Scroll_Ceiling";
-    requiresactivation = false;
+	224
+	{
+		title = "Scroll Ceiling";
+		id = "Scroll_Ceiling";
+		requiresactivation = false;
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Options";
-      type = 12;
-      enum
-      {
-        1 = "Displacement";
-        2 = "Accelerative";
-        4 = "Scroll by linedef dx/dy";
-      }
-    }
-    arg3
-    {
-      title = "Horizontal Speed";
-      default = 128;
-      type = 11;
-      enum = "sector_scroll_speeds_x";
-    }
-    arg4
-    {
-      title = "Vertical Speed";
-      default = 128;
-      type = 11;
-      enum = "sector_scroll_speeds_y";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Options";
+			type = 12;
+			enum
+			{
+				1 = "Displacement";
+				2 = "Accelerative";
+				4 = "Scroll by linedef dx/dy";
+			}
+		}
+		arg3
+		{
+			title = "Horizontal Speed";
+			default = 128;
+			type = 11;
+			enum = "sector_scroll_speeds_x";
+		}
+		arg4
+		{
+			title = "Vertical Speed";
+			default = 128;
+			type = 11;
+			enum = "sector_scroll_speeds_y";
+		}
+	}
 }
 
 light
 {
-  include("Hexen_linedefs.cfg", "light");
+	include("Hexen_linedefs.cfg", "light");
 
-  109 = NULL;
+	109 = NULL;
 
-  117
-  {
-    title = "Light Stop";
-    id = "Light_Stop";
+	117
+	{
+		title = "Light Stop";
+		id = "Light_Stop";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 
-  232
-  {
-    title = "Light Strobe (Doom mode)";
-    id = "Light_StrobeDoom";
+	232
+	{
+		title = "Light Strobe (Doom mode)";
+		id = "Light_StrobeDoom";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Brightest Duration (tics)";
-      type = 11;
-      enum = "delay_tics";
-      default = 35;
-    }
-    arg2
-    {
-      title = "Darkest Duration (tics)";
-      type = 11;
-      enum = "delay_tics";
-      default = 35;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Brightest Duration (tics)";
+			type = 11;
+			enum = "delay_tics";
+			default = 35;
+		}
+		arg2
+		{
+			title = "Darkest Duration (tics)";
+			type = 11;
+			enum = "delay_tics";
+			default = 35;
+		}
+	}
 
-  233
-  {
-    title = "Light Change to Darkest Neightbour";
-    id = "Light_MinNeighbor";
+	233
+	{
+		title = "Light Change to Darkest Neightbour";
+		id = "Light_MinNeighbor";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 
-  234
-  {
-    title = "Light Change to Brightest Neightbour";
-    id = "Light_MaxNeighbor";
+	234
+	{
+		title = "Light Change to Brightest Neightbour";
+		id = "Light_MaxNeighbor";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 }
 
 earthquake
 {
-  include("Hexen_linedefs.cfg", "earthquake");
+	include("Hexen_linedefs.cfg", "earthquake");
 }
 
 sector
 {
-  title = "Sector";
+	title = "Sector";
 
-  54
-  {
-    title = "Sector Change Flags";
-    id = "Sector_ChangeFlags";
+	54
+	{
+		title = "Sector Change Flags";
+		id = "Sector_ChangeFlags";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Set Flags";
-      type = 12;
-      enum = "sector_flags";
-    }
-    arg2
-    {
-      title = "Clear Flags";
-      type = 12;
-      enum = "sector_flags";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Set Flags";
+			type = 12;
+			enum = "sector_flags";
+		}
+		arg2
+		{
+			title = "Clear Flags";
+			type = 12;
+			enum = "sector_flags";
+		}
+	}
 
-  58
-  {
-    title = "Sector Copy Scroller";
-    id = "Sector_CopyScroller";
-    requiresactivation = false;
+	58
+	{
+		title = "Sector Copy Scroller";
+		id = "Sector_CopyScroller";
+		requiresactivation = false;
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Scroller Type";
-      type = 12;
-      enum
-      {
-        1 = "Copy ceiling scroller";
-        2 = "Copy floor scroller";
-        4 = "Copy carrying effect";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Scroller Type";
+			type = 12;
+			enum
+			{
+				1 = "Copy ceiling scroller";
+				2 = "Copy floor scroller";
+				4 = "Copy carrying effect";
+			}
+		}
+	}
 
-  185
-  {
-    title = "Sector Rotate Flat";
-    id = "Sector_SetRotation";
+	185
+	{
+		title = "Sector Rotate Flat";
+		id = "Sector_SetRotation";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Floor Angle";
-      type = 8;
-    }
-    arg2
-    {
-      title = "Ceiling Angle";
-      type = 8;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Floor Angle";
+			type = 8;
+		}
+		arg2
+		{
+			title = "Ceiling Angle";
+			type = 8;
+		}
+	}
 
-  186
-  {
-    title = "Sector Ceiling Panning";
-    id = "Sector_SetCeilingPanning";
+	186
+	{
+		title = "Sector Ceiling Panning";
+		id = "Sector_SetCeilingPanning";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Horizontal Integral";
-    }
-    arg2
-    {
-      title = "Horizontal Fractional";
-    }
-    arg3
-    {
-      title = "Vertical Integral";
-    }
-    arg4
-    {
-      title = "Vertical Fractional";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Horizontal Integral";
+		}
+		arg2
+		{
+			title = "Horizontal Fractional";
+		}
+		arg3
+		{
+			title = "Vertical Integral";
+		}
+		arg4
+		{
+			title = "Vertical Fractional";
+		}
+	}
 
-  187
-  {
-    title = "Sector Floor Panning";
-    id = "Sector_SetFloorPanning";
+	187
+	{
+		title = "Sector Floor Panning";
+		id = "Sector_SetFloorPanning";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Horizontal Integral";
-    }
-    arg2
-    {
-      title = "Horizontal Fractional";
-    }
-    arg3
-    {
-      title = "Vertical Integral";
-    }
-    arg4
-    {
-      title = "Vertical Fractional";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Horizontal Integral";
+		}
+		arg2
+		{
+			title = "Horizontal Fractional";
+		}
+		arg3
+		{
+			title = "Vertical Integral";
+		}
+		arg4
+		{
+			title = "Vertical Fractional";
+		}
+	}
 
-  188
-  {
-    title = "Sector Ceiling Scale";
-    id = "Sector_SetCeilingScale";
+	188
+	{
+		title = "Sector Ceiling Scale";
+		id = "Sector_SetCeilingScale";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Horizontal Integral";
-    }
-    arg2
-    {
-      title = "Horizontal Fractional";
-    }
-    arg3
-    {
-      title = "Vertical Integral";
-    }
-    arg4
-    {
-      title = "Vertical Fractional";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Horizontal Integral";
+		}
+		arg2
+		{
+			title = "Horizontal Fractional";
+		}
+		arg3
+		{
+			title = "Vertical Integral";
+		}
+		arg4
+		{
+			title = "Vertical Fractional";
+		}
+	}
 
-  189
-  {
-    title = "Sector Floor Scale";
-    id = "Sector_SetFloorScale";
+	189
+	{
+		title = "Sector Floor Scale";
+		id = "Sector_SetFloorScale";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Horizontal Integral";
-    }
-    arg2
-    {
-      title = "Horizontal Fractional";
-    }
-    arg3
-    {
-      title = "Vertical Integral";
-    }
-    arg4
-    {
-      title = "Vertical Fractional";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Horizontal Integral";
+		}
+		arg2
+		{
+			title = "Horizontal Fractional";
+		}
+		arg3
+		{
+			title = "Vertical Integral";
+		}
+		arg4
+		{
+			title = "Vertical Fractional";
+		}
+	}
 
-  214
-  {
-    title = "Sector Damage";
-    id = "Sector_SetDamage";
+	214
+	{
+		title = "Sector Damage";
+		id = "Sector_SetDamage";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Damage Amount";
-      default = 15;
-    }
-    arg2
-    {
-      title = "Death";
-      type = 11;
-      enum = "death_types";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Damage Amount";
+			default = 15;
+		}
+		arg2
+		{
+			title = "Death";
+			type = 11;
+			enum = "death_types";
+		}
+	}
 
-  216
-  {
-    title = "Sector Gravity";
-    id = "Sector_SetGravity";
+	216
+	{
+		title = "Sector Gravity";
+		id = "Sector_SetGravity";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Gravity Integral";
-    }
-    arg2
-    {
-      title = "Gravity Fractional";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Gravity Integral";
+		}
+		arg2
+		{
+			title = "Gravity Fractional";
+		}
+	}
 
-  218
-  {
-    title = "Sector Wind";
-    id = "Sector_SetWind";
+	218
+	{
+		title = "Sector Wind";
+		id = "Sector_SetWind";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Wind Strength";
-    }
-    arg2
-    {
-      title = "Wind Angle";
-      type = 22;
-    }
-    arg3
-    {
-      title = "Use Line Vector";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Wind Strength";
+		}
+		arg2
+		{
+			title = "Wind Angle";
+			type = 22;
+		}
+		arg3
+		{
+			title = "Use Line Vector";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 
-  219
-  {
-    title = "Sector Friction";
-    id = "Sector_SetFriction";
-    requiresactivation = false;
+	219
+	{
+		title = "Sector Friction";
+		id = "Sector_SetFriction";
+		requiresactivation = false;
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Friction Amount";
-      type = 11;
-      enum
-      {
-        0 = "Use Line Length";
-        1 = "Very Sludgy";
-        50 = "Sludgy";
-        100 = "Normal";
-        200 = "Icy";
-        255 = "Very Icy";
-      }
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Friction Amount";
+			type = 11;
+			enum
+			{
+				0 = "Use Line Length";
+				1 = "Very Sludgy";
+				50 = "Sludgy";
+				100 = "Normal";
+				200 = "Icy";
+				255 = "Very Icy";
+			}
+		}
+	}
 
-  220
-  {
-    title = "Sector Current";
-    id = "Sector_SetCurrent";
+	220
+	{
+		title = "Sector Current";
+		id = "Sector_SetCurrent";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Current Strength";
-    }
-    arg2
-    {
-      title = "Current Angle";
-      type = 22;
-    }
-    arg3
-    {
-      title = "Use Line Vector";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Current Strength";
+		}
+		arg2
+		{
+			title = "Current Angle";
+			type = 22;
+		}
+		arg3
+		{
+			title = "Use Line Vector";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 }
 
 alert
 {
-  title = "Alert";
+	title = "Alert";
 
-  173
-  {
-    title = "Alert monsters";
-    id = "NoiseAlert";
-  }
+	173
+	{
+		title = "Alert monsters";
+		id = "NoiseAlert";
+	}
 }
 
 point
 {
-  title = "Point";
+	title = "Point";
 
-  227
-  {
-    title = "Point Pusher/Puller Set Force";
-    id = "PointPush_SetForce";
+	227
+	{
+		title = "Point Pusher/Puller Set Force";
+		id = "PointPush_SetForce";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Thing Tag";
-      type = 14;
-    }
-    arg2
-    {
-      title = "Strength";
-    }
-    arg3
-    {
-      title = "Use Line Vector";
-      type = 11;
-      enum = "noyes";
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Thing Tag";
+			type = 14;
+		}
+		arg2
+		{
+			title = "Strength";
+		}
+		arg3
+		{
+			title = "Use Line Vector";
+			type = 11;
+			enum = "noyes";
+		}
+	}
 }
 
 elevator
 {
-  title = "Elevator";
+	title = "Elevator";
 
-  245
-  {
-    title = "Elevator Raise to Nearest Floor";
-    id = "Elevator_RaiseToNearest";
+	245
+	{
+		title = "Elevator Raise to Nearest Floor";
+		id = "Elevator_RaiseToNearest";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
 
-    errorchecker
-    {
-      floorraisetonexthigher = true;
-    }
-  }
+		errorchecker
+		{
+			floorraisetonexthigher = true;
+		}
+	}
 
-  246
-  {
-    title = "Elevator Move to Activated Floor";
-    id = "Elevator_MoveToFloor";
+	246
+	{
+		title = "Elevator Move to Activated Floor";
+		id = "Elevator_MoveToFloor";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 
-  247
-  {
-    title = "Elevator Lower to Nearest Floor";
-    id = "Elevator_LowerToNearest";
+	247
+	{
+		title = "Elevator Lower to Nearest Floor";
+		id = "Elevator_LowerToNearest";
 
-    arg0
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-    arg1
-    {
-      title = "Movement Speed";
-      type = 11;
-      enum = "plat_speeds";
-      default = 16;
-    }
-  }
+		arg0
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+		arg1
+		{
+			title = "Movement Speed";
+			type = 11;
+			enum = "plat_speeds";
+			default = 16;
+		}
+	}
 }
 
 colormap
 {
-  title = "Colormap";
+	title = "Colormap";
 
-  2701
-  {
-    title = "Map Set Colormap";
-    id = "Map_SetColormap";
+	2701
+	{
+		title = "Map Set Colormap";
+		id = "Map_SetColormap";
 
-    arg0
-    {
-      title = "(switch to string)";
-      str = true;
-      titlestr = "Colormap";
-    }
-  }
+		arg0
+		{
+			title = "(switch to string)";
+			str = true;
+			titlestr = "Colormap";
+		}
+	}
 
-  2702
-  {
-    title = "Sector Set Colormap";
-    id = "Sector_SetColormap";
+	2702
+	{
+		title = "Sector Set Colormap";
+		id = "Sector_SetColormap";
 
-    arg0
-    {
-      title = "(switch to string)";
-      str = true;
-      titlestr = "Colormap";
-    }
+		arg0
+		{
+			title = "(switch to string)";
+			str = true;
+			titlestr = "Colormap";
+		}
 
-    arg1
-    {
-      title = "Sector Tag";
-      type = 13;
-    }
-  }
+		arg1
+		{
+			title = "Sector Tag";
+			type = 13;
+		}
+	}
 }

--- a/udb/Includes/DSDADoom_misc.cfg
+++ b/udb/Includes/DSDADoom_misc.cfg
@@ -119,8 +119,8 @@ thingflagscompare
 	gamemodes
 	{
 		single { requiredgroups = "skills"; }
-		coop	 { requiredgroups = "skills"; }
-		dm			{ ignoredgroups = "skills"; }
+		coop   { requiredgroups = "skills"; }
+		dm     { ignoredgroups = "skills"; }
 	}
 }
 

--- a/udb/Includes/DSDADoom_misc.cfg
+++ b/udb/Includes/DSDADoom_misc.cfg
@@ -1,6 +1,6 @@
 linedefflags
 {
-  twosided = "Doublesided";
+	twosided = "Doublesided";
 	dontpegtop = "Upper unpegged";
 	dontpegbottom = "Lower unpegged";
 	blocking = "Impassable";
@@ -29,7 +29,7 @@ linedefflags
 
 linedefactivations
 {
-  repeatspecial
+	repeatspecial
 	{
 		name = "Repeatable action";
 		istrigger = false;
@@ -70,17 +70,17 @@ linedefactivations
 // When the UDMF field name is prefixed with ! it is inverted
 linedefflagstranslation
 {
-  include("Doom_misc.cfg", "linedefflagstranslation");
-  include("Hexen_misc.cfg", "linedefflagstranslation");
+	include("Doom_misc.cfg", "linedefflagstranslation");
+	include("Hexen_misc.cfg", "linedefflagstranslation");
 
-  6144 = "playeruse,passuse"; //mxd
+	6144 = "playeruse,passuse"; //mxd
 	7168 = "impact,missilecross"; //mxd
 	16384 = "blockplayers";
 }
 
 sidedefflags
 {
-  clipmidtex = "Clip middle texture";
+	clipmidtex = "Clip middle texture";
 	wrapmidtex = "Wrap middle texture";
 	smoothlighting = "Smooth lighting";
 	nofakecontrast = "Even lighting";
@@ -88,7 +88,7 @@ sidedefflags
 
 thingflags
 {
-  skill1 = "Skill 1";
+	skill1 = "Skill 1";
 	skill2 = "Skill 2";
 	skill3 = "Skill 3";
 	skill4 = "Skill 4";
@@ -101,7 +101,7 @@ thingflags
 	dormant = "Dormant";
 	translucent = "Translucent (25%)";
 	invisible = "Invisible";
-  countsecret = "Count as secret";
+	countsecret = "Count as secret";
 }
 
 // How to compare thing flags (for the stuck things error checker)
@@ -119,8 +119,8 @@ thingflagscompare
 	gamemodes
 	{
 		single { requiredgroups = "skills"; }
-		coop   { requiredgroups = "skills"; }
-		dm      { ignoredgroups = "skills"; }
+		coop	 { requiredgroups = "skills"; }
+		dm			{ ignoredgroups = "skills"; }
 	}
 }
 
@@ -129,10 +129,10 @@ thingflagscompare
 // When the UDMF field name is prefixed with ! it is inverted
 thingflagstranslation
 {
-  include("Doom_misc.cfg", "thingflagstranslation");
-  include("Hexen_misc.cfg", "thingflagstranslation");
+	include("Doom_misc.cfg", "thingflagstranslation");
+	include("Hexen_misc.cfg", "thingflagstranslation");
 
-  256 = "single";
+	256 = "single";
 	512 = "coop";
 	1024 = "dm";
 	2048 = "translucent";
@@ -143,7 +143,7 @@ thingflagstranslation
 // Default flags for first new thing
 defaultthingflags
 {
-  skill1;
+	skill1;
 	skill2;
 	skill3;
 	skill4;
@@ -280,7 +280,7 @@ Field data types:
 */
 universalfields
 {
-  linedef
+	linedef
 	{
 		comment
 		{
@@ -833,7 +833,7 @@ universalfields
 // DEFAULT SECTOR BRIGHTNESS LEVELS
 sectorbrightness
 {
-  256; 248; 240; 232; 224; 216; 208; 200; 192; 184; 176; 168; 160; 152; 144; 136;
+	256; 248; 240; 232; 224; 216; 208; 200; 192; 184; 176; 168; 160; 152; 144; 136;
 	128; 120; 112; 104; 96; 88; 80; 72; 64; 56; 48; 40; 32; 24; 16; 8; 0;
 }
 
@@ -864,7 +864,7 @@ enums
 
 maplumpnames
 {
-  ~MAP
+	~MAP
 	{
 		required = true;
 		blindcopy = true;
@@ -878,7 +878,7 @@ maplumpnames
 		allowempty = true;
 	}
 
-  ZNODES
+	ZNODES
 	{
 		required = false;
 		nodebuild = true;
@@ -899,7 +899,7 @@ maplumpnames
 		allowempty = true;
 	}
 
-  ENDMAP
+	ENDMAP
 	{
 		required = true;
 		nodebuild = false;

--- a/udb/Includes/DSDADoom_things.cfg
+++ b/udb/Includes/DSDADoom_things.cfg
@@ -1,243 +1,243 @@
 teleports
 {
-  9043
-  {
-    title = "Teleport (Z Height and Gravity)";
-    sprite = "internal:teleport";
-    class = "TeleportDest3";
-  }
+	9043
+	{
+		title = "Teleport (Z Height and Gravity)";
+		sprite = "internal:teleport";
+		class = "TeleportDest3";
+	}
 
-  9044
-  {
-    title = "Teleport (Z Height)";
-    sprite = "internal:teleport";
-    class = "TeleportDest2";
-  }
+	9044
+	{
+		title = "Teleport (Z Height)";
+		sprite = "internal:teleport";
+		class = "TeleportDest2";
+	}
 }
 
 zdoom
 {
-  color = 7;	// Light Grey
-  arrow = 1;
-  title = "ZDoom";
-  sort = 1;
-  width = 10;
-  height = 20;
-  hangs = 0;
-  blocking = 0;
-  fixedsize = true;
-  sprite = "internal:arrow";
+	color = 7; // Light Grey
+	arrow = 1;
+	title = "ZDoom";
+	sort = 1;
+	width = 10;
+	height = 20;
+	hangs = 0;
+	blocking = 0;
+	fixedsize = true;
+	sprite = "internal:arrow";
 
-  9300
-  {
-    title = "Polyobject Anchor";
-    sprite = "internal:anchor";
-    class = "$PolyAnchor";
-    fixedrotation = true;
-    error = 0; // Can be outside of map geometry
-  }
+	9300
+	{
+		title = "Polyobject Anchor";
+		sprite = "internal:anchor";
+		class = "$PolyAnchor";
+		fixedrotation = true;
+		error = 0; // Can be outside of map geometry
+	}
 
-  9301
-  {
-    title = "Polyobject Start Spot";
-    sprite = "internal:anchor";
-    class = "$PolySpawn";
-    fixedrotation = true;
-  }
+	9301
+	{
+		title = "Polyobject Start Spot";
+		sprite = "internal:anchor";
+		class = "$PolySpawn";
+		fixedrotation = true;
+	}
 
-  9302
-  {
-    title = "Polyobject Start Spot (crush)";
-    sprite = "internal:anchor";
-    class = "$PolySpawnCrush";
-    fixedrotation = true;
-  }
+	9302
+	{
+		title = "Polyobject Start Spot (crush)";
+		sprite = "internal:anchor";
+		class = "$PolySpawnCrush";
+		fixedrotation = true;
+	}
 
-  9303
-  {
-    title = "Polyobject Start Spot (hurts to touch)";
-    sprite = "internal:anchor";
-    class = "$PolySpawnHurt";
-    fixedrotation = true;
-  }
+	9303
+	{
+		title = "Polyobject Start Spot (hurts to touch)";
+		sprite = "internal:anchor";
+		class = "$PolySpawnHurt";
+		fixedrotation = true;
+	}
 
-  9001
-  {
-    title = "Map Spot";
-    sprite = "internal:MapSpot";
-    class = "MapSpot";
-  }
+	9001
+	{
+		title = "Map Spot";
+		sprite = "internal:MapSpot";
+		class = "MapSpot";
+	}
 
-  9013
-  {
-    title = "Map Spot (gravity)";
-    sprite = "internal:MapSpotGravity";
-    class = "MapSpotGravity";
-  }
+	9013
+	{
+		title = "Map Spot (gravity)";
+		sprite = "internal:MapSpotGravity";
+		class = "MapSpotGravity";
+	}
 }
 
 sounds
 {
-  color = 7;
-  arrow = 0;
-  title = "Sounds";
-  width = 10;
-  height = 20;
-  sort = 1;
-  blocking = 0;
-  hangs = 0;
-  fixedsize = true;
-  sprite = "internal:sound";
+	color = 7;
+	arrow = 0;
+	title = "Sounds";
+	width = 10;
+	height = 20;
+	sort = 1;
+	blocking = 0;
+	hangs = 0;
+	fixedsize = true;
+	sprite = "internal:sound";
 
-  14001 = "Ambient Sound 01";
-  14002 = "Ambient Sound 02";
-  14003 = "Ambient Sound 03";
-  14004 = "Ambient Sound 04";
-  14005 = "Ambient Sound 05";
-  14006 = "Ambient Sound 06";
-  14007 = "Ambient Sound 07";
-  14008 = "Ambient Sound 08";
-  14009 = "Ambient Sound 09";
-  14010 = "Ambient Sound 10";
-  14011 = "Ambient Sound 11";
-  14012 = "Ambient Sound 12";
-  14013 = "Ambient Sound 13";
-  14014 = "Ambient Sound 14";
-  14015 = "Ambient Sound 15";
-  14016 = "Ambient Sound 16";
-  14017 = "Ambient Sound 17";
-  14018 = "Ambient Sound 18";
-  14019 = "Ambient Sound 19";
-  14020 = "Ambient Sound 20";
-  14021 = "Ambient Sound 21";
-  14022 = "Ambient Sound 22";
-  14023 = "Ambient Sound 23";
-  14024 = "Ambient Sound 24";
-  14025 = "Ambient Sound 25";
-  14026 = "Ambient Sound 26";
-  14027 = "Ambient Sound 27";
-  14028 = "Ambient Sound 28";
-  14029 = "Ambient Sound 29";
-  14030 = "Ambient Sound 30";
-  14031 = "Ambient Sound 31";
-  14032 = "Ambient Sound 32";
-  14033 = "Ambient Sound 33";
-  14034 = "Ambient Sound 34";
-  14035 = "Ambient Sound 35";
-  14036 = "Ambient Sound 36";
-  14037 = "Ambient Sound 37";
-  14038 = "Ambient Sound 38";
-  14039 = "Ambient Sound 39";
-  14040 = "Ambient Sound 40";
-  14041 = "Ambient Sound 41";
-  14042 = "Ambient Sound 42";
-  14043 = "Ambient Sound 43";
-  14044 = "Ambient Sound 44";
-  14045 = "Ambient Sound 45";
-  14046 = "Ambient Sound 46";
-  14047 = "Ambient Sound 47";
-  14048 = "Ambient Sound 48";
-  14049 = "Ambient Sound 49";
-  14050 = "Ambient Sound 50";
-  14051 = "Ambient Sound 51";
-  14052 = "Ambient Sound 52";
-  14053 = "Ambient Sound 53";
-  14054 = "Ambient Sound 54";
-  14055 = "Ambient Sound 55";
-  14056 = "Ambient Sound 56";
-  14057 = "Ambient Sound 57";
-  14058 = "Ambient Sound 58";
-  14059 = "Ambient Sound 59";
-  14060 = "Ambient Sound 60";
-  14061 = "Ambient Sound 61";
-  14062 = "Ambient Sound 62";
-  14063 = "Ambient Sound 63";
-  14064 = "Ambient Sound 64";
+	14001 = "Ambient Sound 01";
+	14002 = "Ambient Sound 02";
+	14003 = "Ambient Sound 03";
+	14004 = "Ambient Sound 04";
+	14005 = "Ambient Sound 05";
+	14006 = "Ambient Sound 06";
+	14007 = "Ambient Sound 07";
+	14008 = "Ambient Sound 08";
+	14009 = "Ambient Sound 09";
+	14010 = "Ambient Sound 10";
+	14011 = "Ambient Sound 11";
+	14012 = "Ambient Sound 12";
+	14013 = "Ambient Sound 13";
+	14014 = "Ambient Sound 14";
+	14015 = "Ambient Sound 15";
+	14016 = "Ambient Sound 16";
+	14017 = "Ambient Sound 17";
+	14018 = "Ambient Sound 18";
+	14019 = "Ambient Sound 19";
+	14020 = "Ambient Sound 20";
+	14021 = "Ambient Sound 21";
+	14022 = "Ambient Sound 22";
+	14023 = "Ambient Sound 23";
+	14024 = "Ambient Sound 24";
+	14025 = "Ambient Sound 25";
+	14026 = "Ambient Sound 26";
+	14027 = "Ambient Sound 27";
+	14028 = "Ambient Sound 28";
+	14029 = "Ambient Sound 29";
+	14030 = "Ambient Sound 30";
+	14031 = "Ambient Sound 31";
+	14032 = "Ambient Sound 32";
+	14033 = "Ambient Sound 33";
+	14034 = "Ambient Sound 34";
+	14035 = "Ambient Sound 35";
+	14036 = "Ambient Sound 36";
+	14037 = "Ambient Sound 37";
+	14038 = "Ambient Sound 38";
+	14039 = "Ambient Sound 39";
+	14040 = "Ambient Sound 40";
+	14041 = "Ambient Sound 41";
+	14042 = "Ambient Sound 42";
+	14043 = "Ambient Sound 43";
+	14044 = "Ambient Sound 44";
+	14045 = "Ambient Sound 45";
+	14046 = "Ambient Sound 46";
+	14047 = "Ambient Sound 47";
+	14048 = "Ambient Sound 48";
+	14049 = "Ambient Sound 49";
+	14050 = "Ambient Sound 50";
+	14051 = "Ambient Sound 51";
+	14052 = "Ambient Sound 52";
+	14053 = "Ambient Sound 53";
+	14054 = "Ambient Sound 54";
+	14055 = "Ambient Sound 55";
+	14056 = "Ambient Sound 56";
+	14057 = "Ambient Sound 57";
+	14058 = "Ambient Sound 58";
+	14059 = "Ambient Sound 59";
+	14060 = "Ambient Sound 60";
+	14061 = "Ambient Sound 61";
+	14062 = "Ambient Sound 62";
+	14063 = "Ambient Sound 63";
+	14064 = "Ambient Sound 64";
 
-  14065
-  {
-    title = "Custom Ambient Sound";
-    class = "AmbientSound";
+	14065
+	{
+		title = "Custom Ambient Sound";
+		class = "AmbientSound";
 
-    arg0
-    {
-      title = "Ambient Sound Index";
-    }
-  }
+		arg0
+		{
+			title = "Ambient Sound Index";
+		}
+	}
 
-  14101 = "Music Changer 01";
-  14102 = "Music Changer 02";
-  14103 = "Music Changer 03";
-  14104 = "Music Changer 04";
-  14105 = "Music Changer 05";
-  14106 = "Music Changer 06";
-  14107 = "Music Changer 07";
-  14108 = "Music Changer 08";
-  14109 = "Music Changer 09";
-  14110 = "Music Changer 10";
-  14111 = "Music Changer 11";
-  14112 = "Music Changer 12";
-  14113 = "Music Changer 13";
-  14114 = "Music Changer 14";
-  14115 = "Music Changer 15";
-  14116 = "Music Changer 16";
-  14117 = "Music Changer 17";
-  14118 = "Music Changer 18";
-  14119 = "Music Changer 19";
-  14120 = "Music Changer 20";
-  14121 = "Music Changer 21";
-  14122 = "Music Changer 22";
-  14123 = "Music Changer 23";
-  14124 = "Music Changer 24";
-  14125 = "Music Changer 25";
-  14126 = "Music Changer 26";
-  14127 = "Music Changer 27";
-  14128 = "Music Changer 28";
-  14129 = "Music Changer 29";
-  14130 = "Music Changer 30";
-  14131 = "Music Changer 31";
-  14132 = "Music Changer 32";
-  14133 = "Music Changer 33";
-  14134 = "Music Changer 34";
-  14135 = "Music Changer 35";
-  14136 = "Music Changer 36";
-  14137 = "Music Changer 37";
-  14138 = "Music Changer 38";
-  14139 = "Music Changer 39";
-  14140 = "Music Changer 40";
-  14141 = "Music Changer 41";
-  14142 = "Music Changer 42";
-  14143 = "Music Changer 43";
-  14144 = "Music Changer 44";
-  14145 = "Music Changer 45";
-  14146 = "Music Changer 46";
-  14147 = "Music Changer 47";
-  14148 = "Music Changer 48";
-  14149 = "Music Changer 49";
-  14150 = "Music Changer 50";
-  14151 = "Music Changer 51";
-  14152 = "Music Changer 52";
-  14153 = "Music Changer 53";
-  14154 = "Music Changer 54";
-  14155 = "Music Changer 55";
-  14156 = "Music Changer 56";
-  14157 = "Music Changer 57";
-  14158 = "Music Changer 58";
-  14159 = "Music Changer 59";
-  14160 = "Music Changer 60";
-  14161 = "Music Changer 61";
-  14162 = "Music Changer 62";
-  14163 = "Music Changer 63";
-  14164 = "Music Changer 64";
+	14101 = "Music Changer 01";
+	14102 = "Music Changer 02";
+	14103 = "Music Changer 03";
+	14104 = "Music Changer 04";
+	14105 = "Music Changer 05";
+	14106 = "Music Changer 06";
+	14107 = "Music Changer 07";
+	14108 = "Music Changer 08";
+	14109 = "Music Changer 09";
+	14110 = "Music Changer 10";
+	14111 = "Music Changer 11";
+	14112 = "Music Changer 12";
+	14113 = "Music Changer 13";
+	14114 = "Music Changer 14";
+	14115 = "Music Changer 15";
+	14116 = "Music Changer 16";
+	14117 = "Music Changer 17";
+	14118 = "Music Changer 18";
+	14119 = "Music Changer 19";
+	14120 = "Music Changer 20";
+	14121 = "Music Changer 21";
+	14122 = "Music Changer 22";
+	14123 = "Music Changer 23";
+	14124 = "Music Changer 24";
+	14125 = "Music Changer 25";
+	14126 = "Music Changer 26";
+	14127 = "Music Changer 27";
+	14128 = "Music Changer 28";
+	14129 = "Music Changer 29";
+	14130 = "Music Changer 30";
+	14131 = "Music Changer 31";
+	14132 = "Music Changer 32";
+	14133 = "Music Changer 33";
+	14134 = "Music Changer 34";
+	14135 = "Music Changer 35";
+	14136 = "Music Changer 36";
+	14137 = "Music Changer 37";
+	14138 = "Music Changer 38";
+	14139 = "Music Changer 39";
+	14140 = "Music Changer 40";
+	14141 = "Music Changer 41";
+	14142 = "Music Changer 42";
+	14143 = "Music Changer 43";
+	14144 = "Music Changer 44";
+	14145 = "Music Changer 45";
+	14146 = "Music Changer 46";
+	14147 = "Music Changer 47";
+	14148 = "Music Changer 48";
+	14149 = "Music Changer 49";
+	14150 = "Music Changer 50";
+	14151 = "Music Changer 51";
+	14152 = "Music Changer 52";
+	14153 = "Music Changer 53";
+	14154 = "Music Changer 54";
+	14155 = "Music Changer 55";
+	14156 = "Music Changer 56";
+	14157 = "Music Changer 57";
+	14158 = "Music Changer 58";
+	14159 = "Music Changer 59";
+	14160 = "Music Changer 60";
+	14161 = "Music Changer 61";
+	14162 = "Music Changer 62";
+	14163 = "Music Changer 63";
+	14164 = "Music Changer 64";
 
-  14165
-  {
-    title = "Custom Music Changer";
-    class = "MusicChanger";
+	14165
+	{
+		title = "Custom Music Changer";
+		class = "MusicChanger";
 
-    arg0
-    {
-      title = "MUSINFO Track Index";
-    }
-  }
+		arg0
+		{
+			title = "MUSINFO Track Index";
+		}
+	}
 }


### PR DESCRIPTION
There are many changes that I've bundled into a single MR. Please say which changes you want to keep and I'll cherrypick them into dedicated MR(s).

- First commit (eb5b67b) are many changes (see text of the commit), but those are the main changes I suggest merging.
- Second commit (96d93d9) just replaces `35` in all the places with `TICRATE`. I did not try changing value of `TICRATE` before and after the change as I don't see it as a constant that is meant to be tweaked but more like naming the "magic number" to make the code more readable
- Third commit (01f6cfc) unifies line indentation style in several files that had multiple styles in them. I recommend merging this one, especially for UDMF where 1st entry used one indent and the rest used a different one.

There are two more changes I've considered:
- `const char * comp_lev_str[MAX_COMPATIBILITY_LEVEL]` is checked as `if (sizeof(comp_lev_str)/sizeof(comp_lev_str[0]) != MAX_COMPATIBILITY_LEVEL)` (both in `g_game.c`) which should never happen and would result in `I_Error("G_ReadDemoHeader: compatibility level strings incomplete");`
- `cmd->angleturn = ((unsigned char)(at = *(*data_p)++))<<8;` in `g_game.c` where `unsigned char` is shifted left by 8, which is the same size as `unsigned char` - as I understand it, it is auto-promoted to `unsigned int` before the shift but I think it should be cast to it instead of casting it to type it already is (`at` is already `unsigned char`).