### PR TITLE
Allow Translucency to be Customisable for Boom and Higher

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1588,7 +1588,7 @@ void deh_changeCompTranslucency(void)
   if (raven) return;
 
   boom_translucent_sprites = dsda_IntConfig(dsda_config_translucent_sprites);
-  vanilla_translucent_sprites = boom_translucent_sprites > 1;
+  vanilla_translucent_sprites = !dsda_StrictMode() && boom_translucent_sprites > 1;
   translucency_active = (compatibility_level >= boom_compatibility_compatibility) ? !comp[comp_translucency] : vanilla_translucent_sprites;
 
   // Reset translucency

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1260,7 +1260,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_translucent_sprites] = {
     "boom_translucent_sprites", dsda_config_translucent_sprites,
-    dsda_config_int, 0, 2, { 1 }, NULL, STRICT_INT(1), deh_changeCompTranslucency
+    dsda_config_int, 0, 2, { 1 }, NULL, NOT_STRICT, deh_changeCompTranslucency
   },
   [dsda_config_translucent_ghosts] = {
     "translucent_ghosts", dsda_config_translucent_ghosts,


### PR DESCRIPTION
Strict Mode no longer restricts the ability to change the boom_translucent_sprites config.

Only thing that is restricted now is translucency under Vanilla complevels. While you can still change the setting, sprites will never be translucent in Vanilla under Strict Mode.