### PR TITLE
Try opening the music lump with the XMP player first

### DIFF
--- a/prboom2/src/SDL/i_sound.c
+++ b/prboom2/src/SDL/i_sound.c
@@ -1058,9 +1058,9 @@ static int music_player_was_init[NUM_MUS_PLAYERS];
 // order in which players are to be tried
 char music_player_order[NUM_MUS_PLAYERS][200] =
 {
+  PLAYER_XMP,
   PLAYER_VORBIS,
   PLAYER_MAD,
-  PLAYER_XMP,
   PLAYER_FLUIDSYNTH,
   PLAYER_OPL,
   PLAYER_PORTMIDI,


### PR DESCRIPTION
There is no magic number or simple identification method for MP3.

Fix #807 