### PR TITLE
Add StartupWMClass to desktop file to fix icon display on some Linux desktops

### DIFF
--- a/prboom2/ICONS/dsda-doom.desktop
+++ b/prboom2/ICONS/dsda-doom.desktop
@@ -8,3 +8,4 @@ Exec=dsda-doom %F
 Categories=Game;ActionGame;
 MimeType=application/x-doom-wad;
 Keywords=first;person;shooter;doom;boom;mbf;prboom;
+StartupWMClass=dsda-doom


### PR DESCRIPTION
Some Linux desktop environments, such as KDE, match the running program to the desktop file based on the filename, which appears to be correct already, but others, like GNOME, instead use the StartupWMClass entry of the desktop file. DSDA's was missing this.

Before:
<img width="157" height="213" alt="image" src="https://github.com/user-attachments/assets/fe988e15-3c77-4d02-ac21-82d8fd858da3" />

After:
<img width="157" height="213" alt="image" src="https://github.com/user-attachments/assets/64adc941-f6ed-46cf-9027-0b4cd88c4fe7" />