### PR TITLE
Fix fighter flechette exploding on the player when using freelook

### DIFF
--- a/prboom2/src/dsda/aim.c
+++ b/prboom2/src/dsda/aim.c
@@ -36,7 +36,7 @@ fixed_t dsda_PlayerSlope(player_t* player)
 
 int dsda_PitchToLookDir(angle_t pitch)
 {
-  return -(int) ((((uint64_t) pitch * FIXED_PI) >> FRACBITS) / ANG1);
+  return -(int) ((((long long)(int) pitch * FIXED_PI) >> FRACBITS) / ANG1);
 }
 
 angle_t dsda_LookDirToPitch(int lookdir)


### PR DESCRIPTION
Yeah so fun thing... while using freelook and playing the Fighter class in Hexen, throwing a flechette would result in it blowing up where the player was...

This fixes that.