### PR TITLE
Remove forced ExCmdDemo recording on DSDA-UDMF/MapInfo wads

### DIFF
--- a/prboom2/src/dsda/demo.c
+++ b/prboom2/src/dsda/demo.c
@@ -794,28 +794,9 @@ void dsda_WriteDSDADemoHeader(byte** p) {
 }
 
 void dsda_ApplyDSDADemoFormat(byte** demo_p) {
-  dboolean use_dsda_format = false;
-
-  if (map_format.zdoom)
-  {
-    if (!mbf21)
-      I_Error("You must use complevel 21 when recording in advanced formats.");
-
-    use_dsda_format = true;
-  }
-  else if (dsda_UseMapinfo())
-  {
-    use_dsda_format = true;
-  }
-
   if (dsda_Flag(dsda_arg_dsdademo))
   {
-    use_dsda_format = true;
     dsda_EnableCasualExCmdFeatures();
-  }
-
-  if (use_dsda_format)
-  {
     dsda_EnableExCmd();
     dsda_WriteDSDADemoHeader(demo_p);
   }


### PR DESCRIPTION
Somewhat experimental change that has consequences for demo recording.

This _should_ completely fix demo recording for Eviternity II, without needing the mapinfo patch -- but also has the major fix of enabling normal demos (non-ExCMdDemo) for DSDA-UDMF/ZDoom maps. Thus allowing valid recording for DSDA-UDMF map sets, like NoSp4, as ExCmdDemos always fail analysis testing, being classified as "Other".