### PR TITLE
Allow Doom-in-Hexen format maps to use Lightning

### DIFF
--- a/prboom2/src/dsda/mapinfo/doom.c
+++ b/prboom2/src/dsda/mapinfo/doom.c
@@ -702,7 +702,12 @@ int dsda_DoomPrepareFinished(void) {
 }
 
 int dsda_DoomMapLightning(int* lightning) {
-  return false;
+  if (raven || !current_map || !current_map->lightning)
+    return false;
+
+  *lightning = current_map->lightning;
+
+  return true;
 }
 
 int dsda_DoomApplyFadeTable(void) {

--- a/prboom2/src/dsda/mapinfo/doom/parser.cpp
+++ b/prboom2/src/dsda/mapinfo/doom/parser.cpp
@@ -382,6 +382,9 @@ static void dsda_ParseDoomMapInfoMapBlock(Scanner &scanner, doom_mapinfo_map_t &
     else if (scanner.StringMatch("BorderTexture")) {
       SCAN_STRING(map.border_texture);
     }
+    else if (scanner.StringMatch("Lightning")) {
+      map.lightning = scanner.number;
+    }
     else if (scanner.StringMatch("EvenLighting")) {
       map.flags |= DMI_EVEN_LIGHTING;
       map.flags &= ~DMI_SMOOTH_LIGHTING;

--- a/prboom2/src/dsda/mapinfo/doom/parser.h
+++ b/prboom2/src/dsda/mapinfo/doom/parser.h
@@ -78,6 +78,7 @@ typedef struct {
   char* author;
   int level_num;
   int cluster;
+  dboolean lightning;
   doom_mapinfo_map_next_t next;
   doom_mapinfo_map_next_t secret_next;
   doom_mapinfo_sky_t sky1;

--- a/prboom2/src/hexen/p_anim.c
+++ b/prboom2/src/hexen/p_anim.c
@@ -102,6 +102,17 @@ void P_AnimateZDoomSurfaces(void)
   // The linespeciallist stuff isn't relevant (using doom scrollers)
   // AnimDef stuff will come later
   // Skies / lightning as well
+  if (LevelHasLightning)
+  {
+    if (!NextLightningFlash || LightningFlash)
+    {
+      P_LightningFlash();
+    }
+    else
+    {
+      NextLightningFlash--;
+    }
+  }
 }
 
 void P_AnimateHexenSurfaces(void)
@@ -277,7 +288,8 @@ static void P_LightningFlash(void)
     if (foundSec)
     {
         Sky1Texture = dsda_Sky2Texture();     // set alternate sky
-        S_StartVoidSound(hexen_sfx_thunder_crash);
+        if (hexen)                            // Doom doesn't have thunder sfx
+            S_StartVoidSound(hexen_sfx_thunder_crash);
     }
     // Calculate the next lighting flash
     if (!NextLightningFlash)


### PR DESCRIPTION
So this is a very very early draft...

Need y'all to look into this. Technically this does work, but we may wanna structure this better.

Requires Doom-in-Hexen map format and MAPINFO with the line "Lightning".
Here's a very basic demo map: [lightning-doom-test-map.wad](https://drive.google.com/file/d/1FW54JznWt_x0utBEcWLV8izXva55gBGp/view?usp=sharing)

Currently the lightning seems to work, but it's currently using `pr_hexen` for randomness (not sure if this is good or not).
Also note that I've disabled the sound currently for Doom.. Not sure how we are gonna deal with that, since currently DSDA only allows sounds in the `sfxenum_t` list.

There is a MAPINFO field called "LightningSound" but it probably uses names from a lump like SNDINFO. ZDoom tends to use "World/Thunder" as the default value. I just don't think DSDA is currently setup for this functionality quite yet.