### PR TITLE
Add support for base spec UDMF namespaces

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -959,9 +959,9 @@ static void AM_HighlightByTag(void)
   {
     highlight.sec = NULL;
     highlight.line = line;
-    highlight.tag = line->tag;
+    highlight.tag = line->special_args[0];
 
-    doom_printf("Highlight line %d, tag %d\n", highlight.line->iLineID, line->tag);
+    doom_printf("Highlight line %d, tag %d\n", highlight.line->iLineID, line->special_args[0]);
   }
   else
   {

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -2155,7 +2155,7 @@ static void D_DoomMainSetup(void)
 
   PostProcessDeh();
   dsda_AppendZDoomMobjInfo();
-  dsda_ApplyDefaultMapFormat();
+  dsda_ApplyBinaryMapFormat();
 
   lprintf(LO_DEBUG, "dsda_InitWadStats: Setting up wad stats.\n");
   dsda_InitWadStats();

--- a/prboom2/src/dsda/global.h
+++ b/prboom2/src/dsda/global.h
@@ -103,8 +103,6 @@ extern int g_mf_shadow;
 
 extern const char* g_skyflatname;
 
-extern dboolean heretic;
-
 void dsda_InitGlobal(void);
 
 #endif

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -269,10 +269,10 @@ extern void P_PostProcessHereticLineSpecial(line_t *ld);
 extern void P_PostProcessHexenLineSpecial(line_t *ld);
 extern void P_PostProcessZDoomLineSpecial(line_t *ld);
 
-extern void P_PostProcessCompatibleSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
-extern void P_PostProcessHereticSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
-extern void P_PostProcessHexenSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
-extern void P_PostProcessZDoomSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
+extern void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i);
+extern void P_PostProcessHereticSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i);
+extern void P_PostProcessHexenSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i);
+extern void P_PostProcessZDoomSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i);
 
 extern void P_AnimateCompatibleSurfaces(void);
 extern void P_AnimateHereticSurfaces(void);

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -16,6 +16,7 @@
 //
 
 #include "doomstat.h"
+#include "dsda/udmf.h"
 #include "lprintf.h"
 #include "p_spec.h"
 #include "r_main.h"
@@ -332,7 +333,7 @@ void dsda_RemoveMobjThingID(mobj_t* mo);
 void P_IterateCompatibleSpecHit(mobj_t *thing, fixed_t oldx, fixed_t oldy);
 void P_IterateZDoomSpecHit(mobj_t *thing, fixed_t oldx, fixed_t oldy);
 
-static const map_format_t zdoom_map_format = {
+static const map_format_t dsda_udmf = {
   .zdoom = true,
   .hexen = true,
   .polyobjs = true,
@@ -387,7 +388,172 @@ static const map_format_t zdoom_map_format = {
   .visibility = VF_ZDOOM | VF_DOOM,
 };
 
-static const map_format_t hexen_map_format = {
+static const map_format_t hexen_udmf = {
+  .zdoom = false,
+  .hexen = true,
+  .polyobjs = true,
+  .acs = true,
+  .thing_id = true,
+  .sndseq = true,
+  .animdefs = true,
+  .doublesky = true,
+  .map99 = true,
+  .generalized_mask = 0, // not used
+  .switch_activation = SPAC_USE | SPAC_IMPACT,
+  .init_sector_special = NULL, // not used
+  .player_in_special_sector = P_PlayerInHexenSector,
+  .mobj_in_special_sector = P_MobjInHexenSector,
+  .spawn_scroller = NULL, // not used
+  .spawn_friction = NULL, // not used
+  .spawn_pusher = NULL, // not used
+  .spawn_extra = NULL, // not used
+  .cross_special_line = P_CrossHexenSpecialLine,
+  .shoot_special_line = P_ShootHexenSpecialLine,
+  .test_activate_line = P_TestActivateHexenLine,
+  .execute_line_special = P_ExecuteHexenLineSpecial,
+  .post_process_line_special = P_PostProcessHexenLineSpecial,
+  .post_process_sidedef_special = P_PostProcessHexenSidedefSpecial,
+  .animate_surfaces = P_AnimateHexenSurfaces,
+  .check_impact = NULL, // not used
+  .translate_line_flags = P_TranslateHexenLineFlags,
+  .apply_sector_movement_special = P_ApplyHereticSectorMovementSpecial,
+  .t_vertical_door = T_VerticalHexenDoor,
+  .t_move_floor = T_MoveHexenFloor,
+  .t_move_ceiling = T_MoveHexenCeiling,
+  .t_build_pillar = T_BuildHexenPillar,
+  .t_plat_raise = T_HexenPlatRaise,
+  .ev_teleport = NULL, // not used
+  .player_thrust = P_HexenPlayerThrust,
+  .build_mobj_thing_id_list = P_CreateTIDList,
+  .add_mobj_thing_id = P_InsertMobjIntoTIDList,
+  .remove_mobj_thing_id = P_RemoveMobjFromTIDList,
+  .iterate_spechit = NULL, // not used
+  .point_on_side = R_ZDoomPointOnSide,
+  .point_on_seg_side = R_ZDoomPointOnSegSide,
+  .point_on_line_side = P_ZDoomPointOnLineSide,
+  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
+  .mapthing_size = sizeof(hexen_mapthing_t),
+  .maplinedef_size = sizeof(hexen_maplinedef_t),
+  .mt_push = -1,
+  .mt_pull = -1,
+  .dn_polyanchor = 3000,
+  .dn_polyspawn_start = 3001,
+  .dn_polyspawn_hurt = -1,
+  .dn_polyspawn_end = 3002,
+  .visibility = VF_HEXEN,
+};
+
+static const map_format_t heretic_udmf = {
+  .zdoom = false,
+  .hexen = false,
+  .polyobjs = false,
+  .acs = false,
+  .thing_id = false,
+  .sndseq = false,
+  .animdefs = false,
+  .doublesky = false,
+  .map99 = false,
+  .generalized_mask = 0,
+  .switch_activation = 0, // not used
+  .init_sector_special = P_SpawnCompatibleSectorSpecial,
+  .player_in_special_sector = P_PlayerInHereticSector,
+  .mobj_in_special_sector = P_MobjInHereticSector,
+  .spawn_scroller = P_SpawnCompatibleScroller,
+  .spawn_friction = P_SpawnCompatibleFriction,
+  .spawn_pusher = P_SpawnCompatiblePusher,
+  .spawn_extra = P_SpawnCompatibleExtra,
+  .cross_special_line = P_CrossHereticSpecialLine,
+  .shoot_special_line = P_ShootCompatibleSpecialLine,
+  .test_activate_line = NULL, // not used
+  .execute_line_special = NULL, // not used
+  .post_process_line_special = P_PostProcessHereticLineSpecial,
+  .post_process_sidedef_special = P_PostProcessHereticSidedefSpecial,
+  .animate_surfaces = P_AnimateHereticSurfaces,
+  .check_impact = P_CheckHereticImpact,
+  .translate_line_flags = P_TranslateCompatibleLineFlags,
+  .apply_sector_movement_special = P_ApplyHereticSectorMovementSpecial,
+  .t_vertical_door = T_VerticalCompatibleDoor,
+  .t_move_floor = T_MoveCompatibleFloor,
+  .t_move_ceiling = T_MoveCompatibleCeiling,
+  .t_build_pillar = NULL, // not used
+  .t_plat_raise = T_CompatiblePlatRaise,
+  .ev_teleport = EV_HereticTeleport,
+  .player_thrust = P_HereticPlayerThrust,
+  .build_mobj_thing_id_list = NULL, // not used
+  .add_mobj_thing_id = NULL, // not used
+  .remove_mobj_thing_id = NULL, // not used
+  .iterate_spechit = P_IterateCompatibleSpecHit,
+  .point_on_side = R_ZDoomPointOnSide,
+  .point_on_seg_side = R_ZDoomPointOnSegSide,
+  .point_on_line_side = P_ZDoomPointOnLineSide,
+  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
+  .mapthing_size = sizeof(doom_mapthing_t),
+  .maplinedef_size = sizeof(doom_maplinedef_t),
+  .mt_push = -1,
+  .mt_pull = -1,
+  .dn_polyanchor = -1,
+  .dn_polyspawn_start = -1,
+  .dn_polyspawn_hurt = -1,
+  .dn_polyspawn_end = -1,
+  .visibility = VF_HERETIC,
+};
+
+static const map_format_t doom_udmf = {
+  .zdoom = false,
+  .hexen = false,
+  .polyobjs = false,
+  .acs = false,
+  .thing_id = false,
+  .sndseq = false,
+  .animdefs = false,
+  .doublesky = false,
+  .map99 = false,
+  .generalized_mask = ~31,
+  .switch_activation = 0, // not used
+  .init_sector_special = P_SpawnCompatibleSectorSpecial,
+  .player_in_special_sector = P_PlayerInCompatibleSector,
+  .mobj_in_special_sector = P_MobjInCompatibleSector,
+  .spawn_scroller = P_SpawnCompatibleScroller,
+  .spawn_friction = P_SpawnCompatibleFriction,
+  .spawn_pusher = P_SpawnCompatiblePusher,
+  .spawn_extra = P_SpawnCompatibleExtra,
+  .cross_special_line = P_CrossCompatibleSpecialLine,
+  .shoot_special_line = P_ShootCompatibleSpecialLine,
+  .test_activate_line = NULL, // not used
+  .execute_line_special = NULL, // not used
+  .post_process_line_special = P_PostProcessCompatibleLineSpecial,
+  .post_process_sidedef_special = P_PostProcessCompatibleSidedefSpecial,
+  .animate_surfaces = P_AnimateCompatibleSurfaces,
+  .check_impact = P_CheckCompatibleImpact,
+  .translate_line_flags = P_TranslateCompatibleLineFlags,
+  .apply_sector_movement_special = P_ApplyCompatibleSectorMovementSpecial,
+  .t_vertical_door = T_VerticalCompatibleDoor,
+  .t_move_floor = T_MoveCompatibleFloor,
+  .t_move_ceiling = T_MoveCompatibleCeiling,
+  .t_build_pillar = NULL, // not used
+  .t_plat_raise = T_CompatiblePlatRaise,
+  .ev_teleport = EV_CompatibleTeleport,
+  .player_thrust = P_CompatiblePlayerThrust,
+  .build_mobj_thing_id_list = NULL, // not used
+  .add_mobj_thing_id = NULL, // not used
+  .remove_mobj_thing_id = NULL, // not used
+  .iterate_spechit = P_IterateCompatibleSpecHit,
+  .point_on_side = R_ZDoomPointOnSide,
+  .point_on_seg_side = R_ZDoomPointOnSegSide,
+  .point_on_line_side = P_ZDoomPointOnLineSide,
+  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
+  .mapthing_size = sizeof(doom_mapthing_t),
+  .maplinedef_size = sizeof(doom_maplinedef_t),
+  .mt_push = MT_PUSH,
+  .mt_pull = MT_PULL,
+  .dn_polyanchor = -1,
+  .dn_polyspawn_start = -1,
+  .dn_polyspawn_hurt = -1,
+  .dn_polyspawn_end = -1,
+  .visibility = VF_DOOM,
+};
+
+static const map_format_t hexen_binary_format = {
   .zdoom = false,
   .hexen = true,
   .polyobjs = true,
@@ -442,7 +608,7 @@ static const map_format_t hexen_map_format = {
   .visibility = VF_HEXEN,
 };
 
-static const map_format_t heretic_map_format = {
+static const map_format_t heretic_binary_format = {
   .zdoom = false,
   .hexen = false,
   .polyobjs = false,
@@ -497,7 +663,7 @@ static const map_format_t heretic_map_format = {
   .visibility = VF_HERETIC,
 };
 
-static const map_format_t doom_map_format = {
+static const map_format_t doom_binary_format = {
   .zdoom = false,
   .hexen = false,
   .polyobjs = false,
@@ -560,7 +726,7 @@ static void dsda_ApplyMapPrecision(void) {
 }
 
 void dsda_ApplyZDoomMapFormat(void) {
-  map_format = zdoom_map_format;
+  map_format = dsda_udmf;
 
   if (!mbf21)
     I_Error("You must use complevel 21 when playing doom-in-hexen format maps.");
@@ -569,13 +735,31 @@ void dsda_ApplyZDoomMapFormat(void) {
   dsda_MigrateMobjInfo();
 }
 
-void dsda_ApplyDefaultMapFormat(void) {
+void dsda_ApplyUDMF(void) {
+  if (udmf_namespace == UDMF_DOOM) {
+    map_format = doom_udmf;
+  }
+  else if (udmf_namespace == UDMF_HERETIC) {
+    map_format = heretic_udmf;
+  }
+  else if (udmf_namespace == UDMF_HEXEN) {
+    map_format = hexen_udmf;
+  }
+  else if (udmf_namespace == UDMF_DSDA) {
+    map_format = dsda_udmf;
+  }
+
+  dsda_ApplyMapPrecision();
+  dsda_MigrateMobjInfo();
+}
+
+void dsda_ApplyBinaryMapFormat(void) {
   if (hexen)
-    map_format = hexen_map_format;
+    map_format = hexen_binary_format;
   else if (heretic)
-    map_format = heretic_map_format;
+    map_format = heretic_binary_format;
   else
-    map_format = doom_map_format;
+    map_format = doom_binary_format;
 
   dsda_ApplyMapPrecision();
   dsda_MigrateMobjInfo();

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -333,7 +333,7 @@ void dsda_RemoveMobjThingID(mobj_t* mo);
 void P_IterateCompatibleSpecHit(mobj_t *thing, fixed_t oldx, fixed_t oldy);
 void P_IterateZDoomSpecHit(mobj_t *thing, fixed_t oldx, fixed_t oldy);
 
-static const map_format_t dsda_udmf = {
+static const map_format_t zdoom_map_format = {
   .zdoom = true,
   .hexen = true,
   .polyobjs = true,
@@ -552,7 +552,7 @@ static void dsda_ApplyLowPrecision(void) {
 }
 
 void dsda_ApplyZDoomMapFormat(void) {
-  map_format = dsda_udmf;
+  map_format = zdoom_map_format;
 
   if (!mbf21)
     I_Error("You must use complevel 21 when playing doom-in-hexen format maps.");
@@ -572,7 +572,7 @@ void dsda_ApplyUDMF(void) {
     map_format = hexen_map_format;
   }
   else if (udmf_namespace == UDMF_DSDA) {
-    map_format = dsda_udmf;
+    map_format = zdoom_map_format;
   }
 
   dsda_ApplyHighPrecision();

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -373,10 +373,6 @@ static const map_format_t dsda_udmf = {
   .add_mobj_thing_id = dsda_AddMobjThingID,
   .remove_mobj_thing_id = dsda_RemoveMobjThingID,
   .iterate_spechit = P_IterateZDoomSpecHit,
-  .point_on_side = R_ZDoomPointOnSide,
-  .point_on_seg_side = R_ZDoomPointOnSegSide,
-  .point_on_line_side = P_ZDoomPointOnLineSide,
-  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
   .mapthing_size = sizeof(hexen_mapthing_t),
   .maplinedef_size = sizeof(hexen_maplinedef_t),
   .mt_push = MT_PUSH,
@@ -388,7 +384,7 @@ static const map_format_t dsda_udmf = {
   .visibility = VF_ZDOOM | VF_DOOM,
 };
 
-static const map_format_t hexen_udmf = {
+static const map_format_t hexen_map_format = {
   .zdoom = false,
   .hexen = true,
   .polyobjs = true,
@@ -428,10 +424,6 @@ static const map_format_t hexen_udmf = {
   .add_mobj_thing_id = P_InsertMobjIntoTIDList,
   .remove_mobj_thing_id = P_RemoveMobjFromTIDList,
   .iterate_spechit = NULL, // not used
-  .point_on_side = R_ZDoomPointOnSide,
-  .point_on_seg_side = R_ZDoomPointOnSegSide,
-  .point_on_line_side = P_ZDoomPointOnLineSide,
-  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
   .mapthing_size = sizeof(hexen_mapthing_t),
   .maplinedef_size = sizeof(hexen_maplinedef_t),
   .mt_push = -1,
@@ -443,7 +435,7 @@ static const map_format_t hexen_udmf = {
   .visibility = VF_HEXEN,
 };
 
-static const map_format_t heretic_udmf = {
+static const map_format_t heretic_map_format = {
   .zdoom = false,
   .hexen = false,
   .polyobjs = false,
@@ -483,10 +475,6 @@ static const map_format_t heretic_udmf = {
   .add_mobj_thing_id = NULL, // not used
   .remove_mobj_thing_id = NULL, // not used
   .iterate_spechit = P_IterateCompatibleSpecHit,
-  .point_on_side = R_ZDoomPointOnSide,
-  .point_on_seg_side = R_ZDoomPointOnSegSide,
-  .point_on_line_side = P_ZDoomPointOnLineSide,
-  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
   .mapthing_size = sizeof(doom_mapthing_t),
   .maplinedef_size = sizeof(doom_maplinedef_t),
   .mt_push = -1,
@@ -498,7 +486,7 @@ static const map_format_t heretic_udmf = {
   .visibility = VF_HERETIC,
 };
 
-static const map_format_t doom_udmf = {
+static const map_format_t doom_map_format = {
   .zdoom = false,
   .hexen = false,
   .polyobjs = false,
@@ -538,10 +526,6 @@ static const map_format_t doom_udmf = {
   .add_mobj_thing_id = NULL, // not used
   .remove_mobj_thing_id = NULL, // not used
   .iterate_spechit = P_IterateCompatibleSpecHit,
-  .point_on_side = R_ZDoomPointOnSide,
-  .point_on_seg_side = R_ZDoomPointOnSegSide,
-  .point_on_line_side = P_ZDoomPointOnLineSide,
-  .point_on_divline_side = P_ZDoomPointOnDivlineSide,
   .mapthing_size = sizeof(doom_mapthing_t),
   .maplinedef_size = sizeof(doom_maplinedef_t),
   .mt_push = MT_PUSH,
@@ -553,176 +537,18 @@ static const map_format_t doom_udmf = {
   .visibility = VF_DOOM,
 };
 
-static const map_format_t hexen_binary_format = {
-  .zdoom = false,
-  .hexen = true,
-  .polyobjs = true,
-  .acs = true,
-  .thing_id = true,
-  .sndseq = true,
-  .animdefs = true,
-  .doublesky = true,
-  .map99 = true,
-  .generalized_mask = 0, // not used
-  .switch_activation = SPAC_USE | SPAC_IMPACT,
-  .init_sector_special = NULL, // not used
-  .player_in_special_sector = P_PlayerInHexenSector,
-  .mobj_in_special_sector = P_MobjInHexenSector,
-  .spawn_scroller = NULL, // not used
-  .spawn_friction = NULL, // not used
-  .spawn_pusher = NULL, // not used
-  .spawn_extra = NULL, // not used
-  .cross_special_line = P_CrossHexenSpecialLine,
-  .shoot_special_line = P_ShootHexenSpecialLine,
-  .test_activate_line = P_TestActivateHexenLine,
-  .execute_line_special = P_ExecuteHexenLineSpecial,
-  .post_process_line_special = P_PostProcessHexenLineSpecial,
-  .post_process_sidedef_special = P_PostProcessHexenSidedefSpecial,
-  .animate_surfaces = P_AnimateHexenSurfaces,
-  .check_impact = NULL, // not used
-  .translate_line_flags = P_TranslateHexenLineFlags,
-  .apply_sector_movement_special = P_ApplyHereticSectorMovementSpecial,
-  .t_vertical_door = T_VerticalHexenDoor,
-  .t_move_floor = T_MoveHexenFloor,
-  .t_move_ceiling = T_MoveHexenCeiling,
-  .t_build_pillar = T_BuildHexenPillar,
-  .t_plat_raise = T_HexenPlatRaise,
-  .ev_teleport = NULL, // not used
-  .player_thrust = P_HexenPlayerThrust,
-  .build_mobj_thing_id_list = P_CreateTIDList,
-  .add_mobj_thing_id = P_InsertMobjIntoTIDList,
-  .remove_mobj_thing_id = P_RemoveMobjFromTIDList,
-  .iterate_spechit = NULL, // not used
-  .point_on_side = R_CompatiblePointOnSide,
-  .point_on_seg_side = R_CompatiblePointOnSegSide,
-  .point_on_line_side = P_CompatiblePointOnLineSide,
-  .point_on_divline_side = P_CompatiblePointOnDivlineSide,
-  .mapthing_size = sizeof(hexen_mapthing_t),
-  .maplinedef_size = sizeof(hexen_maplinedef_t),
-  .mt_push = -1,
-  .mt_pull = -1,
-  .dn_polyanchor = 3000,
-  .dn_polyspawn_start = 3001,
-  .dn_polyspawn_hurt = -1,
-  .dn_polyspawn_end = 3002,
-  .visibility = VF_HEXEN,
-};
+static void dsda_ApplyHighPrecision(void) {
+  R_PointOnSide = R_ZDoomPointOnSide;
+  R_PointOnSegSide = R_ZDoomPointOnSegSide;
+  P_PointOnLineSide = P_ZDoomPointOnLineSide;
+  P_PointOnDivlineSide = P_ZDoomPointOnDivlineSide;
+}
 
-static const map_format_t heretic_binary_format = {
-  .zdoom = false,
-  .hexen = false,
-  .polyobjs = false,
-  .acs = false,
-  .thing_id = false,
-  .sndseq = false,
-  .animdefs = false,
-  .doublesky = false,
-  .map99 = false,
-  .generalized_mask = 0,
-  .switch_activation = 0, // not used
-  .init_sector_special = P_SpawnCompatibleSectorSpecial,
-  .player_in_special_sector = P_PlayerInHereticSector,
-  .mobj_in_special_sector = P_MobjInHereticSector,
-  .spawn_scroller = P_SpawnCompatibleScroller,
-  .spawn_friction = P_SpawnCompatibleFriction,
-  .spawn_pusher = P_SpawnCompatiblePusher,
-  .spawn_extra = P_SpawnCompatibleExtra,
-  .cross_special_line = P_CrossHereticSpecialLine,
-  .shoot_special_line = P_ShootCompatibleSpecialLine,
-  .test_activate_line = NULL, // not used
-  .execute_line_special = NULL, // not used
-  .post_process_line_special = P_PostProcessHereticLineSpecial,
-  .post_process_sidedef_special = P_PostProcessHereticSidedefSpecial,
-  .animate_surfaces = P_AnimateHereticSurfaces,
-  .check_impact = P_CheckHereticImpact,
-  .translate_line_flags = P_TranslateCompatibleLineFlags,
-  .apply_sector_movement_special = P_ApplyHereticSectorMovementSpecial,
-  .t_vertical_door = T_VerticalCompatibleDoor,
-  .t_move_floor = T_MoveCompatibleFloor,
-  .t_move_ceiling = T_MoveCompatibleCeiling,
-  .t_build_pillar = NULL, // not used
-  .t_plat_raise = T_CompatiblePlatRaise,
-  .ev_teleport = EV_HereticTeleport,
-  .player_thrust = P_HereticPlayerThrust,
-  .build_mobj_thing_id_list = NULL, // not used
-  .add_mobj_thing_id = NULL, // not used
-  .remove_mobj_thing_id = NULL, // not used
-  .iterate_spechit = P_IterateCompatibleSpecHit,
-  .point_on_side = R_CompatiblePointOnSide,
-  .point_on_seg_side = R_CompatiblePointOnSegSide,
-  .point_on_line_side = P_CompatiblePointOnLineSide,
-  .point_on_divline_side = P_CompatiblePointOnDivlineSide,
-  .mapthing_size = sizeof(doom_mapthing_t),
-  .maplinedef_size = sizeof(doom_maplinedef_t),
-  .mt_push = -1,
-  .mt_pull = -1,
-  .dn_polyanchor = -1,
-  .dn_polyspawn_start = -1,
-  .dn_polyspawn_hurt = -1,
-  .dn_polyspawn_end = -1,
-  .visibility = VF_HERETIC,
-};
-
-static const map_format_t doom_binary_format = {
-  .zdoom = false,
-  .hexen = false,
-  .polyobjs = false,
-  .acs = false,
-  .thing_id = false,
-  .sndseq = false,
-  .animdefs = false,
-  .doublesky = false,
-  .map99 = false,
-  .generalized_mask = ~31,
-  .switch_activation = 0, // not used
-  .init_sector_special = P_SpawnCompatibleSectorSpecial,
-  .player_in_special_sector = P_PlayerInCompatibleSector,
-  .mobj_in_special_sector = P_MobjInCompatibleSector,
-  .spawn_scroller = P_SpawnCompatibleScroller,
-  .spawn_friction = P_SpawnCompatibleFriction,
-  .spawn_pusher = P_SpawnCompatiblePusher,
-  .spawn_extra = P_SpawnCompatibleExtra,
-  .cross_special_line = P_CrossCompatibleSpecialLine,
-  .shoot_special_line = P_ShootCompatibleSpecialLine,
-  .test_activate_line = NULL, // not used
-  .execute_line_special = NULL, // not used
-  .post_process_line_special = P_PostProcessCompatibleLineSpecial,
-  .post_process_sidedef_special = P_PostProcessCompatibleSidedefSpecial,
-  .animate_surfaces = P_AnimateCompatibleSurfaces,
-  .check_impact = P_CheckCompatibleImpact,
-  .translate_line_flags = P_TranslateCompatibleLineFlags,
-  .apply_sector_movement_special = P_ApplyCompatibleSectorMovementSpecial,
-  .t_vertical_door = T_VerticalCompatibleDoor,
-  .t_move_floor = T_MoveCompatibleFloor,
-  .t_move_ceiling = T_MoveCompatibleCeiling,
-  .t_build_pillar = NULL, // not used
-  .t_plat_raise = T_CompatiblePlatRaise,
-  .ev_teleport = EV_CompatibleTeleport,
-  .player_thrust = P_CompatiblePlayerThrust,
-  .build_mobj_thing_id_list = NULL, // not used
-  .add_mobj_thing_id = NULL, // not used
-  .remove_mobj_thing_id = NULL, // not used
-  .iterate_spechit = P_IterateCompatibleSpecHit,
-  .point_on_side = R_CompatiblePointOnSide,
-  .point_on_seg_side = R_CompatiblePointOnSegSide,
-  .point_on_line_side = P_CompatiblePointOnLineSide,
-  .point_on_divline_side = P_CompatiblePointOnDivlineSide,
-  .mapthing_size = sizeof(doom_mapthing_t),
-  .maplinedef_size = sizeof(doom_maplinedef_t),
-  .mt_push = MT_PUSH,
-  .mt_pull = MT_PULL,
-  .dn_polyanchor = -1,
-  .dn_polyspawn_start = -1,
-  .dn_polyspawn_hurt = -1,
-  .dn_polyspawn_end = -1,
-  .visibility = VF_DOOM,
-};
-
-static void dsda_ApplyMapPrecision(void) {
-  R_PointOnSide = map_format.point_on_side;
-  R_PointOnSegSide = map_format.point_on_seg_side;
-  P_PointOnLineSide = map_format.point_on_line_side;
-  P_PointOnDivlineSide = map_format.point_on_divline_side;
+static void dsda_ApplyLowPrecision(void) {
+  R_PointOnSide = R_CompatiblePointOnSide;
+  R_PointOnSegSide = R_CompatiblePointOnSegSide;
+  P_PointOnLineSide = P_CompatiblePointOnLineSide;
+  P_PointOnDivlineSide = P_CompatiblePointOnDivlineSide;
 }
 
 void dsda_ApplyZDoomMapFormat(void) {
@@ -731,36 +557,36 @@ void dsda_ApplyZDoomMapFormat(void) {
   if (!mbf21)
     I_Error("You must use complevel 21 when playing doom-in-hexen format maps.");
 
-  dsda_ApplyMapPrecision();
+  dsda_ApplyHighPrecision();
   dsda_MigrateMobjInfo();
 }
 
 void dsda_ApplyUDMF(void) {
   if (udmf_namespace == UDMF_DOOM) {
-    map_format = doom_udmf;
+    map_format = doom_map_format;
   }
   else if (udmf_namespace == UDMF_HERETIC) {
-    map_format = heretic_udmf;
+    map_format = heretic_map_format;
   }
   else if (udmf_namespace == UDMF_HEXEN) {
-    map_format = hexen_udmf;
+    map_format = hexen_map_format;
   }
   else if (udmf_namespace == UDMF_DSDA) {
     map_format = dsda_udmf;
   }
 
-  dsda_ApplyMapPrecision();
+  dsda_ApplyHighPrecision();
   dsda_MigrateMobjInfo();
 }
 
 void dsda_ApplyBinaryMapFormat(void) {
   if (hexen)
-    map_format = hexen_binary_format;
+    map_format = hexen_map_format;
   else if (heretic)
-    map_format = heretic_binary_format;
+    map_format = heretic_map_format;
   else
-    map_format = doom_binary_format;
+    map_format = doom_map_format;
 
-  dsda_ApplyMapPrecision();
+  dsda_ApplyLowPrecision();
   dsda_MigrateMobjInfo();
 }

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -269,10 +269,10 @@ extern void P_PostProcessHereticLineSpecial(line_t *ld);
 extern void P_PostProcessHexenLineSpecial(line_t *ld);
 extern void P_PostProcessZDoomLineSpecial(line_t *ld);
 
-extern void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i);
-extern void P_PostProcessHereticSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i);
-extern void P_PostProcessHexenSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i);
-extern void P_PostProcessZDoomSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i);
+extern void P_PostProcessCompatibleSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
+extern void P_PostProcessHereticSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
+extern void P_PostProcessHexenSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
+extern void P_PostProcessZDoomSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i);
 
 extern void P_AnimateCompatibleSurfaces(void);
 extern void P_AnimateHereticSurfaces(void);

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -53,7 +53,7 @@ typedef struct {
   dboolean (*test_activate_line)(line_t *, mobj_t *, int, line_activation_t);
   dboolean (*execute_line_special)(int, int *, line_t *, int, mobj_t *);
   void (*post_process_line_special)(line_t *);
-  void (*post_process_sidedef_special)(side_t *, const char[8], const char[8], const char[8], sector_t *, int);
+  void (*post_process_sidedef_special)(side_t *, const char*, const char*, const char*, sector_t *, int);
   void (*animate_surfaces)(void);
   void (*check_impact)(mobj_t *);
   void (*translate_line_flags)(unsigned int *, line_activation_t *);

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -93,6 +93,7 @@ dboolean dsda_IsDeathExitLine(int index);
 dboolean dsda_IsDeathSecretExitLine(int index);
 dboolean dsda_IsTeleportLine(int index);
 void dsda_ApplyZDoomMapFormat(void);
-void dsda_ApplyDefaultMapFormat(void);
+void dsda_ApplyUDMF(void);
+void dsda_ApplyBinaryMapFormat(void);
 
 #endif

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -53,7 +53,7 @@ typedef struct {
   dboolean (*test_activate_line)(line_t *, mobj_t *, int, line_activation_t);
   dboolean (*execute_line_special)(int, int *, line_t *, int, mobj_t *);
   void (*post_process_line_special)(line_t *);
-  void (*post_process_sidedef_special)(side_t *, const mapsidedef_t *, sector_t *, int);
+  void (*post_process_sidedef_special)(side_t *, const char[8], const char[8], const char[8], sector_t *, int);
   void (*animate_surfaces)(void);
   void (*check_impact)(mobj_t *);
   void (*translate_line_flags)(unsigned int *, line_activation_t *);

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -69,10 +69,6 @@ typedef struct {
   void (*add_mobj_thing_id)(mobj_t *, short);
   void (*remove_mobj_thing_id)(mobj_t *);
   void (*iterate_spechit)(mobj_t *, fixed_t, fixed_t);
-  int (*point_on_side)(fixed_t, fixed_t, const node_t *);
-  int (*point_on_seg_side)(fixed_t, fixed_t, const seg_t *);
-  int (*point_on_line_side)(fixed_t, fixed_t, const line_t *);
-  int (*point_on_divline_side)(fixed_t, fixed_t, const divline_t *);
   size_t mapthing_size;
   size_t maplinedef_size;
   int mt_push;

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -350,7 +350,7 @@ int dsda_UBossAction(mobj_t* mo) {
     if (gamemapinfo->bossactions[i].type == mo->type) {
       junk = *lines;
       junk.special = (short) gamemapinfo->bossactions[i].special;
-      junk.tag = (short) gamemapinfo->bossactions[i].tag;
+      junk.special_args[0] = (short) gamemapinfo->bossactions[i].tag;
 
       // use special semantics for line activation to block problem types.
       if (!P_UseSpecialLine(mo, &junk, 0, true))

--- a/prboom2/src/dsda/udmf.cpp
+++ b/prboom2/src/dsda/udmf.cpp
@@ -15,8 +15,6 @@
 //	DSDA UDMF
 //
 
-#include "doomdef.h"
-#include "lprintf.h"
 #include <cstring>
 #include <vector>
 
@@ -25,8 +23,8 @@ char *Z_StrdupLevel(const char *s);
 void *Z_MallocLevel(size_t size);
 }
 
+#include "doomdef.h"
 #include "scanner.h"
-
 #include "udmf.h"
 
 udmf_namespace_t udmf_namespace = UDMF_NONE;

--- a/prboom2/src/dsda/udmf.cpp
+++ b/prboom2/src/dsda/udmf.cpp
@@ -15,6 +15,8 @@
 //	DSDA UDMF
 //
 
+#include "doomdef.h"
+#include "lprintf.h"
 #include <cstring>
 #include <vector>
 
@@ -26,6 +28,8 @@ void *Z_MallocLevel(size_t size);
 #include "scanner.h"
 
 #include "udmf.h"
+
+udmf_namespace_t udmf_namespace = UDMF_NONE;
 
 std::vector<udmf_line_t> udmf_lines;
 std::vector<udmf_side_t> udmf_sides;
@@ -802,8 +806,21 @@ static void dsda_ParseUDMFIdentifier(Scanner &scanner) {
     scanner.MustGetToken('=');
     scanner.MustGetToken(TK_StringConst);
 
-    if (stricmp(scanner.string, "zdoom") && stricmp(scanner.string, "dsda"))
-      scanner.ErrorF("Unknown UDMF namespace \"%s\"", scanner.string);
+    if (!stricmp(scanner.string, "doom") && !raven) {
+      udmf_namespace = UDMF_DOOM;
+    }
+    else if (!stricmp(scanner.string, "heretic") && heretic) {
+      udmf_namespace = UDMF_HERETIC;
+    }
+    else if (!stricmp(scanner.string, "hexen") && hexen) {
+      udmf_namespace = UDMF_HEXEN;
+    }
+    else if ((!stricmp(scanner.string, "dsda") || !stricmp(scanner.string, "zdoom")) && !raven) {
+      udmf_namespace = UDMF_DSDA;
+    }
+    else {
+      scanner.ErrorF("Unsupported UDMF namespace \"%s\"", scanner.string);
+    }
 
     scanner.MustGetToken(';');
   }

--- a/prboom2/src/dsda/udmf.cpp
+++ b/prboom2/src/dsda/udmf.cpp
@@ -19,12 +19,11 @@
 #include <vector>
 
 extern "C" {
+#include "doomdef.h"
 char *Z_StrdupLevel(const char *s);
 void *Z_MallocLevel(size_t size);
 }
 
-#include "dsda/global.h"
-#include "doomdef.h"
 #include "scanner.h"
 #include "udmf.h"
 

--- a/prboom2/src/dsda/udmf.cpp
+++ b/prboom2/src/dsda/udmf.cpp
@@ -23,6 +23,7 @@ char *Z_StrdupLevel(const char *s);
 void *Z_MallocLevel(size_t size);
 }
 
+#include "dsda/global.h"
 #include "doomdef.h"
 #include "scanner.h"
 #include "udmf.h"

--- a/prboom2/src/dsda/udmf.h
+++ b/prboom2/src/dsda/udmf.h
@@ -24,6 +24,16 @@ extern "C" {
 
 #include <inttypes.h>
 
+typedef enum {
+  UDMF_NONE,
+  UDMF_DOOM,
+  UDMF_HERETIC,
+  UDMF_HEXEN,
+  UDMF_DSDA,
+} udmf_namespace_t;
+
+extern udmf_namespace_t udmf_namespace;
+
 #define UDMF_ML_BLOCKING           0x0000000000000001ull
 #define UDMF_ML_BLOCKMONSTERS      0x0000000000000002ull
 #define UDMF_ML_TWOSIDED           0x0000000000000004ull

--- a/prboom2/src/p_ceilng.c
+++ b/prboom2/src/p_ceilng.c
@@ -443,13 +443,13 @@ int EV_DoCeiling
     case silentCrushAndRaise:
     case crushAndRaise:
       //jff 4/5/98 return if activated
-      rtn = P_ActivateInStasisCeiling(line->tag); // heretic_note: rtn not set in heretic
+      rtn = P_ActivateInStasisCeiling(line->special_args[0]); // heretic_note: rtn not set in heretic
     default:
       break;
   }
 
   // affects all sectors with the same tag as the linedef
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sec = &sectors[*id_p];
 
@@ -639,7 +639,7 @@ int EV_CeilingCrushStop(line_t* line)
   for (cl=activeceilings; cl; cl=cl->next)
   {
     ceiling_t *ceiling = cl->ceiling;
-    if (ceiling->direction != 0 && ceiling->tag == line->tag)
+    if (ceiling->direction != 0 && ceiling->tag == line->special_args[0])
     {
       ceiling->olddirection = ceiling->direction;
       ceiling->direction = 0;

--- a/prboom2/src/p_doors.c
+++ b/prboom2/src/p_doors.c
@@ -518,7 +518,7 @@ int EV_DoDoor
   rtn = 0;
 
   // open all doors with the same tag as the activating line
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sec = &sectors[*id_p];
     // if the ceiling already moving, don't start the door action
@@ -764,7 +764,7 @@ int EV_VerticalDoor
   door->line = line; // jff 1/31/98 remember line that triggered us
 
   /* killough 10/98: use gradual lighting changes if nonzero tag given */
-  door->lighttag = comp[comp_doorlight] ? 0 : line->tag;
+  door->lighttag = comp[comp_doorlight] ? 0 : line->special_args[0];
 
   // set the type of door from the activating linedef type
   switch(line->special)

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -1119,7 +1119,7 @@ void A_KeenDie(mobj_t* mo)
           return;                           // other Keen not dead
       }
 
-  junk.tag = 666;
+  junk.special_args[0] = 666;
   EV_DoDoor(&junk,openDoor);
 }
 
@@ -2725,14 +2725,14 @@ void A_BossDeath(mobj_t *mo)
     {
       if (mo->flags2 & MF2_MAP07BOSS1)
       {
-        junk.tag = 666;
+        junk.special_args[0] = 666;
         EV_DoFloor(&junk,lowerFloorToLowest);
         return;
       }
 
       if (mo->flags2 & MF2_MAP07BOSS2)
       {
-        junk.tag = 667;
+        junk.special_args[0] = 667;
         EV_DoFloor(&junk,raiseToTexture);
         return;
       }
@@ -2743,7 +2743,7 @@ void A_BossDeath(mobj_t *mo)
     switch(gameepisode)
     {
       case 1:
-        junk.tag = 666;
+        junk.special_args[0] = 666;
         EV_DoFloor(&junk, lowerFloorToLowest);
         return;
         break;
@@ -2752,13 +2752,13 @@ void A_BossDeath(mobj_t *mo)
         switch(gamemap)
         {
           case 6:
-            junk.tag = 666;
+            junk.special_args[0] = 666;
             EV_DoDoor(&junk, blazeOpen);
             return;
             break;
 
           case 8:
-            junk.tag = 666;
+            junk.special_args[0] = 666;
             EV_DoFloor(&junk, lowerFloorToLowest);
             return;
             break;
@@ -3175,7 +3175,7 @@ void A_LineEffect(mobj_t *mo)
   junk.special = (short)mo->state->misc1;
   if (!junk.special)
     return;
-  junk.tag = (short)mo->state->misc2;
+  junk.special_args[0] = (short)mo->state->misc2;
   if (!P_UseSpecialLine(mo, &junk, 0, false))
     map_format.cross_special_line(&junk, 0, mo, false);
   mo->state->misc1 = junk.special;
@@ -5035,7 +5035,7 @@ void Heretic_A_BossDeath(mobj_t * actor)
     {                           // Kill any remaining monsters
         P_Massacre();
     }
-    dummyLine.tag = 666;
+    dummyLine.special_args[0] = 666;
     EV_DoFloor(&dummyLine, lowerFloor);
 }
 

--- a/prboom2/src/p_floor.c
+++ b/prboom2/src/p_floor.c
@@ -489,7 +489,7 @@ int EV_DoFloor
   rtn = 0;
 
   // move all floors with the same tag as the linedef
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sec = &sectors[*id_p];
 
@@ -776,7 +776,7 @@ int EV_BuildStairs
   sector_t*     sec;
 
   // start a stair at each sector tagged the same as the linedef
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     //e6y sector_t*
     sec = &sectors[*id_p];
@@ -931,7 +931,7 @@ int EV_BuildStairs
     }
     /* killough 10/98: compatibility option */
     if (comp[comp_stairs]) {
-      id_p = dsda_FindSectorsFromID(line->tag);
+      id_p = dsda_FindSectorsFromID(line->special_args[0]);
 
       /* cph 2001/09/22 - emulate buggy MBF comp_stairs for demos, with logic
        * reversed since we now have a separate outer loop index.
@@ -1100,7 +1100,7 @@ int EV_DoDonut(line_t *line)
   int rtn = 0;
 
   // do function on all sectors with same tag as linedef
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
     rtn |= P_SpawnDonut(*id_p, line, FLOORSPEED / 2, FLOORSPEED / 2);
 
   return rtn;
@@ -1209,7 +1209,7 @@ int EV_DoElevator
 
   rtn = 0;
   // act on all sectors with the same tag as the triggering linedef
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sec = &sectors[*id_p];
 

--- a/prboom2/src/p_genlin.c
+++ b/prboom2/src/p_genlin.c
@@ -53,7 +53,7 @@
                             } \
                             else \
                             { \
-                              id_p = dsda_FindSectorsFromID(line->tag); \
+                              id_p = dsda_FindSectorsFromID(line->special_args[0]); \
                             }
 
 //////////////////////////////////////////////////////////
@@ -448,7 +448,7 @@ int EV_DoGenLift
   // Activate all <type> plats that are in_stasis
 
   if (Targ==LnF2HnF)
-    P_ActivateInStasis(line->tag);
+    P_ActivateInStasis(line->special_args[0]);
 
   FIND_GENLIN_SECTORS;
 
@@ -470,7 +470,7 @@ int EV_DoGenLift
     plat->sector->floordata = plat;
     plat->thinker.function = T_PlatRaise;
     plat->crush = NO_CRUSH;
-    plat->tag = line->tag;
+    plat->tag = line->special_args[0];
 
     plat->type = genLift;
     plat->high = sec->floorheight;
@@ -755,7 +755,7 @@ int EV_DoGenCrusher
 
   //jff 2/22/98  Reactivate in-stasis ceilings...for certain types.
   //jff 4/5/98 return if activated
-  rtn = P_ActivateInStasisCeiling(line->tag);
+  rtn = P_ActivateInStasisCeiling(line->special_args[0]);
 
   FIND_GENLIN_SECTORS;
 
@@ -866,7 +866,7 @@ int EV_DoGenLockedDoor
     /* killough 10/98: implement gradual lighting */
     door->lighttag = !comp[comp_doorlight] &&
       (line->special&6) == 6 &&
-      line->special > GenLockedBase ? line->tag : 0;
+      line->special > GenLockedBase ? line->special_args[0] : 0;
 
     // setup speed of door motion
     switch(Sped)
@@ -986,7 +986,7 @@ int EV_DoGenDoor
     /* killough 10/98: implement gradual lighting */
     door->lighttag = !comp[comp_doorlight] &&
       (line->special&6) == 6 &&
-      line->special > GenLockedBase ? line->tag : 0;
+      line->special > GenLockedBase ? line->special_args[0] : 0;
 
     // set kind of door, whether it opens then close, opens, closes etc.
     // assign target heights accordingly

--- a/prboom2/src/p_lights.c
+++ b/prboom2/src/p_lights.c
@@ -315,7 +315,7 @@ int EV_StartLightStrobing(line_t* line)
   sector_t* sec;
 
   // start lights strobing in all sectors tagged same as line
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sec = &sectors[*id_p];
 
@@ -347,7 +347,7 @@ int EV_TurnTagLightsOff(line_t* line)
   // search sectors for those with same tag as activating line
 
   // killough 10/98: replaced inefficient search with fast search
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sector_t *sector = sectors + *id_p, *tsec;
     int i, min = sector->lightlevel;
@@ -379,7 +379,7 @@ int EV_LightTurnOn(line_t *line, int bright)
   // search all sectors for ones with same tag as activating line
 
   // killough 10/98: replace inefficient search with fast search
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sector_t *temp, *sector = sectors+*id_p;
     int j, tbright = bright; //jff 5/17/98 search for maximum PER sector
@@ -425,7 +425,7 @@ int EV_LightTurnOnPartway(line_t *line, fixed_t level)
     level = FRACUNIT;
 
   // search all sectors for ones with same tag as activating line
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sector_t *temp, *sector = sectors+*id_p;
     int j, bright = 0, min = sector->lightlevel;

--- a/prboom2/src/p_plats.c
+++ b/prboom2/src/p_plats.c
@@ -487,11 +487,11 @@ int EV_DoPlat
   switch(type)
   {
     case perpetualRaise:
-      P_ActivateInStasis(line->tag);
+      P_ActivateInStasis(line->special_args[0]);
       break;
 
     case toggleUpDn:
-      P_ActivateInStasis(line->tag);
+      P_ActivateInStasis(line->special_args[0]);
       rtn=1;
       break;
 
@@ -500,7 +500,7 @@ int EV_DoPlat
   }
 
   // act on all sectors tagged the same as the activating linedef
-  FIND_SECTORS(id_p, line->tag)
+  FIND_SECTORS(id_p, line->special_args[0])
   {
     sec = &sectors[*id_p];
 
@@ -519,7 +519,7 @@ int EV_DoPlat
     plat->sector->floordata = plat; //jff 2/23/98 multiple thinkers
     plat->thinker.function = T_PlatRaise;
     plat->crush = NO_CRUSH;
-    plat->tag = line->tag;
+    plat->tag = line->special_args[0];
 
     //jff 1/26/98 Avoid raise plat bouncing a head off a ceiling and then
     //going down forever -- default low to plat height when triggered
@@ -685,7 +685,7 @@ int EV_StopPlat(line_t* line)
   for (pl=activeplats; pl; pl=pl->next)  // search the active plats
   {
     plat_t *plat = pl->plat;             // for one with the tag not in stasis
-    if (plat->status != in_stasis && plat->tag == line->tag)
+    if (plat->status != in_stasis && plat->tag == line->special_args[0])
     {
       plat->oldstatus = plat->status;    // put it in stasis
       plat->status = in_stasis;

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -202,7 +202,7 @@ void P_ArchiveWorld (void)
 
     P_SAVE_X(li->flags);
     P_SAVE_X(li->special);
-    P_SAVE_X(li->tag);
+    P_SAVE_X(li->id);
     P_SAVE_BYTE(li->player_activations);
     P_SAVE_ARRAY(li->special_args);
 
@@ -300,7 +300,7 @@ void P_UnArchiveWorld (void)
 
     P_LOAD_X(li->flags);
     P_LOAD_X(li->special);
-    P_LOAD_X(li->tag);
+    P_LOAD_X(li->id);
     P_LOAD_BYTE(li->player_activations);
     P_LOAD_ARRAY(li->special_args);
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2397,7 +2397,7 @@ static void P_AllocateUDMFSideDefs(int lump)
   sides = calloc_IfSameLevel(sides, numsides, sizeof(side_t));
 }
 
-void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
+void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const char *bottom, const char *mid, const char *top, sector_t *sec, int i)
 {
   // killough 4/4/98: allow sidedef texture names to be overloaded
   // killough 4/11/98: refined to allow colormaps to work as wall
@@ -2434,21 +2434,21 @@ void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const char bottom[8], con
   }
 }
 
-void P_PostProcessHereticSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
+void P_PostProcessHereticSidedefSpecial(side_t *sd, const char *bottom, const char *mid, const char *top, sector_t *sec, int i)
 {
   sd->midtexture = R_SafeTextureNumForName(mid, i);
   sd->toptexture = R_SafeTextureNumForName(top, i);
   sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
-void P_PostProcessHexenSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
+void P_PostProcessHexenSidedefSpecial(side_t *sd, const char *bottom, const char *mid, const char *top, sector_t *sec, int i)
 {
   sd->midtexture = R_SafeTextureNumForName(mid, i);
   sd->toptexture = R_SafeTextureNumForName(top, i);
   sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
-void P_PostProcessZDoomSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
+void P_PostProcessZDoomSidedefSpecial(side_t *sd, const char *bottom, const char *mid, const char *top, sector_t *sec, int i)
 {
   sd->midtexture = R_SafeTextureNumForName(mid, i);
   sd->toptexture = R_SafeTextureNumForName(top, i);

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2304,7 +2304,7 @@ void P_PostProcessCompatibleLineSpecial(line_t *ld)
       else
         tranmap = W_LumpByNum(lump - 1);
 
-      if (!ld->special_args[0])         // if tag==0,
+      if (!ld->special_args[0]) // if tag==0,
       {
         ld->tranmap = tranmap;  // affect this linedef only
         ld->alpha = 0.66f;
@@ -3367,18 +3367,20 @@ dboolean P_CheckLumpsForSameSource(int lump1, int lump2)
   return true;
 }
 
-static void P_CheckForUDMF(int lumpnum)
+static dboolean P_CheckForUDMF(int lumpnum)
 {
   const int32_t textmap = lumpnum + ML_TEXTMAP;
 
   if (P_CheckLumpsForSameSource(lumpnum, textmap))
   {
-    if (!strcasecmp(lumpinfo[textmap].name, "TEXTMAP"))
+    if (!strncasecmp(lumpinfo[textmap].name, "TEXTMAP", 8))
     {
       dsda_ParseUDMF(W_LumpByNum(textmap), W_LumpLength(textmap), I_Error);
-      return;
+      return true;
     }
   }
+
+  return false;
 }
 
 static dboolean P_CheckForBehavior(int lumpnum)
@@ -3538,9 +3540,7 @@ map_loader_t map_loader;
 
 void P_UpdateMapLoader(int lumpnum)
 {
-  P_CheckForUDMF(lumpnum);
-
-  map_loader = (udmf_namespace != UDMF_NONE) ? udmf_map_loader : binary_map_loader;
+  map_loader = (P_CheckForUDMF(lumpnum)) ? udmf_map_loader : binary_map_loader;
 }
 
 //

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -35,6 +35,7 @@
 #include <math.h>
 #include <zlib.h>
 
+#include "doomdef.h"
 #include "doomstat.h"
 #include "doomtype.h"
 #include "m_bbox.h"
@@ -1759,6 +1760,8 @@ static void P_LoadUDMFThings(int lump)
       }
     }
 
+    mt.options |= MTF_NOTSINGLE|MTF_NOTDM|MTF_NOTCOOP;
+
     if (dmt->flags & UDMF_TF_SKILL1)
       mt.options |= MTF_SKILL1;
 
@@ -1778,13 +1781,22 @@ static void P_LoadUDMFThings(int lump)
       mt.options |= MTF_AMBUSH;
 
     if (dmt->flags & UDMF_TF_SINGLE)
+    {
       mt.options |= MTF_GSINGLE;
+      mt.options &= ~MTF_NOTSINGLE;
+    }
 
     if (dmt->flags & UDMF_TF_DM)
+    {
       mt.options |= MTF_GDEATHMATCH;
+      mt.options &= ~MTF_NOTDM;
+    }
 
     if (dmt->flags & UDMF_TF_COOP)
+    {
       mt.options |= MTF_GCOOP;
+      mt.options &= ~MTF_NOTCOOP;
+    }
 
     if (dmt->flags & UDMF_TF_FRIEND)
       mt.options |= MTF_FRIENDLY;
@@ -2385,7 +2397,7 @@ static void P_AllocateUDMFSideDefs(int lump)
   sides = calloc_IfSameLevel(sides, numsides, sizeof(side_t));
 }
 
-void P_PostProcessCompatibleSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
+void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
 {
   // killough 4/4/98: allow sidedef texture names to be overloaded
   // killough 4/11/98: refined to allow colormaps to work as wall
@@ -2422,21 +2434,21 @@ void P_PostProcessCompatibleSidedefSpecial(side_t *sd, char bottom[8], char mid[
   }
 }
 
-void P_PostProcessHereticSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
+void P_PostProcessHereticSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
 {
   sd->midtexture = R_SafeTextureNumForName(mid, i);
   sd->toptexture = R_SafeTextureNumForName(top, i);
   sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
-void P_PostProcessHexenSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
+void P_PostProcessHexenSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
 {
   sd->midtexture = R_SafeTextureNumForName(mid, i);
   sd->toptexture = R_SafeTextureNumForName(top, i);
   sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
-void P_PostProcessZDoomSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
+void P_PostProcessZDoomSidedefSpecial(side_t *sd, const char bottom[8], const char mid[8], const char top[8], sector_t *sec, int i)
 {
   sd->midtexture = R_SafeTextureNumForName(mid, i);
   sd->toptexture = R_SafeTextureNumForName(top, i);

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -1911,21 +1911,21 @@ static void P_SetLineID(line_t *ld)
   switch (ld->special)
   {
     case zl_line_set_identification:
-      ld->tag = (unsigned short) 256 * ld->special_args[4] + ld->special_args[0];
+      ld->id = (unsigned short) 256 * ld->special_args[4] + ld->special_args[0];
       ld->special = 0;
       break;
     case zl_translucent_line:
-      ld->tag = ld->special_args[0];
+      ld->id = ld->special_args[0];
       break;
     case zl_teleport_line:
     case zl_scroll_texture_model:
-      ld->tag = ld->special_args[0];
+      ld->id = ld->special_args[0];
       break;
     case zl_polyobj_start_line:
-      ld->tag = ld->special_args[3];
+      ld->id = ld->special_args[3];
       break;
     case zl_polyobj_explicit_line:
-      ld->tag = ld->special_args[4];
+      ld->id = ld->special_args[4];
       break;
   }
 }
@@ -2046,7 +2046,7 @@ static void P_LoadLineDefs (int lump)
 
       ld->flags = (unsigned short)LittleShort(mld->flags);
       ld->special = mld->special; // just a byte in hexen
-      ld->tag = 0;
+      ld->id = 0;
       ld->special_args[0] = mld->arg1;
       ld->special_args[1] = mld->arg2;
       ld->special_args[2] = mld->arg3;
@@ -2064,8 +2064,8 @@ static void P_LoadLineDefs (int lump)
 
       ld->flags = (unsigned short)LittleShort(mld->flags);
       ld->special = LittleShort(mld->special);
-      ld->tag = LittleShort(mld->tag);
-      ld->special_args[0] = 0;
+      ld->id = LittleShort(mld->tag);
+      ld->special_args[0] = ld->id; // UDMF: tag -> arg0/id split
       ld->special_args[1] = 0;
       ld->special_args[2] = 0;
       ld->special_args[3] = 0;
@@ -2080,7 +2080,7 @@ static void P_LoadLineDefs (int lump)
 
     P_CalculateLineDefProperties(ld);
 
-    dsda_AddLineID(ld->tag, i);
+    dsda_AddLineID(ld->id, i);
   }
 }
 
@@ -2102,7 +2102,7 @@ static void P_LoadUDMFLineDefs(int lump)
 
     ld->flags = (mld->flags & ML_BOOM);
     ld->special = mld->special;
-    ld->tag = (mld->id >= 0 ? mld->id : 0);
+    ld->id = (mld->id >= 0 ? mld->id : 0);
     ld->special_args[0] = mld->arg0;
     ld->special_args[1] = mld->arg1;
     ld->special_args[2] = mld->arg2;
@@ -2250,8 +2250,8 @@ static void P_LoadUDMFLineDefs(int lump)
     if (ld->healthgroup)
       dsda_AddLineToHealthGroup(ld);
 
-    if (ld->tag > 0)
-      dsda_AddLineID(ld->tag, i);
+    if (ld->id > 0)
+      dsda_AddLineID(ld->id, i);
 
     if (mld->moreids)
     {
@@ -2292,14 +2292,14 @@ void P_PostProcessCompatibleLineSpecial(line_t *ld)
       else
         tranmap = W_LumpByNum(lump - 1);
 
-      if (!ld->tag)             // if tag==0,
+      if (!ld->special_args[0])         // if tag==0,
       {
         ld->tranmap = tranmap;  // affect this linedef only
         ld->alpha = 0.66f;
       }
       else
         for (j=0;j<numlines;j++)          // if tag!=0,
-          if (lines[j].tag == ld->tag)    // affect all matching linedefs
+          if (lines[j].id == ld->special_args[0]) // affect all matching linedefs
           {
             lines[j].tranmap = tranmap;
             lines[j].alpha = 0.66f;

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2385,7 +2385,7 @@ static void P_AllocateUDMFSideDefs(int lump)
   sides = calloc_IfSameLevel(sides, numsides, sizeof(side_t));
 }
 
-void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i)
+void P_PostProcessCompatibleSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
 {
   // killough 4/4/98: allow sidedef texture names to be overloaded
   // killough 4/11/98: refined to allow colormaps to work as wall
@@ -2394,53 +2394,53 @@ void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const mapsidedef_t *msd, 
   {
     case 242:                       // variable colormap via 242 linedef
       sd->bottomtexture =
-        (sec->bottommap =   R_ColormapNumForName(msd->bottomtexture)) < 0 ?
-        sec->bottommap = 0, R_TextureNumForName(msd->bottomtexture): 0 ;
+        (sec->bottommap =   R_ColormapNumForName(bottom)) < 0 ?
+        sec->bottommap = 0, R_TextureNumForName(bottom): 0 ;
       sd->midtexture =
-        (sec->midmap =   R_ColormapNumForName(msd->midtexture)) < 0 ?
-        sec->midmap = 0, R_TextureNumForName(msd->midtexture)  : 0 ;
+        (sec->midmap =   R_ColormapNumForName(mid)) < 0 ?
+        sec->midmap = 0, R_TextureNumForName(mid)  : 0 ;
       sd->toptexture =
-        (sec->topmap =   R_ColormapNumForName(msd->toptexture)) < 0 ?
-        sec->topmap = 0, R_TextureNumForName(msd->toptexture)  : 0 ;
+        (sec->topmap =   R_ColormapNumForName(top)) < 0 ?
+        sec->topmap = 0, R_TextureNumForName(top)  : 0 ;
       break;
 
     case 260: // killough 4/11/98: apply translucency to 2s normal texture
-      sd->midtexture = strncasecmp("TRANMAP", msd->midtexture, 8) ?
-        (sd->special = W_CheckNumForName(msd->midtexture)) == LUMP_NOT_FOUND ||
+      sd->midtexture = strncasecmp("TRANMAP", mid, 8) ?
+        (sd->special = W_CheckNumForName(mid)) == LUMP_NOT_FOUND ||
         W_LumpLength(sd->special) != 65536 ?
-        sd->special=0, R_TextureNumForName(msd->midtexture) :
+        sd->special=0, R_TextureNumForName(mid) :
           (sd->special++, 0) : (sd->special=0);
-      sd->toptexture = R_TextureNumForName(msd->toptexture);
-      sd->bottomtexture = R_TextureNumForName(msd->bottomtexture);
+      sd->toptexture = R_TextureNumForName(top);
+      sd->bottomtexture = R_TextureNumForName(bottom);
       break;
 
     default:                        // normal cases
-      sd->midtexture = R_SafeTextureNumForName(msd->midtexture, i);
-      sd->toptexture = R_SafeTextureNumForName(msd->toptexture, i);
-      sd->bottomtexture = R_SafeTextureNumForName(msd->bottomtexture, i);
+      sd->midtexture = R_SafeTextureNumForName(mid, i);
+      sd->toptexture = R_SafeTextureNumForName(top, i);
+      sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
       break;
   }
 }
 
-void P_PostProcessHereticSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i)
+void P_PostProcessHereticSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
 {
-  sd->midtexture = R_SafeTextureNumForName(msd->midtexture, i);
-  sd->toptexture = R_SafeTextureNumForName(msd->toptexture, i);
-  sd->bottomtexture = R_SafeTextureNumForName(msd->bottomtexture, i);
+  sd->midtexture = R_SafeTextureNumForName(mid, i);
+  sd->toptexture = R_SafeTextureNumForName(top, i);
+  sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
-void P_PostProcessHexenSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i)
+void P_PostProcessHexenSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
 {
-  sd->midtexture = R_SafeTextureNumForName(msd->midtexture, i);
-  sd->toptexture = R_SafeTextureNumForName(msd->toptexture, i);
-  sd->bottomtexture = R_SafeTextureNumForName(msd->bottomtexture, i);
+  sd->midtexture = R_SafeTextureNumForName(mid, i);
+  sd->toptexture = R_SafeTextureNumForName(top, i);
+  sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
-void P_PostProcessZDoomSidedefSpecial(side_t *sd, const mapsidedef_t *msd, sector_t *sec, int i)
+void P_PostProcessZDoomSidedefSpecial(side_t *sd, char bottom[8], char mid[8], char top[8], sector_t *sec, int i)
 {
-  sd->midtexture = R_SafeTextureNumForName(msd->midtexture, i);
-  sd->toptexture = R_SafeTextureNumForName(msd->toptexture, i);
-  sd->bottomtexture = R_SafeTextureNumForName(msd->bottomtexture, i);
+  sd->midtexture = R_SafeTextureNumForName(mid, i);
+  sd->toptexture = R_SafeTextureNumForName(top, i);
+  sd->bottomtexture = R_SafeTextureNumForName(bottom, i);
 }
 
 // killough 4/4/98: delay using texture names until
@@ -2477,7 +2477,7 @@ static void P_LoadSideDefs(int lump)
       sd->sector = sec = &sectors[sector_num];
     }
 
-    map_format.post_process_sidedef_special(sd, msd, sec, i);
+    map_format.post_process_sidedef_special(sd, msd->bottomtexture, msd->midtexture, msd->toptexture, sec, i);
   }
 }
 
@@ -2535,9 +2535,7 @@ static void P_LoadUDMFSideDefs(int lump)
 
     sd->sector = &sectors[msd->sector];
 
-    sd->midtexture = R_SafeTextureNumForName(msd->texturemiddle, i);
-    sd->toptexture = R_SafeTextureNumForName(msd->texturetop, i);
-    sd->bottomtexture = R_SafeTextureNumForName(msd->texturebottom, i);
+    map_format.post_process_sidedef_special(sd, msd->texturebottom, msd->texturemiddle, msd->texturetop, sd->sector, i);
 
     if (sd->scalex_top != FRACUNIT || sd->scaley_top != FRACUNIT ||
         sd->scalex_mid != FRACUNIT || sd->scaley_mid != FRACUNIT ||

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -1321,7 +1321,7 @@ int P_CheckTag(line_t *line)
 {
   /* tag not zero, allowed, or
    * killough 11/98: compatibility option */
-  if (comp[comp_zerotags] || line->tag)//e6y
+  if (comp[comp_zerotags] || line->special_args[0])//e6y
     return 1;
 
   switch(line->special)
@@ -1645,7 +1645,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
       if (!thing->player && !bossaction)
         if ((line->special & FloorChange) || !(line->special & FloorModel))
           return;     // FloorModel is "Allow Monsters" if FloorChange is 0
-      if (!line->tag) //jff 2/27/98 all walk generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all walk generalized types require tag
         return;
       linefunc = EV_DoGenFloor;
     }
@@ -1654,7 +1654,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
       if (!thing->player && !bossaction)
         if ((line->special & CeilingChange) || !(line->special & CeilingModel))
           return;     // CeilingModel is "Allow Monsters" if CeilingChange is 0
-      if (!line->tag) //jff 2/27/98 all walk generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all walk generalized types require tag
         return;
       linefunc = EV_DoGenCeiling;
     }
@@ -1667,7 +1667,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
         if (line->flags & ML_SECRET) // they can't open secret doors either
           return;
       }
-      if (!line->tag) //3/2/98 move outside the monster check
+      if (!line->special_args[0]) //3/2/98 move outside the monster check
         return;
       linefunc = EV_DoGenDoor;
     }
@@ -1689,7 +1689,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
       if (!thing->player && !bossaction)
         if (!(line->special & LiftMonster))
           return; // monsters disallowed
-      if (!line->tag) //jff 2/27/98 all walk generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all walk generalized types require tag
         return;
       linefunc = EV_DoGenLift;
     }
@@ -1698,7 +1698,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
       if (!thing->player && !bossaction)
         if (!(line->special & StairMonster))
           return; // monsters disallowed
-      if (!line->tag) //jff 2/27/98 all walk generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all walk generalized types require tag
         return;
       linefunc = EV_DoGenStairs;
     }
@@ -1709,7 +1709,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
       if (!thing->player && !bossaction)
         if (!(line->special & StairMonster))
           return; // monsters disallowed
-      if (!line->tag) //jff 2/27/98 all walk generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all walk generalized types require tag
         return;
       linefunc = EV_DoGenCrusher;
     }
@@ -1891,7 +1891,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
 
     case 39:
       // TELEPORT! //jff 02/09/98 fix using up with wrong side crossing
-      if (map_format.ev_teleport(0, line->tag, line, side, thing, TELF_VANILLA) || demo_compatibility)
+      if (map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_VANILLA) || demo_compatibility)
         line->special = 0;
       break;
 
@@ -2010,7 +2010,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
     case 125:
       // TELEPORT MonsterONLY
       if (!thing->player &&
-          (map_format.ev_teleport(0, line->tag, line, side, thing, TELF_VANILLA) || demo_compatibility))
+          (map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_VANILLA) || demo_compatibility))
         line->special = 0;
       break;
 
@@ -2147,7 +2147,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
 
     case 97:
       // TELEPORT!
-      map_format.ev_teleport( 0, line->tag, line, side, thing, TELF_VANILLA );
+      map_format.ev_teleport( 0, line->special_args[0], line, side, thing, TELF_VANILLA );
       break;
 
     case 98:
@@ -2178,7 +2178,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
     case 126:
       // TELEPORT MonsterONLY.
       if (!thing->player)
-        map_format.ev_teleport( 0, line->tag, line, side, thing, TELF_VANILLA );
+        map_format.ev_teleport( 0, line->special_args[0], line, side, thing, TELF_VANILLA );
       break;
 
     case 128:
@@ -2259,7 +2259,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
 
           case 207:
             // killough 2/16/98: W1 silent teleporter (normal kind)
-            if (map_format.ev_teleport(0, line->tag, line, side, thing, TELF_SILENT))
+            if (map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_SILENT))
               line->special = 0;
             break;
 
@@ -2267,14 +2267,14 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
           case 153: //jff 3/15/98 create texture change no motion type
             // Texture/Type Change Only (Trig)
             // 153 W1 Change Texture/Type Only
-            if (EV_DoChange(line,trigChangeOnly,line->tag))
+            if (EV_DoChange(line,trigChangeOnly,line->special_args[0]))
               line->special = 0;
             break;
 
           case 239: //jff 3/15/98 create texture change no motion type
             // Texture/Type Change Only (Numeric)
             // 239 W1 Change Texture/Type Only
-            if (EV_DoChange(line,numChangeOnly,line->tag))
+            if (EV_DoChange(line,numChangeOnly,line->special_args[0]))
               line->special = 0;
             break;
 
@@ -2308,29 +2308,29 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
 
           case 243: //jff 3/6/98 make fit within DCK's 256 linedef types
             // killough 2/16/98: W1 silent teleporter (linedef-linedef kind)
-            if (EV_SilentLineTeleport(line, side, thing, line->tag, false))
+            if (EV_SilentLineTeleport(line, side, thing, line->special_args[0], false))
               line->special = 0;
             break;
 
           case 262: //jff 4/14/98 add silent line-line reversed
-            if (EV_SilentLineTeleport(line, side, thing, line->tag, true))
+            if (EV_SilentLineTeleport(line, side, thing, line->special_args[0], true))
               line->special = 0;
             break;
 
           case 264: //jff 4/14/98 add monster-only silent line-line reversed
             if (!thing->player &&
-                EV_SilentLineTeleport(line, side, thing, line->tag, true))
+                EV_SilentLineTeleport(line, side, thing, line->special_args[0], true))
               line->special = 0;
             break;
 
           case 266: //jff 4/14/98 add monster-only silent line-line
             if (!thing->player &&
-                EV_SilentLineTeleport(line, side, thing, line->tag, false))
+                EV_SilentLineTeleport(line, side, thing, line->special_args[0], false))
               line->special = 0;
             break;
 
           case 268: //jff 4/14/98 add monster-only silent
-            if (!thing->player && map_format.ev_teleport(0, line->tag, line, side, thing, TELF_SILENT))
+            if (!thing->player && map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_SILENT))
               line->special = 0;
             break;
 
@@ -2425,7 +2425,7 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
 
           case 208:
             // killough 2/16/98: WR silent teleporter (normal kind)
-            map_format.ev_teleport(0, line->tag, line, side, thing, TELF_SILENT);
+            map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_SILENT);
             break;
 
           case 212: //jff 3/14/98 create instant toggle floor type
@@ -2438,13 +2438,13 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
           case 154: //jff 3/15/98 create texture change no motion type
             // Texture/Type Change Only (Trigger)
             // 154 WR Change Texture/Type Only
-            EV_DoChange(line,trigChangeOnly,line->tag);
+            EV_DoChange(line,trigChangeOnly,line->special_args[0]);
             break;
 
           case 240: //jff 3/15/98 create texture change no motion type
             // Texture/Type Change Only (Numeric)
             // 240 WR Change Texture/Type Only
-            EV_DoChange(line,numChangeOnly,line->tag);
+            EV_DoChange(line,numChangeOnly,line->special_args[0]);
             break;
 
           case 220:
@@ -2473,26 +2473,26 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
 
           case 244: //jff 3/6/98 make fit within DCK's 256 linedef types
             // killough 2/16/98: WR silent teleporter (linedef-linedef kind)
-            EV_SilentLineTeleport(line, side, thing, line->tag, false);
+            EV_SilentLineTeleport(line, side, thing, line->special_args[0], false);
             break;
 
           case 263: //jff 4/14/98 add silent line-line reversed
-            EV_SilentLineTeleport(line, side, thing, line->tag, true);
+            EV_SilentLineTeleport(line, side, thing, line->special_args[0], true);
             break;
 
           case 265: //jff 4/14/98 add monster-only silent line-line reversed
             if (!thing->player)
-              EV_SilentLineTeleport(line, side, thing, line->tag, true);
+              EV_SilentLineTeleport(line, side, thing, line->special_args[0], true);
             break;
 
           case 267: //jff 4/14/98 add monster-only silent line-line
             if (!thing->player)
-              EV_SilentLineTeleport(line, side, thing, line->tag, false);
+              EV_SilentLineTeleport(line, side, thing, line->special_args[0], false);
             break;
 
           case 269: //jff 4/14/98 add monster-only silent
             if (!thing->player)
-              map_format.ev_teleport(0, line->tag, line, side, thing, TELF_SILENT);
+              map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_SILENT);
             break;
 
             //jff 1/29/98 end of added WR linedef types
@@ -2557,7 +2557,7 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
       if (!thing->player)
         if ((line->special & FloorChange) || !(line->special & FloorModel))
           return;   // FloorModel is "Allow Monsters" if FloorChange is 0
-      if (!line->tag) //jff 2/27/98 all gun generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all gun generalized types require tag
         return;
 
       linefunc = EV_DoGenFloor;
@@ -2567,7 +2567,7 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
       if (!thing->player)
         if ((line->special & CeilingChange) || !(line->special & CeilingModel))
           return;   // CeilingModel is "Allow Monsters" if CeilingChange is 0
-      if (!line->tag) //jff 2/27/98 all gun generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all gun generalized types require tag
         return;
       linefunc = EV_DoGenCeiling;
     }
@@ -2580,7 +2580,7 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
         if (line->flags & ML_SECRET) // they can't open secret doors either
           return;
       }
-      if (!line->tag) //jff 3/2/98 all gun generalized types require tag
+      if (!line->special_args[0]) //jff 3/2/98 all gun generalized types require tag
         return;
       linefunc = EV_DoGenDoor;
     }
@@ -2595,7 +2595,7 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
       }
       else
         return;
-      if (!line->tag) //jff 2/27/98 all gun generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all gun generalized types require tag
         return;
 
       linefunc = EV_DoGenLockedDoor;
@@ -2612,7 +2612,7 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
       if (!thing->player)
         if (!(line->special & StairMonster))
           return; // monsters disallowed
-      if (!line->tag) //jff 2/27/98 all gun generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all gun generalized types require tag
         return;
       linefunc = EV_DoGenStairs;
     }
@@ -2621,7 +2621,7 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
       if (!thing->player)
         if (!(line->special & StairMonster))
           return; // monsters disallowed
-      if (!line->tag) //jff 2/27/98 all gun generalized types require tag
+      if (!line->special_args[0]) //jff 2/27/98 all gun generalized types require tag
         return;
       linefunc = EV_DoGenCrusher;
     }
@@ -3455,7 +3455,7 @@ static void P_SpawnVanillaExtras(void)
 
         case 271:   // Regular sky
         case 272:   // Same, only flipped
-          FIND_SECTORS(id_p, lines[i].tag)
+          FIND_SECTORS(id_p, lines[i].special_args[0])
           {
             sectors[*id_p].floorsky = i | PL_SKYFLAT_LINE;
             sectors[*id_p].ceilingsky = i | PL_SKYFLAT_LINE;
@@ -3475,7 +3475,7 @@ void P_SpawnCompatibleExtra(line_t *l, int i)
     // support for drawn heights coming from different sector
     case 242:
       sec = sides[*l->sidenum].sector->iSectorID;
-      FIND_SECTORS(id_p, lines[i].tag)
+      FIND_SECTORS(id_p, lines[i].special_args[0])
         sectors[*id_p].heightsec = sec;
       break;
 
@@ -3483,7 +3483,7 @@ void P_SpawnCompatibleExtra(line_t *l, int i)
     // floor lighting independently (e.g. lava)
     case 213:
       sec = sides[*l->sidenum].sector->iSectorID;
-      FIND_SECTORS(id_p, lines[i].tag)
+      FIND_SECTORS(id_p, lines[i].special_args[0])
         sectors[*id_p].floorlightsec = sec;
       break;
 
@@ -3491,7 +3491,7 @@ void P_SpawnCompatibleExtra(line_t *l, int i)
     // ceiling lighting independently
     case 261:
       sec = sides[*l->sidenum].sector->iSectorID;
-      FIND_SECTORS(id_p, lines[i].tag)
+      FIND_SECTORS(id_p, lines[i].special_args[0])
         sectors[*id_p].ceilinglightsec = sec;
       break;
 
@@ -3506,7 +3506,7 @@ void P_SpawnCompatibleExtra(line_t *l, int i)
 
     case 271:   // Regular sky
     case 272:   // Same, only flipped
-      FIND_SECTORS(id_p, lines[i].tag)
+      FIND_SECTORS(id_p, lines[i].special_args[0])
       {
         sectors[*id_p].floorsky = i | PL_SKYFLAT_LINE;
         sectors[*id_p].ceilingsky = i | PL_SKYFLAT_LINE;
@@ -3770,13 +3770,13 @@ void P_SpawnCompatibleScroller(line_t *l, int i)
     const int *id_p;
 
     case 250:   // scroll effect ceiling
-      FIND_SECTORS(id_p, l->tag)
+      FIND_SECTORS(id_p, l->special_args[0])
         dsda_AddControlCeilingScroller(-dx, dy, control, *id_p, accel, 0);
       break;
 
     case 251:   // scroll effect floor
     case 253:   // scroll and carry objects on floor
-      FIND_SECTORS(id_p, l->tag)
+      FIND_SECTORS(id_p, l->special_args[0])
         dsda_AddControlFloorScroller(-dx, dy, control, *id_p, accel, 0);
       if (special != 253)
         break;
@@ -3785,14 +3785,14 @@ void P_SpawnCompatibleScroller(line_t *l, int i)
     case 252: // carry objects on floor
       dx = FixedMul(dx, CARRYFACTOR);
       dy = FixedMul(dy, CARRYFACTOR);
-      FIND_SECTORS(id_p, l->tag)
+      FIND_SECTORS(id_p, l->special_args[0])
         dsda_AddControlFloorCarryScroller(dx, dy, control, *id_p, accel, 0);
       break;
 
       // killough 3/1/98: scroll wall according to linedef
       // (same direction and speed as scrolling floors)
     case 254:
-      FIND_LINES(id_p, l->tag)
+      FIND_LINES(id_p, l->special_args[0])
         if (*id_p != i)
           Add_WallScroller(dx, dy, lines + *id_p, control, accel);
       break;
@@ -3805,7 +3805,7 @@ void P_SpawnCompatibleScroller(line_t *l, int i)
     case 1024: // special 255 with tag control
     case 1025:
     case 1026:
-      if (l->tag == 0)
+      if (l->special_args[0] == 0)
         I_Error("Line %d is missing a tag!", i);
 
       if (special > 1024)
@@ -3817,7 +3817,7 @@ void P_SpawnCompatibleScroller(line_t *l, int i)
       side = lines[i].sidenum[0];
       dx = -sides[side].textureoffset / 8;
       dy = sides[side].rowoffset / 8;
-      FIND_LINES(id_p, l->tag)
+      FIND_LINES(id_p, l->special_args[0])
         if (*id_p != i)
           dsda_AddControlSideScroller(dx, dy, control, lines[*id_p].sidenum[0], accel, 0);
 
@@ -4227,7 +4227,7 @@ void P_SpawnCompatibleFriction(line_t *l)
     value = P_AproxDistance(l->dx, l->dy) >> FRACBITS;
     use_thinker = !demo_compatibility && !mbf_features && !prboom_comp[PC_PRBOOM_FRICTION].state;
 
-    P_ApplySectorFriction(l->tag, value, use_thinker);
+    P_ApplySectorFriction(l->special_args[0], value, use_thinker);
   }
 }
 
@@ -4561,15 +4561,15 @@ void P_SpawnCompatiblePusher(line_t *l)
   switch(l->special)
   {
     case 224: // wind
-      FIND_SECTORS(id_p, l->tag)
+      FIND_SECTORS(id_p, l->special_args[0])
         Add_Pusher(p_wind, l->dx, l->dy, NULL, *id_p);
       break;
     case 225: // current
-      FIND_SECTORS(id_p, l->tag)
+      FIND_SECTORS(id_p, l->special_args[0])
         Add_Pusher(p_current, l->dx, l->dy, NULL, *id_p);
       break;
     case 226: // push/pull
-      FIND_SECTORS(id_p, l->tag)
+      FIND_SECTORS(id_p, l->special_args[0])
       {
         thing = P_GetPushThing(*id_p);
         if (thing) // No MT_P* means no effect
@@ -5045,7 +5045,7 @@ void P_CrossHereticSpecialLine(line_t * line, int side, mobj_t * thing, dboolean
             line->special = 0;
             break;
         case 39:               // TELEPORT!
-            map_format.ev_teleport(0, line->tag, line, side, thing, TELF_VANILLA);
+            map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_VANILLA);
             line->special = 0;
             break;
         case 40:               // RaiseCeilingLowerFloor
@@ -5172,7 +5172,7 @@ void P_CrossHereticSpecialLine(line_t * line, int side, mobj_t * thing, dboolean
             EV_DoFloor(line, raiseToTexture);
             break;
         case 97:               // TELEPORT!
-            map_format.ev_teleport(0, line->tag, line, side, thing, TELF_VANILLA);
+            map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_VANILLA);
             break;
         case 98:               // Lower Floor (TURBO)
             EV_DoFloor(line, turboLower);

--- a/prboom2/src/p_switch.c
+++ b/prboom2/src/p_switch.c
@@ -453,7 +453,7 @@ P_UseSpecialLine
       if (!thing->player && !bossaction)
         if ((line->special & FloorChange) || !(line->special & FloorModel))
           return false; // FloorModel is "Allow Monsters" if FloorChange is 0
-      if (!line->tag && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
         return false;                         // generalized types require tag
       linefunc = EV_DoGenFloor;
     }
@@ -462,7 +462,7 @@ P_UseSpecialLine
       if (!thing->player && !bossaction)
         if ((line->special & CeilingChange) || !(line->special & CeilingModel))
           return false;   // CeilingModel is "Allow Monsters" if CeilingChange is 0
-      if (!line->tag && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
         return false;                         // generalized types require tag
       linefunc = EV_DoGenCeiling;
     }
@@ -475,7 +475,7 @@ P_UseSpecialLine
         if (line->flags & ML_SECRET) // they can't open secret doors either
           return false;
       }
-      if (!line->tag && ((line->special&6)!=6)) //jff 3/2/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 3/2/98 all non-manual
         return false;                         // generalized types require tag
       linefunc = EV_DoGenDoor;
     }
@@ -485,7 +485,7 @@ P_UseSpecialLine
         return false;   // monsters disallowed from unlocking doors
       if (!P_CanUnlockGenDoor(line,thing->player))
         return false;
-      if (!line->tag && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
         return false;                         // generalized types require tag
 
       linefunc = EV_DoGenLockedDoor;
@@ -495,7 +495,7 @@ P_UseSpecialLine
       if (!thing->player && !bossaction)
         if (!(line->special & LiftMonster))
           return false; // monsters disallowed
-      if (!line->tag && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
         return false;                         // generalized types require tag
       linefunc = EV_DoGenLift;
     }
@@ -504,7 +504,7 @@ P_UseSpecialLine
       if (!thing->player && !bossaction)
         if (!(line->special & StairMonster))
           return false; // monsters disallowed
-      if (!line->tag && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
         return false;                         // generalized types require tag
       linefunc = EV_DoGenStairs;
     }
@@ -513,7 +513,7 @@ P_UseSpecialLine
       if (!thing->player && !bossaction)
         if (!(line->special & CrusherMonster))
           return false; // monsters disallowed
-      if (!line->tag && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
+      if (!line->special_args[0] && ((line->special&6)!=6)) //jff 2/27/98 all non-manual
         return false;                         // generalized types require tag
       linefunc = EV_DoGenCrusher;
     }
@@ -929,7 +929,7 @@ P_UseSpecialLine
           case 174:
             // Teleport
             // 174 S1  Teleport(side,thing)
-            if (map_format.ev_teleport(0, line->tag,line,side,thing,TELF_VANILLA))
+            if (map_format.ev_teleport(0, line->special_args[0],line,side,thing,TELF_VANILLA))
               P_ChangeSwitchTexture(line,0);
             return true;
 
@@ -943,7 +943,7 @@ P_UseSpecialLine
           case 189: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Trigger)
             // 189 S1 Change Texture/Type Only
-            if (EV_DoChange(line,trigChangeOnly,line->tag))
+            if (EV_DoChange(line,trigChangeOnly,line->special_args[0]))
               P_ChangeSwitchTexture(line,0);
             return true;
 
@@ -964,14 +964,14 @@ P_UseSpecialLine
           case 209:
             // killough 1/31/98: silent teleporter
             //jff 209 S1 SilentTeleport
-            if (map_format.ev_teleport(0, line->tag, line, side, thing, TELF_SILENT))
+            if (map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_SILENT))
               P_ChangeSwitchTexture(line,0);
             return true;
 
           case 241: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Numeric)
             // 241 S1 Change Texture/Type Only
-            if (EV_DoChange(line,numChangeOnly,line->tag))
+            if (EV_DoChange(line,numChangeOnly,line->special_args[0]))
               P_ChangeSwitchTexture(line,0);
             return true;
 
@@ -1012,7 +1012,7 @@ P_UseSpecialLine
           case 78: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Numeric)
             // 78 SR Change Texture/Type Only
-            if (EV_DoChange(line,numChangeOnly,line->tag))
+            if (EV_DoChange(line,numChangeOnly,line->special_args[0]))
               P_ChangeSwitchTexture(line,1);
             return true;
 
@@ -1112,7 +1112,7 @@ P_UseSpecialLine
           case 190: //jff 3/15/98 create texture change no motion type
             // Texture Change Only (Trigger)
             // 190 SR Change Texture/Type Only
-            if (EV_DoChange(line,trigChangeOnly,line->tag))
+            if (EV_DoChange(line,trigChangeOnly,line->special_args[0]))
               P_ChangeSwitchTexture(line,1);
             return true;
 
@@ -1147,7 +1147,7 @@ P_UseSpecialLine
           case 195:
             // Teleport
             // 195 SR  Teleport(side,thing)
-            if (map_format.ev_teleport(0, line->tag,line,side,thing,TELF_VANILLA))
+            if (map_format.ev_teleport(0, line->special_args[0],line,side,thing,TELF_VANILLA))
               P_ChangeSwitchTexture(line,1);
             return true;
 
@@ -1175,7 +1175,7 @@ P_UseSpecialLine
           case 210:
             // killough 1/31/98: silent teleporter
             //jff 210 SR SilentTeleport
-            if (map_format.ev_teleport(0, line->tag, line, side, thing, TELF_SILENT))
+            if (map_format.ev_teleport(0, line->special_args[0], line, side, thing, TELF_SILENT))
               P_ChangeSwitchTexture(line,1);
             return true;
 

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -318,7 +318,7 @@ typedef struct line_s
   float texel_length;
   line_flags_t flags;           // Animation related.
   short special;
-  short tag;
+  short id;
   unsigned short sidenum[2];        // Visual appearance: SideDefs.
   fixed_t bbox[4];       // A bounding box, for the linedef's extent
   slopetype_t slopetype; // To aid move clipping.
@@ -335,6 +335,7 @@ typedef struct line_s
   byte player_activations;
 
   // hexen
+  // also used in UDMF -- tag -> arg0/id split
   int special_args[5];
 
   // zdoom


### PR DESCRIPTION
As per the increased support for the UDMF spec discussed on the cross-port, the existing support on (U)ZDoom, Eternity, and the recently added support on Helion and Woof.

Also adds the needed "Tag -> id/arg0" split in non-parameterized map formats (Doom/Heretic), matching existing implementations in ports/editors.

Test maps: [udmf_test.zip](https://github.com/user-attachments/files/22991392/udmf_test.zip) -- all presented in the "Doom" namespace.
* MAP01 is a conversion of Vandacts.wad (cl2/3/4)
* MAP02 is an example of the aforementioned tag split (cl9)
* MAP03 is a conversion of Boomedit.wad (cl9)
