### PR TITLE
Fix potential out-of-bounds read in scanner

### DIFF
--- a/prboom2/src/scanner.cpp
+++ b/prboom2/src/scanner.cpp
@@ -643,7 +643,7 @@ void Scanner::Unescape(char *str)
 		if (c != '\\') {
 			*str++ = c;
 		}
-		else {
+		else if (*p) {
 			switch (*p) {
 			case 'a':
 				*str++ = '\a';
@@ -718,6 +718,10 @@ void Scanner::Unescape(char *str)
 				break;
 			}
 			p++;
+		}
+		else
+		{
+			// Trailing backslash
 		}
 	}
 	*str = 0;


### PR DESCRIPTION
Brought to our attention here:
https://github.com/fabiangreffrath/woof/pull/2521

This is already fixed in G/UZDoom's scanner code, though not ZDoom's