### PR TITLE
Fix "Always Pistol Start" revert in save games

### DIFF
--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -167,7 +167,9 @@ void dsda_UnArchiveGameModifiers(void)
   P_LOAD_X(saved_nomonsters);
   P_LOAD_X(saved_coop_spawns);
 
-  dsda_UpdateIntConfig(dsda_config_pistol_start,     saved_pistolstart, true);
+  // If "Always Pistol Start" is enabled, skip resetting "Pistol Start" upon load
+  if (!dsda_IntConfig(dsda_config_always_pistol_start) && dsda_IntConfig(dsda_config_pistol_start))
+    dsda_UpdateIntConfig(dsda_config_pistol_start,     saved_pistolstart, true);
   dsda_UpdateIntConfig(dsda_config_respawn_monsters, saved_respawnparm, true);
   dsda_UpdateIntConfig(dsda_config_fast_monsters,    saved_fastparm,    true);
   dsda_UpdateIntConfig(dsda_config_no_monsters,      saved_nomonsters,  true);


### PR DESCRIPTION
Fixes an oversight regarding the "Always Pistol Start" option.

Currently, If you have "Always Pistol Start" enabled, and load a save game with "Pistol Start" disabled, it forces "Pistol Start" and "Always Pistol Start" off.

This fixes that, and will not force "Pistol Start" status off, when "Always Pistol Start" is enabled.