### PR TITLE
Bring back the `-loadgame` parameter (but not `-recordfrom`)

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -1919,7 +1919,7 @@ static void IdentifyVersion (void)
 
 static void D_DoomMainSetup(void)
 {
-  int p;
+  int p, slot = -1;
   dsda_arg_t *arg;
   dboolean autoload;
 
@@ -2229,10 +2229,19 @@ static void D_DoomMainSetup(void)
     dsda_SetDemoBaseName(arg->value.v_string);
     dsda_InitDemoRecording();
   }
+  else
+  {
+    arg = dsda_Arg(dsda_arg_loadgame);
+    if (arg->found)
+    {
+      slot = arg->value.v_int;
+      G_LoadGame(slot, true);
+    }
+  }
 
   dsda_ExecutePlaybackOptions();
 
-  if (!userdemo)
+  if (slot == -1 && !userdemo)
   {
     if (autostart || netgame)
     {

--- a/prboom2/src/dsda/args.c
+++ b/prboom2/src/dsda/args.c
@@ -73,6 +73,11 @@ static arg_config_t arg_config[dsda_arg_count] = {
     "loads additional deh files",
     arg_string_array, AT_LEAST_ONE_STRING,
   },
+  [dsda_arg_loadgame] = {
+    "-loadgame", NULL, NULL,
+    "loads the given savegame slot",
+    arg_int, 0, 118,
+  },
   [dsda_arg_playdemo] = {
     "-playdemo", NULL, NULL,
     "plays the given demo file",

--- a/prboom2/src/dsda/args.h
+++ b/prboom2/src/dsda/args.h
@@ -25,6 +25,7 @@ typedef enum {
   dsda_arg_iwad,
   dsda_arg_file,
   dsda_arg_deh,
+  dsda_arg_loadgame,
   dsda_arg_playdemo,
   dsda_arg_playlump,
   dsda_arg_timedemo,

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -161,6 +161,7 @@ int             gameepisode;
 int             gamemap;
 // CPhipps - moved *_loadgame vars here
 static dboolean forced_loadgame = false;
+static dboolean commandline_loadgame = false;
 static dboolean load_via_cmd = false;
 
 dboolean         timingdemo;    // if true, exit with report on completion
@@ -1641,6 +1642,7 @@ void G_Ticker (void)
             savegameslot = ex->load_slot;
             gameaction = ga_loadgame;
             forced_loadgame = true;
+            commandline_loadgame = false;
             load_via_cmd = true;
             R_SmoothPlaying_Reset(NULL);
           }
@@ -2358,7 +2360,7 @@ void G_ForcedLoadGame(void)
 }
 
 // killough 3/16/98: add slot info
-void G_LoadGame(int slot)
+void G_LoadGame(int slot, dboolean via_commandline)
 {
   if (demorecording)
   {
@@ -2366,7 +2368,7 @@ void G_LoadGame(int slot)
     return;
   }
 
-  if (!demoplayback)
+  if (!demoplayback && !via_commandline)
   {
     forced_loadgame = netgame; // CPhipps - always force load netgames
   }
@@ -2381,6 +2383,7 @@ void G_LoadGame(int slot)
 
   gameaction = ga_loadgame;
   savegameslot = slot;
+  commandline_loadgame = via_commandline;
   load_via_cmd = false;
   R_SmoothPlaying_Reset(NULL); // e6y
 }
@@ -2392,6 +2395,11 @@ static void G_LoadGameErr(const char *msg)
 {
   P_FreeSaveBuffer();
   M_ForcedLoadGame(msg);             // Print message asking for 'Y' to force
+  if (commandline_loadgame)
+  {
+    D_StartTitle();
+    gamestate = GS_DEMOSCREEN;
+  }
 }
 
 const char * comp_lev_str[MAX_COMPATIBILITY_LEVEL] =
@@ -2475,7 +2483,7 @@ void G_DoLoadGame(void)
   // [crispy] loaded game must always be single player.
   // Needed for ability to use a further game loading, as well as
   // cheat codes and other single player only specifics.
-  if (!load_via_cmd)
+  if (!commandline_loadgame && !load_via_cmd)
   {
     netgame = false;
     deathmatch = false;
@@ -3904,7 +3912,7 @@ const byte* G_ReadDemoHeaderEx(const byte *demo_p, size_t size, unsigned int par
     netgame = true;
   }
 
-  if (!(params & RDH_SKIP_HEADER))
+  if (!(params & RDH_SKIP_HEADER) && gameaction != ga_loadgame)
   {
     G_InitNew(skill, episode, map, true);
     demo_p = dsda_EvaluateDemoStartPoint(demo_p);

--- a/prboom2/src/g_game.h
+++ b/prboom2/src/g_game.h
@@ -49,7 +49,7 @@ void G_DeathMatchSpawnPlayer(int playernum);
 void G_InitNew(int skill, int episode, int map, dboolean prepare);
 void G_DeferedInitNew(int skill, int episode, int map);
 void G_DeferedPlayDemo(const char *demo); // CPhipps - const
-void G_LoadGame(int slot); // killough 5/15/98
+void G_LoadGame(int slot, dboolean via_commandline); // killough 5/15/98
 void G_ForcedLoadGame(void);           // killough 5/15/98: forced loadgames
 void G_DoLoadGame(void);
 void G_SaveGame(int slot, const char *description); // Called by M_Responder.

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -913,7 +913,7 @@ void M_LoadSelect(int choice)
   //  to g_game.c, this only passes the slot.
 
   // killough 3/16/98, 5/15/98: add slot, cmd
-  G_LoadGame(choice + current_page * g_menu_save_page_size);
+  G_LoadGame(choice + current_page * g_menu_save_page_size, false);
   M_ClearMenus();
 }
 
@@ -1521,7 +1521,7 @@ static void M_QuickLoad(void)
 
   if (M_FileExists(name))
   {
-    G_LoadGame(QUICKSAVESLOT);
+    G_LoadGame(QUICKSAVESLOT, false);
     doom_printf("quickload");
   }
   else


### PR DESCRIPTION
Fixes #572