### PR TITLE
Fix SSG fire "bleeding line"

### DIFF
--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -349,6 +349,9 @@ void R_SetDefaultDrawColumnVars(draw_column_vars_t *dcvars) {
   dcvars->edgeslope = dcvars->drawingmasked = 0;
   dcvars->flags = 0;
 
+  // [AR] mark weapon sprite
+  dcvars->isplayersprite = false;
+
   // heretic
   dcvars->baseclip = -1;
 }

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -351,6 +351,7 @@ void R_SetDefaultDrawColumnVars(draw_column_vars_t *dcvars) {
 
   // [AR] mark weapon sprite
   dcvars->isplayersprite = false;
+  dcvars->pspritepostheight = 0;
 
   // heretic
   dcvars->baseclip = -1;

--- a/prboom2/src/r_draw.h
+++ b/prboom2/src/r_draw.h
@@ -79,6 +79,9 @@ typedef struct draw_column_vars_s
   int                 drawingmasked;
   unsigned int        flags; //e6y: for detect patches ind colfunc()
 
+  // [AR] mark weapon sprite
+  dboolean isplayersprite;
+
   // heretic
   int baseclip;
 } draw_column_vars_t;

--- a/prboom2/src/r_draw.h
+++ b/prboom2/src/r_draw.h
@@ -80,7 +80,8 @@ typedef struct draw_column_vars_s
   unsigned int        flags; //e6y: for detect patches ind colfunc()
 
   // [AR] mark weapon sprite
-  dboolean isplayersprite;
+  dboolean            isplayersprite;
+  int                 pspritepostheight;
 
   // heretic
   int baseclip;

--- a/prboom2/src/r_drawcolumn.inl
+++ b/prboom2/src/r_drawcolumn.inl
@@ -166,7 +166,20 @@ static void R_DRAWCOLUMN_FUNCNAME(draw_column_vars_t *dcvars)
     //
     // killough 2/1/98: more performance tuning
 
-    if (dcvars->texheight == 128) {
+    // [AR] Fix SSG fire bleeding bottom line
+    // Player sprites can round one row past the current post.
+    // Moved from R_DrawMaskedColumn() to fix >128 height (multi-post) psprites
+    if (dcvars->pspritepostheight) {
+      const fixed_t maxfrac = (dcvars->pspritepostheight << FRACBITS) - 1;
+
+      while (count--) {
+        const fixed_t pspritefrac = BETWEEN(0, maxfrac, frac);
+
+        *dest = GETCOL(pspritefrac);
+        dest += 4;
+        frac += fracstep;
+      }
+    } else if (dcvars->texheight == 128) {
       #define FIXEDT_128MASK ((127<<FRACBITS)|0xffff)
       while(count--) {
         *dest = GETCOL(frac & FIXEDT_128MASK);

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -501,6 +501,28 @@ void R_DrawMaskedColumn(
           // Drawn by either R_DrawColumn
           //  or (SHADOW) R_DrawFuzzColumn.
           dcvars->drawingmasked = 1; // POPE
+          // [AR] Fix SSG fire bleeding bottom line
+          // Player sprites can round one row past the current post.
+          if (dcvars->isplayersprite)
+          {
+            fixed_t post_end    = post->length << FRACBITS;
+            fixed_t frac_start  = dcvars->texturemid + (dcvars->yl - centery) * dcvars->iscale;
+            fixed_t frac_end    = dcvars->texturemid + (dcvars->yh - centery) * dcvars->iscale;
+
+            // Trim extra top rows of player sprite.
+            while (dcvars->yl <= dcvars->yh && frac_start < 0)
+            {
+              dcvars->yl++;
+              frac_start += dcvars->iscale;
+            }
+
+            // Trim extra bottom rows of player sprite.
+            while (dcvars->yl <= dcvars->yh && frac_end >= post_end)
+            {
+              dcvars->yh--;
+              frac_end -= dcvars->iscale;
+            }
+          }
           colfunc (dcvars);
           dcvars->drawingmasked = 0; // POPE
 
@@ -533,6 +555,9 @@ static void R_DrawVisSprite(vissprite_t *vis)
   R_SetDefaultDrawColumnVars(&dcvars);
 
   dcvars.colormap = vis->colormap;
+
+  if (vis->mobjflags & MF_PLAYERSPRITE)
+    dcvars.isplayersprite = true;
 
   // hexen_note: colfunc: No idea how to merge this right now...
   // if (vis->mobjflags & (MF_SHADOW | MF_ALTSHADOW))

--- a/prboom2/src/r_things.c
+++ b/prboom2/src/r_things.c
@@ -496,33 +496,12 @@ void R_DrawMaskedColumn(
           dcvars->nextsource = nextcolumn->pixels + post->topdelta;
 
           dcvars->texturemid = basetexturemid - (post->topdelta<<FRACBITS);
+          dcvars->pspritepostheight = dcvars->isplayersprite ? post->length : 0;
 
           dcvars->edgeslope = post->slope;
           // Drawn by either R_DrawColumn
           //  or (SHADOW) R_DrawFuzzColumn.
           dcvars->drawingmasked = 1; // POPE
-          // [AR] Fix SSG fire bleeding bottom line
-          // Player sprites can round one row past the current post.
-          if (dcvars->isplayersprite)
-          {
-            fixed_t post_end    = post->length << FRACBITS;
-            fixed_t frac_start  = dcvars->texturemid + (dcvars->yl - centery) * dcvars->iscale;
-            fixed_t frac_end    = dcvars->texturemid + (dcvars->yh - centery) * dcvars->iscale;
-
-            // Trim extra top rows of player sprite.
-            while (dcvars->yl <= dcvars->yh && frac_start < 0)
-            {
-              dcvars->yl++;
-              frac_start += dcvars->iscale;
-            }
-
-            // Trim extra bottom rows of player sprite.
-            while (dcvars->yl <= dcvars->yh && frac_end >= post_end)
-            {
-              dcvars->yh--;
-              frac_end -= dcvars->iscale;
-            }
-          }
           colfunc (dcvars);
           dcvars->drawingmasked = 0; // POPE
 


### PR DESCRIPTION
So this does work... I'm partly concerned that it could maybe be slightly taxing on the software renderer?

The PrBoom renderer is annoying because when it comes to drawing the player's weapons, it can sometimes bleed outside of the bounds, due to how it stretches sprites. This clamps it so that it never "wraps around".

This was extremely relevant in some resolutions, where when the SSG was fired on it's lowest point, the top of the SSG firing sprite would "wrap around" to the bottom of the sprite creating a red/orangish line as seen here:

<img width="372" height="350" alt="image" src="https://github.com/user-attachments/assets/8a2d4468-74b4-47c6-966b-275998063add" />

My resolution of testing was 2560x1440, where this could happen consistently. It's much more noticeable when running the [Minor Sprite Fix](https://www.doomworld.com/forum/topic/62403-doom-2-minor-sprite-fixing-project-v20-release-updated-112822/) which fixes the SSG firing animation (Nyan includes this [automatically](https://github.com/andrikpowell/nyan-doom/blob/0539454dfbeedb1b575f35adc485ef9a47d05e03/prboom2/src/deh/compatibility.c#L247-L254)).

Related is a PrBoom PR https://github.com/coelckers/prboom-plus/pull/181 and issue https://github.com/coelckers/prboom-plus/issues/95 that tried to fix the opposite with the bleeding on the top of the weapon. Maybe there's a way to simplify these fixes?