### PR TITLE
Remove path when checking IWAD name

### DIFF
--- a/prboom2/src/SDL/i_system.c
+++ b/prboom2/src/SDL/i_system.c
@@ -451,6 +451,28 @@ static const char *I_GetBasePath(void)
   return executable_dir;
 }
 
+const char* I_FileNameFromPath(const char *path)
+{
+  const char *filename = path;
+  const char *p;
+
+  // Find last path separator
+  for (p = path; *p; ++p)
+  {
+    if (*p == '/'
+#if defined(_WIN32)
+        || *p == '\\'
+#endif
+#if defined(AMIGA)
+        || *p == ':'
+#endif
+        )
+      filename = p + 1;
+  }
+
+  return filename;
+}
+
 /*
  * I_FindFile
  *

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1188,23 +1188,14 @@ static char *FindIWADFile(void)
   return iwad;
 }
 
-static dboolean FileMatchesIWAD(const char *name)
+static dboolean FileMatchesIWAD(const char *path)
 {
   int i;
-  int name_length;
+  const char* wadname = I_FileNameFromPath(path);
 
-  name_length = strlen(name);
   for (i = 0; i < nstandard_iwads; ++i)
-  {
-    int iwad_length;
-
-    iwad_length = strlen(standard_iwads[i]);
-    if (
-      name_length >= iwad_length &&
-      !stricmp(name + name_length - iwad_length, standard_iwads[i])
-    )
+    if (!stricmp(wadname, standard_iwads[i]))
       return true;
-  }
 
   return false;
 }

--- a/prboom2/src/i_system.h
+++ b/prboom2/src/i_system.h
@@ -80,6 +80,7 @@ const char *I_ExeDir(void); // killough 2/16/98: path to executable's dir
 const char *I_ConfigDir(void); // path to config and autoload dir
 
 dboolean HasTrailingSlash(const char* dn);
+const char* I_FileNameFromPath(const char *path);
 char* I_RequireFile(const char* wfname, const char* ext);
 char* I_FindFile(const char* wfname, const char* ext);
 const char* I_FindFile2(const char* wfname, const char* ext);


### PR DESCRIPTION
- Fixes stuff like paintitdoom.wad

Let me know if I missed something, I used the directory format from `HasTrailingSlash()`, but I'm a bit unfamiliar with how Linux/Mac paths work.