### PR TITLE
Ensure integer parsing in config flags does not discard data.

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -15,6 +15,8 @@
 //	DSDA Config
 //
 
+#include <errno.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "am_map.h"
@@ -1484,9 +1486,18 @@ static void dsda_ParseConfigArg(int arg_id, dboolean persist) {
       conf = &dsda_config[id];
       if (conf->type == dsda_config_int) {
         int value;
+        char* str_end;
 
-        if (sscanf(key_value[1], "%i", &value) != 1)
-          I_Error("Config variable \"%s\" requires an integer value", key_value[0]);
+        errno = 0;
+        value = strtol(key_value[1], &str_end, 0);
+        if (errno != 0) {
+          I_Error("Config variable \"%s\" requires an integer value (was \"%s\", err \"%s\")",
+              key_value[0], key_value[1], strerror(errno));
+        }
+        if (*str_end != '\0') {
+          I_Error("Value for config variable \"%s\" was not converted into an integer in its entirety (was \"%s\")",
+          key_value[0], key_value[1]);
+        }
 
         dsda_InitIntConfig(conf, value, persist);
       }


### PR DESCRIPTION
When reading the values stored in the -assign and -update command line variables, sscanf is used to convert integer values.  However, sscanf has no ability to report an inability to parse the string in full, instead simply returning the number of arguments successfully converted. This means a flag value such as "a=1,b=2", will set a to 1 and silently discard the rest.

Here we replace sscanf with strtol.  By setting endptr and checking that its value is '\0' after being called, we ensure that the whole string was indeed read.  We also check the value of errno; the only possible error here should be EINVAL for a value outside the range of a long.