### PR TITLE
Actually fix "Always Pistol Start" revert in save games (for real this time guys)

### DIFF
--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -168,8 +168,9 @@ void dsda_UnArchiveGameModifiers(void)
   P_LOAD_X(saved_coop_spawns);
 
   // If "Always Pistol Start" is enabled, skip resetting "Pistol Start" upon load
-  if (!dsda_IntConfig(dsda_config_always_pistol_start) && dsda_IntConfig(dsda_config_pistol_start))
-    dsda_UpdateIntConfig(dsda_config_pistol_start,     saved_pistolstart, true);
+  if (!dsda_IntConfig(dsda_config_always_pistol_start))
+    dsda_UpdateIntConfig(dsda_config_pistol_start,   saved_pistolstart, true);
+
   dsda_UpdateIntConfig(dsda_config_respawn_monsters, saved_respawnparm, true);
   dsda_UpdateIntConfig(dsda_config_fast_monsters,    saved_fastparm,    true);
   dsda_UpdateIntConfig(dsda_config_no_monsters,      saved_nomonsters,  true);


### PR DESCRIPTION
This is an amendment to #793 , which for months I've fixed in Nyan, but didn't get around to updating DSDA-Doom. Thankfully a new version hasn't released yet :)

This will actually be the final fix for this...