### PR TITLE
Add clangd cache folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ CMakeUserPresets.json
 # Visual Studio Code
 /.vscode/**
 !/.vscode/extension.json
+
+# clangd
+/.cache/


### PR DESCRIPTION
Clangd generates cached indexing files under this sub directory, they very easily get in the way of any Git operation, cluttering the list of untracked files.