### PR TITLE
Fixes autoloaded HELP lumps being treated as missing

### DIFF
--- a/prboom2/src/w_wad.c
+++ b/prboom2/src/w_wad.c
@@ -610,7 +610,7 @@ int W_LumpNumExists(int lump)
 
 int W_PWADLumpNumExists(int lump)
 {
-  return W_LumpNumExists(lump) && (lumpinfo[lump].source == source_pwad);
+  return W_LumpNumExists(lump) && (lumpinfo[lump].source == source_pwad || lumpinfo[lump].source == source_auto_load);
 }
 
 int W_LumpNameExists(const char *name)


### PR DESCRIPTION
Autoloading a WAD that replaces HELP and/or CREDIT lump, causes those lumps not to appear while while pressing F1, instead defaulting to dsda-doom credits.