### PR TITLE
Minor fix to "demo loop" logic and Dynamic Credits

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -656,15 +656,41 @@ void D_PageTicker(void)
     D_AdvanceDemo();
 }
 
-// Check whether to skip IWAD Demos
-static int dsda_SkipIwadDemos(void)
+static dboolean dsda_IsBlankPWADLump(const char* lumpname)
 {
-  int pwaddemo = W_PWADLumpNameExists("DEMO1");
+  if (!W_PWADLumpNameExists(lumpname))
+    return false;
+
+  return lumpinfo[W_CheckNumForName(lumpname)].size == 0;
+}
+
+// Check whether to skip IWAD Demos
+static dboolean dsda_SimpleDemoLoop(void)
+{
+  int pwaddemos_start = W_PWADLumpNameExists("DEMO1");
   int pwadmaps = W_PWADMapExists();
 
-  if ((pwadmaps && !pwaddemo) || lumpinfo[W_CheckNumForName("DEMO1")].size == 0)
+  if ((pwadmaps && !pwaddemos_start) || dsda_IsBlankPWADLump("DEMO1"))
     return true;
-  
+
+  return false;
+}
+
+static dboolean dsda_ForcePWADCredit(void)
+{
+  if (W_PWADLumpNameExists("CREDIT"))
+  {
+    // Simple demo loop and PWAD CREDIT
+    if (dsda_SimpleDemoLoop())
+      return true;
+
+    // Normal demo loop
+    // Check if CREDIT is shown twice in demoloop, else skip dynamic credits
+    // Fixes condition with PWAD CREDIT + REAL DEMO1 + BLANK DEMO2
+    if (W_PWADLumpNameExists("DEMO1") && dsda_IsBlankPWADLump("DEMO2"))
+      return true;
+  }
+
   return false;
 }
 
@@ -696,7 +722,7 @@ static void D_PageDrawer(void)
     V_ClearBorder();
     V_DrawNamePatchFS(0, 0, 0, pagename, CR_DEFAULT, VPT_STRETCH);
   }
-  else if (dsda_SkipIwadDemos() && W_PWADLumpNameExists("CREDIT"))
+  else if (dsda_ForcePWADCredit())
     M_DrawCredits();
   else
     M_DrawCreditsDynamic();
@@ -842,7 +868,7 @@ void D_DoAdvanceDemo(void)
   if (demosequence == 6 && gamemode == commercial && !W_LumpNameExists("demo4"))
     demosequence = 0;
 
-  if (dsda_SkipIwadDemos())
+  if (dsda_SimpleDemoLoop())
   {
     // Skip blank / IWAD demos in PWADs
     if (demostates[demosequence][gamemode].func == G_DeferedPlayDemo)


### PR DESCRIPTION
This PR has some cleanup to make a few of these functions more clear...

Also I fixed a bit of an obscure condition that Xyzzy ran into, where the wad had:

```
TITLEPIC
DEMO1
CREDIT
DEMO2 - Blank
```

Which mostly worked, but due to how Dynamic Credits tends to replace the first CREDIT screen (since the second CREDIT would show after DEMO2), I added a condition where the PWAD CREDIT would be preferred when only one CREDIT is reached.