### PR TITLE
Add `libsndfile` to the `apt-get` line

### DIFF
--- a/prboom2/INSTALL
+++ b/prboom2/INSTALL
@@ -11,6 +11,7 @@ Prerequisites
      * MAD (MP3)
      * libxmp (various tracker-style formats)
      * vorbisfile (OGG)
+     * libsndfile (???)
 
 You will need `cmake` and `make` if you haven't already installed them.
 
@@ -18,7 +19,7 @@ On a typical Debian or Ubuntu system, these commands may be sufficient:
 `sudo apt install build-essential cmake git`
 
 As well as the following:
-`sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libfluidsynth-dev libportmidi-dev libmad0-dev libxmp-dev libvorbis-dev libzip-dev zipcmp zipmerge ziptool fluidsynth libglu1-mesa-dev`
+`sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libfluidsynth-dev libportmidi-dev libmad0-dev libxmp-dev libvorbis-dev libzip-dev zipcmp zipmerge ziptool fluidsynth libglu1-mesa-dev libsndfile1-dev`
 
 On a typical Fedora system, these commands may be sufficient:
 `dnf install cmake git gcc gcc-g++`


### PR DESCRIPTION
It was failing like this without that:
```
-- Checking for module 'sndfile'
--   No package 'sndfile' found
CMake Error at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:165 (message):
  Could NOT find SndFile (missing: SndFile_LIBRARY SndFile_INCLUDE_DIR)
  (Required is at least version "1.0.29")
Call Stack (most recent call first):
  /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:458 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindSndFile.cmake:28 (find_package_handle_standard_args)
  cmake/DsdaDependencies.cmake:25 (find_package)
  CMakeLists.txt:34 (include)

-- Configuring incomplete, errors occurred!
```