### PR TITLE
add option to show linetraces on automap

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2931,7 +2931,7 @@ void AM_Drawer (dboolean minimap)
     AM_drawGrid(mapcolor_p->grid);      //jff 1/7/98 grid default color
   AM_drawWalls();
   AM_drawPlayers();
-  if (dsda_IntConfig(dsda_config_map_traces) && dsda_RevealAutomap())
+  if (dsda_IntConfig(dsda_config_map_traces) && dsda_RevealAutomap() == 2)
     AM_drawLineTraces();
   AM_drawThings(); //jff 1/5/98 default double IDDT sprite
   AM_DrawConnections();

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2782,7 +2782,7 @@ static void AM_drawLineTraces(void)
   for (unsigned short i = 0; i < NUMAMLINETRACES; i++)
   {
     amlinetrace_t *p = &amlinetraces[(cur_amlinetrace + i) % NUMAMLINETRACES];
-    int fade = (gametic - p->when) << 1;
+    int fade = (leveltime - p->when) << 1;
     if (fade < 24 && (p->x1 != p->x2 || p->y1 != p->y2))
     {
       int color;
@@ -2801,7 +2801,7 @@ static void AM_drawLineTraces(void)
         AM_SetMPointFloatValue(&pathline.b);
       }
       // red to fading gray
-      color = gametic <= p->when + 1 ? 176 : 78 + fade;
+      color = leveltime <= p->when + 1 ? 176 : 78 + fade;
       AM_drawMline(&pathline, color);
     }
   }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2777,6 +2777,36 @@ static void AM_drawCrosshair(int color)
   V_DrawLine(&line, color);
 }
 
+static void AM_drawLineTraces(void)
+{
+  for (unsigned short i = 0; i < NUMAMLINETRACES; i++)
+  {
+    amlinetrace_t *p = &amlinetraces[(cur_amlinetrace + i) % NUMAMLINETRACES];
+    int fade = (gametic - p->when) << 1;
+    if (fade < 24 && (p->x1 != p->x2 || p->y1 != p->y2))
+    {
+      int color;
+      mline_t pathline = {
+        {p->x1 >> FRACTOMAPBITS, p->y1 >> FRACTOMAPBITS},
+        {p->x2 >> FRACTOMAPBITS, p->y2 >> FRACTOMAPBITS}};
+
+      if (automap_rotate)
+      {
+        AM_rotatePoint(&pathline.a);
+        AM_rotatePoint(&pathline.b);
+      }
+      else
+      {
+        AM_SetMPointFloatValue(&pathline.a);
+        AM_SetMPointFloatValue(&pathline.b);
+      }
+      // red to fading gray
+      color = gametic <= p->when + 1 ? 176 : 78 + fade;
+      AM_drawMline(&pathline, color);
+    }
+  }
+}
+
 void M_ChangeMapTextured(void)
 {
   map_textured = dsda_IntConfig(dsda_config_map_textured);
@@ -2901,6 +2931,8 @@ void AM_Drawer (dboolean minimap)
     AM_drawGrid(mapcolor_p->grid);      //jff 1/7/98 grid default color
   AM_drawWalls();
   AM_drawPlayers();
+  if (dsda_IntConfig(dsda_config_map_traces) && dsda_RevealAutomap())
+    AM_drawLineTraces();
   AM_drawThings(); //jff 1/5/98 default double IDDT sprite
   AM_DrawConnections();
   AM_drawCrosshair(mapcolor_p->hair);   //jff 1/7/98 default crosshair color

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1083,6 +1083,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "map_trail_size", dsda_config_map_trail_size,
     dsda_config_int, 0, 350, { 105 }, NULL, STRICT_INT(0), AM_initPlayerTrail
   },
+  [dsda_config_map_traces] = {
+    "map_traces", dsda_config_map_traces,
+    CONF_BOOL(0)
+  },
   [dsda_config_automap_overlay] = {
     "automap_overlay", dsda_config_automap_overlay,
     dsda_config_int, 0, 2, { 0 }, &automap_overlay

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -239,6 +239,7 @@ typedef enum {
   dsda_config_map_trail,
   dsda_config_map_trail_collisions,
   dsda_config_map_trail_size,
+  dsda_config_map_traces,
   dsda_config_automap_overlay,
   dsda_config_automap_rotate,
   dsda_config_automap_follow,

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -2993,6 +2993,7 @@ setup_menu_t auto_appearance_settings[] =
 {
   { "Enable textured display", S_YESNO, m_conf, AA_X, dsda_config_map_textured },
   { "Things appearance", S_CHOICE, m_conf, AA_X, dsda_config_map_things_appearance, 0, map_things_appearance_list },
+  { "Show Line Traces", S_YESNO, m_conf, AA_X, dsda_config_map_traces },
   EMPTY_LINE,
   { "Translucency percentage", S_SKIP | S_TITLE, m_null, AA_X},
   { "Textured automap", S_NUM, m_conf, AA_X, dsda_config_map_textured_trans },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -247,6 +247,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_map_trail),
   MIGRATED_SETTING(dsda_config_map_trail_collisions),
   MIGRATED_SETTING(dsda_config_map_trail_size),
+  MIGRATED_SETTING(dsda_config_map_traces),
   MIGRATED_SETTING(dsda_config_automap_overlay),
   MIGRATED_SETTING(dsda_config_automap_rotate),
   MIGRATED_SETTING(dsda_config_automap_follow),

--- a/prboom2/src/p_maputl.c
+++ b/prboom2/src/p_maputl.c
@@ -47,6 +47,7 @@
 #include "e6y.h"//e6y
 
 #include "dsda/map_format.h"
+#include <dsda/configuration.h>
 
 //
 // P_AproxDistance
@@ -773,6 +774,9 @@ dboolean P_TraverseIntercepts(traverser_t func, fixed_t maxfrac)
   return true;                  // everything was traversed
 }
 
+amlinetrace_t amlinetraces[NUMAMLINETRACES] = {0};
+unsigned int cur_amlinetrace = 0;
+
 //
 // P_PathTraverse
 // Traces a line from x1,y1 to x2,y2,
@@ -794,6 +798,17 @@ dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
   int     mapx1, mapy1;
   int     mapxstep, mapystep;
   int     count;
+
+	if (dsda_IntConfig(dsda_config_map_traces))
+	{
+		extern int gametic;
+		amlinetraces[cur_amlinetrace].x1 = x1;
+		amlinetraces[cur_amlinetrace].x2 = x2;
+		amlinetraces[cur_amlinetrace].y1 = y1;
+		amlinetraces[cur_amlinetrace].y2 = y2;
+		amlinetraces[cur_amlinetrace].when = gametic;
+		cur_amlinetrace = (cur_amlinetrace + 1) % NUMAMLINETRACES;
+	}
 
   validcount++;
   intercept_p = intercepts;

--- a/prboom2/src/p_maputl.c
+++ b/prboom2/src/p_maputl.c
@@ -806,7 +806,7 @@ dboolean P_PathTraverse(fixed_t x1, fixed_t y1, fixed_t x2, fixed_t y2,
 		amlinetraces[cur_amlinetrace].x2 = x2;
 		amlinetraces[cur_amlinetrace].y1 = y1;
 		amlinetraces[cur_amlinetrace].y2 = y2;
-		amlinetraces[cur_amlinetrace].when = gametic;
+		amlinetraces[cur_amlinetrace].when = leveltime;
 		cur_amlinetrace = (cur_amlinetrace + 1) % NUMAMLINETRACES;
 	}
 

--- a/prboom2/src/p_maputl.h
+++ b/prboom2/src/p_maputl.h
@@ -118,4 +118,27 @@ extern divline_t trace;
 
 dboolean P_GetMidTexturePosition(const line_t *line, int sideno, fixed_t *top, fixed_t *bottom);
 
+// bes 01/20/24: foul hacks to draw these lines on automap
+//  bes 02/28/24: moved this to maputl.h and renamed pathtrace to amlinetrace
+typedef struct
+{
+	fixed_t x1, y1, x2, y2;
+	int when;
+} amlinetrace_t;
+
+#define NUMAMLINETRACES 64
+extern amlinetrace_t amlinetraces[NUMAMLINETRACES];
+extern unsigned int cur_amlinetrace;
+
+// bes 02/28/24: automap rectangle traces for blocks (itc ovf blockmap tiles)
+typedef struct
+{
+	fixed_t x1, y1, x2, y2;
+	int when;
+} amrecttrace_t;
+
+#define NUMAMRECTTRACES 64
+extern amrecttrace_t amrecttraces[NUMAMRECTTRACES];
+extern unsigned int cur_amrecttrace;
+
 #endif  /* __P_MAPUTL__ */


### PR DESCRIPTION
Another [besus](https://github.com/complevel9/susdoom) feature. Tell me if the way the option is handled needs changing.

<img width="640" height="480" alt="изображение" src="https://github.com/user-attachments/assets/e1f72d3f-02f9-4299-82b7-0a7f3302e30a" />

<img width="640" height="480" alt="изображение" src="https://github.com/user-attachments/assets/deea8481-518c-4243-8621-9a12ef88933e" />

<img width="640" height="480" alt="ddd54685c96bc1e8" src="https://github.com/user-attachments/assets/3b389345-2985-461b-8b0c-45fb822593d2" />
