### PR TITLE
Add `comp_thingsectorlight` property

### DIFF
--- a/prboom2/src/doomstat.c
+++ b/prboom2/src/doomstat.c
@@ -57,7 +57,7 @@ complevel_t compatibility_level;
 // it's required for demos recorded in "demo compatibility" mode by boom201 for example
 int demover;
 
-int comp[MBF_COMP_TOTAL];    // killough 10/98
+int comp[COMP_TOTAL];    // killough 10/98
 int default_comperr[COMPERR_NUM];
 
 int demo_insurance;        // killough 1/16/98

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -116,6 +116,8 @@ enum {
   comp_friendlyspawn,
   comp_voodooscroller,
   comp_reservedlineflag,
+  comp_thingsectorlight,
+  COMP_TOTAL,
 
   MBF_COMP_TOTAL = 32  // limit in MBF format
 };
@@ -128,7 +130,7 @@ enum {
   COMPERR_NUM
 };
 
-extern int comp[MBF_COMP_TOTAL];
+extern int comp[COMP_TOTAL];
 extern int default_comperr[COMPERR_NUM];
 
 // -------------------------------------------

--- a/prboom2/src/dsda/options.c
+++ b/prboom2/src/dsda/options.c
@@ -100,6 +100,7 @@ static const dsda_options_t default_mbf_options = {
   // .comp_friendlyspawn = 1,
   // .comp_voodooscroller = 1,
   // .comp_reservedlineflag = 1,
+  // .comp_thingsectorlight = 1,
 };
 
 static const dsda_options_t default_latest_options = {
@@ -148,6 +149,7 @@ static const dsda_options_t default_latest_options = {
   .comp_friendlyspawn = 1,
   .comp_voodooscroller = 0,
   .comp_reservedlineflag = 1,
+  .comp_thingsectorlight = 0,
 };
 
 static dsda_options_t mbf_options;
@@ -198,6 +200,7 @@ static dsda_option_t option_list[] = {
   { "comp_friendlyspawn", &mbf_options.comp_friendlyspawn, 0, 1 },
   { "comp_voodooscroller", &mbf_options.comp_voodooscroller, 0, 1 },
   { "comp_reservedlineflag", &mbf_options.comp_reservedlineflag, 0, 1 },
+  { "comp_thingsectorlight", &mbf_options.comp_thingsectorlight, 0, 1 },
 
   { "mapcolor_back", NULL, 0, 255, dsda_config_mapcolor_back },
   { "mapcolor_grid", NULL, 0, 255, dsda_config_mapcolor_grid },
@@ -330,7 +333,7 @@ const dsda_options_t* dsda_Options(void) {
   return dsda_MBFOptions();
 }
 
-#define MBF21_COMP_TOTAL 25
+#define MBF21_COMP_TOTAL 26
 
 static int mbf21_comp_translation[MBF21_COMP_TOTAL] = {
   comp_telefrag,
@@ -358,6 +361,7 @@ static int mbf21_comp_translation[MBF21_COMP_TOTAL] = {
   comp_friendlyspawn,
   comp_voodooscroller,
   comp_reservedlineflag,
+  comp_thingsectorlight,
 };
 
 // killough 5/2/98: number of bytes reserved for saving options
@@ -461,6 +465,10 @@ const byte *dsda_ReadOptions21(const byte *demo_p) {
   if (count < 25)
     comp[mbf21_comp_translation[24]] = 0;
 
+  // comp_thingsectorlight
+  if (count < 26)
+    comp[mbf21_comp_translation[25]] = 0;
+  
   G_Compatibility();
 
   return demo_p;

--- a/prboom2/src/dsda/options.h
+++ b/prboom2/src/dsda/options.h
@@ -62,6 +62,7 @@ typedef struct dsda_options {
   int comp_friendlyspawn;
   int comp_voodooscroller;
   int comp_reservedlineflag;
+  int comp_thingsectorlight;
 } dsda_options_t;
 
 void dsda_ParseOptionsLump(void);

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2712,11 +2712,13 @@ void G_Compatibility(void)
     // comp_voodooscroller - Voodoo dolls on slow scrollers move too slowly
     { mbf21_compatibility, mbf21_compatibility },
     // comp_reservedlineflag - ML_RESERVED clears extended flags
-    { mbf21_compatibility, mbf21_compatibility }
+    { mbf21_compatibility, mbf21_compatibility },
+    // comp_thingsectorlight - MObjs are lit according to the average of transferred light levels
+    { mbf21_compatibility, mbf21_compatibility },
   };
   unsigned int i;
 
-  if (sizeof(levels)/sizeof(*levels) != MBF_COMP_TOTAL)
+  if (sizeof(levels)/sizeof(*levels) != COMP_TOTAL)
     I_Error("G_Compatibility: consistency error");
 
   for (i = 0; i < sizeof(levels)/sizeof(*levels); i++)
@@ -2856,6 +2858,7 @@ void G_ReloadDefaults(void)
     comp[comp_friendlyspawn] = options->comp_friendlyspawn;
     comp[comp_voodooscroller] = options->comp_voodooscroller;
     comp[comp_reservedlineflag] = options->comp_reservedlineflag;
+    comp[comp_thingsectorlight] = options->comp_thingsectorlight;
   }
 
   G_Compatibility();

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2713,7 +2713,7 @@ void G_Compatibility(void)
     { mbf21_compatibility, mbf21_compatibility },
     // comp_reservedlineflag - ML_RESERVED clears extended flags
     { mbf21_compatibility, mbf21_compatibility },
-    // comp_thingsectorlight - MObjs are lit according to the average of transferred light levels
+    // comp_thingsectorlight - Sprites are lit according to the average of transferred light levels
     { mbf21_compatibility, mbf21_compatibility },
   };
   unsigned int i;

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -927,8 +927,7 @@ void R_AddSprites(subsector_t* subsec, int lightlevel)
   sector_t* sec=subsec->sector;
   mobj_t *thing;
 
-  if (compatibility_level <= boom_202_compatibility)
-    lightlevel = sec->lightlevel;
+  lightlevel = (comp[comp_thingsectorlight]) ? lightlevel : sec->lightlevel;
 
   // Handle all things in sector.
 


### PR DESCRIPTION
`Alongside the fake heights transfer (242), Boom also introduced two separate line specials that individually transfer floor and ceiling light levels (213 and 261) onto a tagged sector. Normally, in Boom and CL9, any Things present in said sector will be lit according to the sector's normal light level. MBF, however, changed this behavior to decide a Thing's light level using the average of the transferred floor and ceiling light levels, instead.`

Not only is the MBF behavior incredibly unpopular among mappers, the choice of which behavior is also widely inconsistent among ports. Some ports will only use the Boom behavior of defining a Thing's light level based on the true sector, some will only use the MBF behavior and others will only read the transferred floor light level, instead. This proposition formally defines the behavior in question as part of MBF21.

Relevant:
https://github.com/doom-cross-port-collab/issue-tracker/issues/1
https://github.com/kraflab/mbf21/pull/6
https://github.com/fabiangreffrath/woof/pull/2393
https://github.com/team-eternity/eternity/pull/740
https://github.com/odamex/odamex/pull/1499