### PR TITLE
OpenGL wide weapon alignment fix

### DIFF
--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -800,7 +800,9 @@ void gld_DrawWeapon(int weaponlump, vissprite_t *vis, int lightlevel)
   // More precise weapon drawing:
   // Shotgun from DSV3_War looks correctly now. Especially during movement.
   // There is no more line of graphics under certain weapons.
-  x1 = vis->x1;
+  //
+  // [AR] fix wide opengl weapons alignment
+  x1 = vis->gx1;
   x2 = roundf(x1 + gltexture->realtexwidth * pspritexscale_f);
   y1 = roundf(viewheight / 2.0 - vis->texturemid * pspriteyscale_f / FRACUNIT);
   y2 = roundf(y1 + gltexture->realtexheight * pspriteyscale_f);

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -491,6 +491,7 @@ typedef struct
 typedef struct vissprite_s
 {
   short x1, x2;
+  short gx1;                   // [AR] opengl weapon alignment
   fixed_t gx, gy;              // for line side calculation
   fixed_t gz, gzt;             // global bottom / top for silhouette clipping
   fixed_t startfrac;           // horizontal position of x1

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -1030,6 +1030,7 @@ static int PSpriteSY[NUMCLASSES][NUMWEAPONS] = {
 static void R_DrawPSprite (pspdef_t *psp)
 {
   int           x1, x2;
+  int           gx1;
   spritedef_t   *sprdef;
   spriteframe_t *sprframe;
   int           lump;
@@ -1118,6 +1119,9 @@ static void R_DrawPSprite (pspdef_t *psp)
     tx -= patch->leftoffset<<FRACBITS;
     x1 = (centerxfrac + FixedMul (tx,pspritexscale))>>FRACBITS;
 
+    // [AR] opengl weapon alignment
+    gx1 = x1;
+
     tx += patch->width<<FRACBITS;
     x2 = ((centerxfrac + FixedMul (tx, pspritexscale) ) >>FRACBITS) - 1;
 
@@ -1148,6 +1152,10 @@ static void R_DrawPSprite (pspdef_t *psp)
 
   vis->x1 = x1 < 0 ? 0 : x1;
   vis->x2 = x2 >= viewwidth ? viewwidth-1 : x2;
+
+  // [AR] opengl weapon alignment
+  vis->gx1 = gx1;
+
 // proff 11/06/98: Added for high-res
   vis->scale = pspriteyscale;
   vis->color = 0;
@@ -1217,6 +1225,8 @@ static void R_DrawPSprite (pspdef_t *psp)
     {
       int x1;
       int x1_prev;
+      int gx1;
+      int gx1_prev;
       int texturemid;
       int texturemid_prev;
       int lump;
@@ -1227,10 +1237,12 @@ static void R_DrawPSprite (pspdef_t *psp)
     if (realframe)
     {
       psp_inter.x1 = psp_inter.x1_prev;
+      psp_inter.gx1 = psp_inter.gx1_prev;
       psp_inter.texturemid = psp_inter.texturemid_prev;
     }
 
     psp_inter.x1_prev = vis->x1;
+    psp_inter.gx1_prev = vis->gx1;
     psp_inter.texturemid_prev = vis->texturemid;
 
     // Do not interpolate on the first tic of the level
@@ -1240,12 +1252,14 @@ static void R_DrawPSprite (pspdef_t *psp)
       {
         int deltax = vis->x2 - vis->x1;
         vis->x1 = psp_inter.x1 + FixedMul (tic_vars.frac, (vis->x1 - psp_inter.x1));
+        vis->gx1 = psp_inter.gx1 + FixedMul(tic_vars.frac, (vis->gx1 - psp_inter.gx1));
         vis->x2 = vis->x1 + deltax;
         vis->texturemid = psp_inter.texturemid + FixedMul (tic_vars.frac, (vis->texturemid - psp_inter.texturemid));
       }
       else
       {
         psp_inter.x1 = vis->x1;
+        psp_inter.gx1 = vis->gx1;
         psp_inter.texturemid = vis->texturemid;
         psp_inter.lump=lump;
       }


### PR DESCRIPTION
This is kind of a response to #853 .

I didn't like how that PR was changing the software drawing path. Software clamps `x1` for a reason.

I think it would be better to pass the original x1 data before the clamp over to GL instead.