### PR TITLE
Minimap Coordinates Fix

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -2866,7 +2866,7 @@ void AM_Drawer (dboolean minimap)
 
   V_BeginAutomapDraw();
 
-  if (automap_follow)
+  if (automap_follow || minimap)
     AM_doFollowPlayer();
 
   // Change the zoom if necessary

--- a/prboom2/src/dsda/hud_components/minimap.c
+++ b/prboom2/src/dsda/hud_components/minimap.c
@@ -25,15 +25,21 @@ typedef struct {
 
 static local_component_t* local;
 
-void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
-  *data = Z_Calloc(1, sizeof(local_component_t));
-  local = *data;
+// backups of original values
+// (so we can access them later)
+static int xx, yy, ww, hh;
+static int yy_offset, flags;
 
-  local->x = x_offset;
-  local->y = dsda_HudComponentY(y_offset, vpt, 0);
-  local->width = args[0];
-  local->height = args[1];
-  local->scale = args[2];
+static void dsda_UpdateMinimapCoordinates(void) {
+
+  // Must recalculate y each update
+  yy = dsda_HudComponentY(yy_offset, flags, 0);
+
+  // Varables
+  local->x      = xx;
+  local->y      = yy;
+  local->width  = ww;
+  local->height = hh;
 
   if (local->x < 0)
     local->x = 0;
@@ -53,10 +59,32 @@ void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_
   if (local->y + local->height > 200)
     local->y = 200 - local->height;
 
+  V_GetWideRect(&local->x, &local->y, &local->width, &local->height, flags);
+}
+
+void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
+  *data = Z_Calloc(1, sizeof(local_component_t));
+  local = *data;
+
+  // Varables
+  local->x = x_offset;
+  local->width = args[0];
+  local->height = args[1];
+  local->scale = args[2];
+
+  // Constants
+  xx = local->x;
+  ww = local->width;
+  hh = local->height;
+
+  yy_offset = y_offset;
+  flags = vpt;
+
+  // Init scale
   if (local->scale < 64)
     local->scale = 1024;
 
-  V_GetWideRect(&local->x, &local->y, &local->width, &local->height, vpt);
+  dsda_UpdateMinimapCoordinates();
 }
 
 void dsda_UpdateMinimapHC(void* data) {
@@ -72,6 +100,8 @@ void dsda_DrawMinimapHC(void* data) {
 void dsda_CopyMinimapCoordinates(int* f_x, int* f_y, int* f_w, int* f_h) {
   if (!local)
     return;
+
+  dsda_UpdateMinimapCoordinates();
 
   *f_x = local->x;
   *f_y = local->y;

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -57,8 +57,10 @@
 
 #include "dsda/configuration.h"
 #include "dsda/cr_table.h"
+#include "dsda/exhud.h"
 #include "dsda/global.h"
 #include "dsda/palette.h"
+#include "dsda/settings.h"
 #include "dsda/stretch.h"
 #include "dsda/text_color.h"
 
@@ -1508,6 +1510,12 @@ void V_ChangeScreenResolution(void)
   if (V_IsOpenGLMode())
   {
     gld_PreprocessLevel();
+  }
+
+  // Refresh Minimap Coordinates
+  if (dsda_ShowMinimap())
+  {
+    dsda_RefreshExHudMinimap();
   }
 }
 


### PR DESCRIPTION
Fixes #574 
See that issue for more detail.

Basically the minimap coordinates set in DSDAHUD would only be used once, and then be overwritten. This caused a problem whenever you changed your resolution, as it didn't have access to the original values.

This actually could cause a crash if you had the minimap enabled and went from 2560x1440 to a very small resolution like 640x400, as it would result in the minimap coordinates going out-of-bounds.

This PR fixes that.

Note there is an issue when changing resolution where the minimap doesn't center around the player... This was an issue before, and should eventually be fixed... although I haven't found a solution quite yet. but you can fix this pretty easily by just entering and exiting the main automap.

Also I added the second commit, because imo it doesn't make sense for the minimap to not follow the player.