### PR TITLE
Allow "Death Use Action: Nothing" in Demos

### DIFF
--- a/prboom2/src/dsda/death.c
+++ b/prboom2/src/dsda/death.c
@@ -38,6 +38,20 @@ typedef enum {
   death_use_reload,
 } death_use_action_t;
 
+int dsda_SkipDeathUseAction(void)
+{
+  // if demo playback, don't skip
+  if (demoplayback)
+    return false;
+
+  // if demo recording and death_use_nothing is set, skip DeathUseAction
+  if (demorecording)
+    if (players[consoleplayer].playerstate == PST_DEAD && dsda_IntConfig(dsda_config_death_use_action) == death_use_nothing)
+      return true;
+
+  return false;
+}
+
 static int dsda_DeathUseAction(void)
 {
   if (demorecording ||
@@ -50,6 +64,9 @@ static int dsda_DeathUseAction(void)
 }
 
 void dsda_DeathUse(player_t* player) {
+  if (dsda_SkipDeathUseAction())
+    return;
+
   switch (dsda_DeathUseAction())
   {
     case death_use_default:

--- a/prboom2/src/dsda/death.c
+++ b/prboom2/src/dsda/death.c
@@ -38,35 +38,30 @@ typedef enum {
   death_use_reload,
 } death_use_action_t;
 
-int dsda_SkipDeathUseAction(void)
+int dsda_DeathUseNothingInDemo(void)
 {
-  // if demo playback, don't skip
-  if (demoplayback)
-    return false;
-
-  // if demo recording and death_use_nothing is set, skip DeathUseAction
+  // if demorecording and death_use_nothing is set, allow
   if (demorecording)
-    if (players[consoleplayer].playerstate == PST_DEAD && dsda_IntConfig(dsda_config_death_use_action) == death_use_nothing)
+    if (players[consoleplayer].playerstate == PST_DEAD &&
+        dsda_IntConfig(dsda_config_death_use_action) == death_use_nothing)
       return true;
 
+  // if demoplayback / casual play, ignore
   return false;
 }
 
 static int dsda_DeathUseAction(void)
 {
-  if (demorecording ||
-      demoplayback ||
-      map_info.flags & MI_ALLOW_RESPAWN ||
-      skill_info.flags & SI_PLAYER_RESPAWN)
+  dboolean force_death_use = demorecording && !dsda_DeathUseNothingInDemo();
+  dboolean mapinfo_respawn = map_info.flags & MI_ALLOW_RESPAWN || skill_info.flags & SI_PLAYER_RESPAWN;
+
+  if (demoplayback || force_death_use || mapinfo_respawn)
     return death_use_default;
 
   return dsda_IntConfig(dsda_config_death_use_action);
 }
 
 void dsda_DeathUse(player_t* player) {
-  if (dsda_SkipDeathUseAction())
-    return;
-
   switch (dsda_DeathUseAction())
   {
     case death_use_default:

--- a/prboom2/src/dsda/death.h
+++ b/prboom2/src/dsda/death.h
@@ -15,8 +15,8 @@
 //	DSDA Death
 //
 
-#ifndef __DSDA_DEMO__
-#define __DSDA_DEMO__
+#ifndef __DSDA_DEATH__
+#define __DSDA_DEATH__
 
 void dsda_DeathUse(player_t* player);
 

--- a/prboom2/src/dsda/death.h
+++ b/prboom2/src/dsda/death.h
@@ -18,7 +18,7 @@
 #ifndef __DSDA_DEATH__
 #define __DSDA_DEATH__
 
-extern int dsda_SkipDeathUseAction(void);
 void dsda_DeathUse(player_t* player);
+extern int dsda_DeathUseNothingInDemo(void);
 
 #endif

--- a/prboom2/src/dsda/death.h
+++ b/prboom2/src/dsda/death.h
@@ -18,6 +18,7 @@
 #ifndef __DSDA_DEATH__
 #define __DSDA_DEATH__
 
+extern int dsda_SkipDeathUseAction(void);
 void dsda_DeathUse(player_t* player);
 
 #endif

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -838,7 +838,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   if (dsda_InputActive(dsda_input_use) || dsda_InputTickActivated(dsda_input_use))
   {
-    if (!dsda_SkipDeathUseAction())
+    if (!dsda_DeathUseNothingInDemo())
       cmd->buttons |= BT_USE;
     // clear double clicks if hit use button
     dclicks = 0;
@@ -982,7 +982,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
         dclicks++;
       if (dclicks == 2)
         {
-          if (!dsda_SkipDeathUseAction())
+          if (!dsda_DeathUseNothingInDemo())
             cmd->buttons |= BT_USE;
           dclicks = 0;
         }
@@ -1005,7 +1005,7 @@ void G_BuildTiccmd(ticcmd_t* cmd)
         dclicks2++;
       if (dclicks2 == 2)
         {
-          if (!dsda_SkipDeathUseAction())
+          if (!dsda_DeathUseNothingInDemo())
             cmd->buttons |= BT_USE;
           dclicks2 = 0;
         }

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -93,6 +93,7 @@
 #include "dsda/build.h"
 #include "dsda/configuration.h"
 #include "dsda/console.h"
+#include "dsda/death.h"
 #include "dsda/demo.h"
 #include "dsda/excmd.h"
 #include "dsda/exdemo.h"
@@ -837,7 +838,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
 
   if (dsda_InputActive(dsda_input_use) || dsda_InputTickActivated(dsda_input_use))
   {
-    cmd->buttons |= BT_USE;
+    if (!dsda_SkipDeathUseAction())
+      cmd->buttons |= BT_USE;
     // clear double clicks if hit use button
     dclicks = 0;
   }
@@ -980,7 +982,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
         dclicks++;
       if (dclicks == 2)
         {
-          cmd->buttons |= BT_USE;
+          if (!dsda_SkipDeathUseAction())
+            cmd->buttons |= BT_USE;
           dclicks = 0;
         }
       else
@@ -1002,7 +1005,8 @@ void G_BuildTiccmd(ticcmd_t* cmd)
         dclicks2++;
       if (dclicks2 == 2)
         {
-          cmd->buttons |= BT_USE;
+          if (!dsda_SkipDeathUseAction())
+            cmd->buttons |= BT_USE;
           dclicks2 = 0;
         }
       else


### PR DESCRIPTION
Fixes #630

This took me a while to implement...
You need to actually stop the "use" action being recorded in the demo actions.

Also I found an incorrect header... which I'm shocked hasn't caused any problems up to now.