### PR TITLE
Add joy strafe restrictions

### DIFF
--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -35,6 +35,7 @@
  *-----------------------------------------------------------------------------
  */
 
+#include <math.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -1435,7 +1436,7 @@ dboolean G_Responder (event_t* ev)
     case ev_move_analog:
       dsda_WatchGameControllerEvent();
 
-      left_analog_x = ev->data1.f;
+      left_analog_x = dsda_StrictMode() ? lroundf(ev->data1.f * 0.5f) * 2 : ev->data1.f;
       left_analog_y = ev->data2.f;
       return true;    // eat events
 


### PR DESCRIPTION
XDRE examples:

With strict mode:
<img width="46" height="147" alt="after" src="https://github.com/user-attachments/assets/cf50fbda-379c-462f-b420-240fb8efad4c" />

Without strict mode:
<img width="35" height="115" alt="before" src="https://github.com/user-attachments/assets/b88b095b-6d8c-4001-b024-8cd0f992982c" />