### PR TITLE
Fix monochrome menu options in OpenGL

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -682,7 +682,7 @@ void gld_FillPatch(int lump, int x, int y, int width, int height, enum patch_tra
 // use colormaps[0] as a fallback in such a case.
 const lighttable_t *gld_GetActiveColormap()
 {
-  if (V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed())
+  if (V_IsUILightmodeIndexed() || V_IsAutomapLightmodeIndexed() || V_IsMenuLightmodeIndexed())
     return colormaps[0];
   else if (fixedcolormap)
     return fixedcolormap;


### PR DESCRIPTION
Fixes colors in the automap menu being monochrome, when invulnerable
<img width="360" height="270" alt="before_c" src="https://github.com/user-attachments/assets/81053a2f-52be-4c5a-9501-f0260c0dc942" />
<img width="360" height="270" alt="after_c" src="https://github.com/user-attachments/assets/d8c4c506-6ed0-463e-8e1f-d578a981a411" />
