### PR TITLE
Fix interaction between -warp and negative -skiptic values.

### DIFF
--- a/prboom2/src/dsda/skip.c
+++ b/prboom2/src/dsda/skip.c
@@ -141,23 +141,16 @@ void dsda_EvaluateSkipModeInitNew(void) {
 }
 
 void dsda_EvaluateSkipModeBuildTiccmd(void) {
-  if (dsda_SkipMode() && gametic > 0)
-    if (
-      (
-        !skip_until_logictic &&
-        skip_until_map == -1 &&
-        demo_skiptics &&
-        (
-          demo_skiptics > 0 ?
-            gametic > demo_skiptics :
-            dsda_DemoTic() - demo_skiptics >= demo_tics_count
-        )
-      ) ||
-      (
-        demo_warp_reached && gametic - levelstarttic > demo_skiptics
-      )
-    )
-      dsda_ExitSkipMode();
+  dboolean at_target_tic;
+
+  if (!dsda_SkipMode() || gametic <= 0) return;
+
+  at_target_tic = demo_skiptics > 0 ?
+          gametic > demo_skiptics :
+          dsda_DemoTic() - demo_skiptics >= demo_tics_count;
+  if ((!skip_until_logictic && skip_until_map == -1 && demo_skiptics && at_target_tic) ||
+      (demo_warp_reached && at_target_tic))
+    dsda_ExitSkipMode();
 }
 
 void dsda_EvaluateSkipModeDoCompleted(void) {


### PR DESCRIPTION
The original code here has two separate clauses to handle -warp not being specified and not being specified, respectively.  However, only the first of them gives negative skiptic values the special handling promised in the flag help text.  The second just compares the current tics to the skiptic value, terminating immediately if it's negative.

This change calculates whether or not we're at the target tic once, then reuses it in both clauses of the if statement.  We also exit early if we're not in skip mode or the gametic isn't positive to reduce the overall nesting needed in this function.