### PR TITLE
Fix demo playback bar desync

### DIFF
--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -142,15 +142,36 @@ static void dsda_UnArchiveContext(void) {
   true_basetic = gametic - true_logictic_value;
 }
 
-int saved_pistolstart, saved_respawnparm, saved_fastparm, saved_nomonsters, saved_coop_spawns;
+static int saved_pistolstart;
+static int saved_respawnparm;
+static int saved_fastparm;
+static int saved_nomonsters;
+static int saved_coop_spawns;
 
-void dsda_ArchiveGameModifiers(void)
+static void dsda_GetGameModifiers(void)
 {
   saved_pistolstart = pistolstart;
   saved_respawnparm = respawnparm;
   saved_fastparm    = fastparm;
   saved_nomonsters  = nomonsters;
   saved_coop_spawns = coop_spawns;
+}
+
+static void dsda_SetGameModifiers(void)
+{
+  // If "Always Pistol Start" is enabled, skip resetting "Pistol Start"
+  if (!dsda_IntConfig(dsda_config_always_pistol_start))
+    dsda_UpdateIntConfig(dsda_config_pistol_start,saved_pistolstart,true);
+
+  dsda_UpdateIntConfig(dsda_config_respawn_monsters,saved_respawnparm,true);
+  dsda_UpdateIntConfig(dsda_config_fast_monsters,saved_fastparm,true);
+  dsda_UpdateIntConfig(dsda_config_no_monsters,saved_nomonsters,true);
+  dsda_UpdateIntConfig(dsda_config_coop_spawns,saved_coop_spawns,true);
+}
+
+static void dsda_ArchiveGameModifiers(void)
+{
+  dsda_GetGameModifiers();
 
   P_SAVE_X(saved_pistolstart);
   P_SAVE_X(saved_respawnparm);
@@ -159,7 +180,7 @@ void dsda_ArchiveGameModifiers(void)
   P_SAVE_X(saved_coop_spawns);
 }
 
-void dsda_UnArchiveGameModifiers(void)
+static void dsda_UnArchiveGameModifiers(void)
 {
   P_LOAD_X(saved_pistolstart);
   P_LOAD_X(saved_respawnparm);
@@ -167,14 +188,7 @@ void dsda_UnArchiveGameModifiers(void)
   P_LOAD_X(saved_nomonsters);
   P_LOAD_X(saved_coop_spawns);
 
-  // If "Always Pistol Start" is enabled, skip resetting "Pistol Start" upon load
-  if (!dsda_IntConfig(dsda_config_always_pistol_start))
-    dsda_UpdateIntConfig(dsda_config_pistol_start,   saved_pistolstart, true);
-
-  dsda_UpdateIntConfig(dsda_config_respawn_monsters, saved_respawnparm, true);
-  dsda_UpdateIntConfig(dsda_config_fast_monsters,    saved_fastparm,    true);
-  dsda_UpdateIntConfig(dsda_config_no_monsters,      saved_nomonsters,  true);
-  dsda_UpdateIntConfig(dsda_config_coop_spawns,      saved_coop_spawns, true);
+  dsda_SetGameModifiers();
 }
 
 void dsda_ArchiveAll(void) {

--- a/prboom2/src/dsda/save.c
+++ b/prboom2/src/dsda/save.c
@@ -159,6 +159,10 @@ static void dsda_GetGameModifiers(void)
 
 static void dsda_SetGameModifiers(void)
 {
+  // [AR] when playing / recording demos, do NOT touch configs
+  if (!allow_incompatibility)
+    return;
+
   // If "Always Pistol Start" is enabled, skip resetting "Pistol Start"
   if (!dsda_IntConfig(dsda_config_always_pistol_start))
     dsda_UpdateIntConfig(dsda_config_pistol_start,saved_pistolstart,true);


### PR DESCRIPTION
It's a pretty specific bug that I'm not sure how common it'd be to run across... Basically it's related to the temp game modifiers (fast, respawn, nomo, coop_spawns) and loading save games...

To be more specific, playing a demo front to back is fine and works with no issues... However if you have a demo that one of the above modifiers, AND seek forward using the demo progress bar, it seems that it could desync the demo. This caused a desync because when pressing on the demo progress bar, it is essentially loading a save game.

Again, playing demos in full or just playing normal demos play back fine.  It's only when fast, respawn, nomo, or coop_spawns were active and you clicked on the progress bar.