### PR TITLE
Print date and time in the Load/Save Game menus in the current locale

### DIFF
--- a/prboom2/src/SDL/i_main.c
+++ b/prboom2/src/SDL/i_main.c
@@ -68,6 +68,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <locale.h>
 
 #include "e6y.h"
 
@@ -292,6 +293,9 @@ int main(int argc, char **argv)
   lprintf(LO_DEBUG, "M_LoadDefaults: Load system defaults.\n");
   M_LoadDefaults();              // load before initing other systems
   lprintf(LO_DEBUG, "\n");
+
+  // Print date and time in the Load/Save Game menus in the current locale
+  setlocale(LC_TIME, "");
 
   /* Version info */
   PrintVer();

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -1482,7 +1482,7 @@ static void M_QuickSave(void)
   time (&now);
   timeinfo = localtime (&now);
 
-  strftime(description, sizeof(description), "quick %x %X", timeinfo);
+  strftime(description, sizeof(description), "%x %X", timeinfo);
 
   G_SaveGame(QUICKSAVESLOT, description);
   doom_printf("%s", description);


### PR DESCRIPTION
Fixes #818