### PR TITLE
Fix REKKR bow being offset to the right when using opengl

### DIFF
--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1146,7 +1146,7 @@ static void R_DrawPSprite (pspdef_t *psp)
   // Move the weapon down for 1280x1024.
   vis->texturemid -= psprite_offset;
 
-  vis->x1 = x1 < 0 ? 0 : x1;
+  vis->x1 = x1;
   vis->x2 = x2 >= viewwidth ? viewwidth-1 : x2;
 // proff 11/06/98: Added for high-res
   vis->scale = pspriteyscale;


### PR DESCRIPTION
[Someone mentioned this](https://desuarchive.org/vr/thread/12413141/#12422947) in /vr/doom/. 
<img width="1920" height="1080" alt="doom04" src="https://github.com/user-attachments/assets/9080d569-7871-4fae-aedf-1483ce8ceb13" />
Now matches the software mode.