### PR TITLE
Add ID24 music changer linedef support (for Doom / Heretic)

### DIFF
--- a/docs/guides/console.md
+++ b/docs/guides/console.md
@@ -123,10 +123,11 @@ The in-game console offers extra tools for advanced users, including adjusting p
 
 #### Line Manipulation
 - Line activation (use / cross / shoot)
-  - `player.activate_line <line_id>`
-  - `target.activate_line <line_id>`
-  - `mobj.activate_line <mobj_index> <line_id>`
-  - `boss.activate_line <mobj_index> <line_id>`
+  - "line_side" is optional. front sidedef = 0, back sidedef = 1.
+  - `player.activate_line <line_id> <line_side>`
+  - `target.activate_line <line_id> <line_side>`
+  - `mobj.activate_line <mobj_index> <line_id> <line_side>`
+  - `boss.activate_line <mobj_index> <line_id> <line_side>`
     - activates the line with the boss action flag set
 
 #### State Manipulation

--- a/docs/id24.md
+++ b/docs/id24.md
@@ -1,0 +1,49 @@
+# ID24
+
+DSDA-Doom supports some ID24 features, which currently only supported in Classic Doom (Vanilla-MBF21) and Heretic map formats.
+
+UDMF and Hexen do not support these features.
+
+## Line Specials
+
+### Music Changer Specials
+
+ID24 music line specials allow for mappers to change the current music track. These specials are allowed regardless of complevel.
+
+The linedef actions are similar in function to MUSINFO, but with a few differences:
+- Unlike MUSINFO's slight music change delay, these will change the music immediately
+- Set the upper texture to the music lump to activate via the front side of the linedef
+- Set the lower texutre to the music lump to activate via the back side of the linedef
+
+Unless using the "reset" lines, the music will not change if:
+- the texture lump set doesn't exist
+- the upper/lower textures are not set
+
+If using "reset" lines and the music track is blank, when activated the map's default looping music will start playing.
+
+ID | Usage | Description |
+| --- | --- | --- |
+2057 | W1 | Change music and make it loop only if a track is defined
+2058 | WR | Change music and make it loop only if a track is defined
+2059 | S1 | Change music and make it loop only if a track is defined
+2060 | SR | Change music and make it loop only if a track is defined
+2061 | G1 | Change music and make it loop only if a track is defined
+2062 | GR | Change music and make it loop only if a track is defined
+2063 | W1 | Change music and make it play only once
+2064 | WR | Change music and make it play only once
+2065 | S1 | Change music and make it play only once
+2066 | SR | Change music and make it play only once
+2067 | G1 | Change music and make it play only once
+2068 | GR | Change music and make it play only once
+2087 | W1 | Change music and make it loop, reset to looping default if no track defined
+2088 | WR | Change music and make it loop, reset to looping default if no track defined
+2089 | S1 | Change music and make it loop, reset to looping default if no track defined
+2090 | SR | Change music and make it loop, reset to looping default if no track defined
+2091 | G1 | Change music and make it loop, reset to looping default if no track defined
+2092 | GR | Change music and make it loop, reset to looping default if no track defined
+2093 | W1 | Change music and make it play only once, reset to looping default if no track defined
+2094 | WR | Change music and make it play only once, reset to looping default if no track defined
+2095 | S1 | Change music and make it play only once, reset to looping default if no track defined
+2096 | SR | Change music and make it play only once, reset to looping default if no track defined
+2097 | G1 | Change music and make it play only once, reset to looping default if no track defined
+2098 | GR | Change music and make it play only once, reset to looping default if no track defined

--- a/prboom2/src/dsda/console.c
+++ b/prboom2/src/dsda/console.c
@@ -201,26 +201,38 @@ static dboolean console_LevelSecretExit(const char* command, const char* args) {
   return true;
 }
 
-static dboolean console_ActivateLine(mobj_t* mobj, int id, dboolean bossaction) {
+static dboolean console_ActivateLine(mobj_t* mobj, int id, int side, dboolean bossaction) {
   if (!mobj || id < 0 || id >= numlines)
     return false;
 
   P_MapStart();
-  P_UseSpecialLine(mobj, &lines[id], 0, bossaction);
-  map_format.cross_special_line(&lines[id], 0, mobj, bossaction);
-  map_format.shoot_special_line(mobj, &lines[id]);
+  P_UseSpecialLine(mobj, &lines[id], side, bossaction);
+  map_format.cross_special_line(&lines[id], side, mobj, bossaction);
+  map_format.shoot_special_line(mobj, &lines[id], side);
   P_MapEnd();
 
   return true;
 }
 
 static dboolean console_PlayerActivateLine(const char* command, const char* args) {
+  int arg_count;
   int id;
+  int side;
 
-  if (sscanf(args, "%i", &id) != 1)
-    return false;
+  arg_count = sscanf(args, "%i %i", &id, &side);
 
-  return console_ActivateLine(target_player.mo, id, false);
+  if (arg_count == 1 || arg_count == 2)
+  {
+    // No side provided, use front side (0) by default
+    if (arg_count != 2)
+      side = 0;
+
+    side = BETWEEN(0, 1, side);
+
+    return console_ActivateLine(target_player.mo, id, side, false);
+  }
+
+  return false;
 }
 
 static dboolean console_PlayerSetHealth(const char* command, const char* args) {
@@ -1449,15 +1461,27 @@ static dboolean console_TargetTargetPlayer(const char* command, const char* args
 }
 
 static dboolean console_TargetActivateLine(const char* command, const char* args) {
+  int arg_count;
   int id;
+  int side;
   mobj_t* target;
 
-  if (sscanf(args, "%i", &id) != 1)
-    return false;
+  arg_count = sscanf(args, "%i %i", &id, &side);
 
-  target = HU_Target();
+  if (arg_count == 1 || arg_count == 2)
+  {
+    // No side provided, use front side (0) by default
+    if (arg_count != 2)
+      side = 0;
 
-  return console_ActivateLine(target, id, false);
+    side = BETWEEN(0, 1, side);
+
+    target = HU_Target();
+
+    return console_ActivateLine(target, id, side, false);
+  }
+
+  return false;
 }
 
 static dboolean console_TargetAddFlags(const char* command, const char* args) {
@@ -1696,16 +1720,27 @@ static dboolean console_MobjTargetPlayer(const char* command, const char* args) 
 }
 
 static dboolean console_MobjActivateLine(const char* command, const char* args) {
+  int arg_count;
   int id;
+  int side;
   int index;
   mobj_t* target;
 
-  if (sscanf(args, "%d %i", &index, &id) != 2)
-    return false;
+  arg_count = sscanf(args, "%d %i %i", &index, &id, &side);
 
-  target = dsda_FindMobj(index);
+  if (arg_count == 2 || arg_count == 3)
+  {
+    // No side provided, use front side (0) by default
+    if (arg_count != 3)
+      side = 0;
 
-  return console_ActivateLine(target, id, false);
+    side = BETWEEN(0, 1, side);
+
+    target = dsda_FindMobj(index);
+    return console_ActivateLine(target, id, side, false);
+  }
+
+  return false;
 }
 
 static dboolean console_MobjAddFlags(const char* command, const char* args) {
@@ -1775,16 +1810,27 @@ static dboolean console_MobjSetFlags(const char* command, const char* args) {
 }
 
 static dboolean console_BossActivateLine(const char* command, const char* args) {
+  int arg_count;
   int id;
+  int side;
   int index;
   mobj_t* target;
 
-  if (sscanf(args, "%d %i", &index, &id) != 2)
-    return false;
+  arg_count = sscanf(args, "%d %i %i", &index, &id, &side);
 
-  target = dsda_FindMobj(index);
+  if (arg_count == 1 || arg_count == 2)
+  {
+    // No side provided, use front side (0) by default
+    if (arg_count != 2)
+      side = 0;
 
-  return console_ActivateLine(target, id, true);
+    side = BETWEEN(0, 1, side);
+
+    target = dsda_FindMobj(index);
+    return console_ActivateLine(target, id, side, true);
+  }
+
+  return false;
 }
 
 static dboolean console_Spawn(const char* command, const char* args) {

--- a/prboom2/src/dsda/map_format.c
+++ b/prboom2/src/dsda/map_format.c
@@ -258,8 +258,8 @@ extern void P_CrossZDoomSpecialLine(line_t *line, int side, mobj_t *thing, dbool
 extern void P_CrossHereticSpecialLine(line_t *line, int side, mobj_t *thing, dboolean bossaction);
 extern void P_CrossHexenSpecialLine(line_t *line, int side, mobj_t *thing, dboolean bossaction);
 
-extern void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line);
-extern void P_ShootHexenSpecialLine(mobj_t *thing, line_t *line);
+extern void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line, int side);
+extern void P_ShootHexenSpecialLine(mobj_t *thing, line_t *line, int side);
 
 extern dboolean P_TestActivateZDoomLine(line_t *line, mobj_t *mo, int side, line_activation_t activationType);
 extern dboolean P_TestActivateHexenLine(line_t *line, mobj_t *mo, int side, line_activation_t activationType);

--- a/prboom2/src/dsda/map_format.h
+++ b/prboom2/src/dsda/map_format.h
@@ -49,7 +49,7 @@ typedef struct {
   void (*spawn_pusher)(line_t*);
   void (*spawn_extra)(line_t*, int);
   void (*cross_special_line)(line_t *, int, mobj_t *, dboolean);
-  void (*shoot_special_line)(mobj_t *, line_t *);
+  void (*shoot_special_line)(mobj_t *, line_t *, int);
   dboolean (*test_activate_line)(line_t *, mobj_t *, int, line_activation_t);
   dboolean (*execute_line_special)(int, int *, line_t *, int, mobj_t *);
   void (*post_process_line_special)(line_t *);

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -1442,7 +1442,7 @@ void P_CheckHereticImpact(mobj_t *thing)
 
   for (i = numspechit - 1; i >= 0; i--)
   {
-    map_format.shoot_special_line(thing->target, spechit[i]);
+    map_format.shoot_special_line(thing->target, spechit[i], 0);
   }
 }
 
@@ -2329,7 +2329,10 @@ dboolean PTR_ShootTraverse (intercept_t* in)
     line_t *li = in->d.line;
 
     if (li->special)
-      map_format.shoot_special_line(shootthing, li);
+    {
+	    int side = P_PointOnLineSide(shootthing->x, shootthing->y, li);
+      map_format.shoot_special_line(shootthing, li, side);
+    }
 
     if (map_format.zdoom && li->special == zl_line_horizon)
       return false;

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -211,6 +211,10 @@ void P_ArchiveWorld (void)
     P_SAVE_X(li->health);
     P_SAVE_X(li->alpha);
 
+    // ID24
+    P_SAVE_X(li->frontmusic);
+    P_SAVE_X(li->backmusic);
+
     for (j = 0; j < 2; j++)
       if (li->sidenum[j] != NO_INDEX)
       {
@@ -308,6 +312,10 @@ void P_UnArchiveWorld (void)
     P_LOAD_X(li->automap_style);
     P_LOAD_X(li->health);
     P_LOAD_X(li->alpha);
+
+    // ID24
+    P_LOAD_X(li->frontmusic);
+    P_LOAD_X(li->backmusic);
 
     if (li->alpha < 1.f)
       li->tranmap = dsda_TranMap(dsda_FloatToPercent(li->alpha));

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -2404,8 +2404,67 @@ static void P_AllocateUDMFSideDefs(int lump)
   sides = calloc_IfSameLevel(sides, numsides, sizeof(side_t));
 }
 
+dboolean P_PostProcessID24MusicSidedefSpecial(side_t *sd, const char *bottom, const char *mid, const char *top, sector_t *sec, int i)
+{
+  dboolean found = false;
+
+  switch (sd->special)
+  {
+    case 2057: case 2058: case 2059: case 2060: case 2061: case 2062:
+    case 2063: case 2064: case 2065: case 2066: case 2067: case 2068:
+    case 2087: case 2088: case 2089: case 2090: case 2091: case 2092:
+    case 2093: case 2094: case 2095: case 2096: case 2097: case 2098:
+    {
+      // All of the W1, WR, S1, SR, G1, GR activations can be triggered from
+      // the back sidedef (reading the front bottom texture) and triggered
+      // from the front sidedef (reading the front upper texture).
+      for (int j = 0; j < numlines; j++)
+      {
+        if (lines[j].sidenum[0] == i)
+        {
+          // Back triggered
+          if ((lines[j].backmusic = W_CheckNumForName(bottom)) < 0)
+          {
+            lines[j].backmusic = 0;
+            sd->bottomtexture = R_TextureNumForName(bottom);
+          }
+          else
+          {
+            sd->bottomtexture = 0;
+          }
+
+          // Front triggered
+          if ((lines[j].frontmusic = W_CheckNumForName(top)) < 0)
+          {
+            lines[j].frontmusic = 0;
+            sd->toptexture = R_TextureNumForName(top);
+          }
+          else
+          {
+            sd->toptexture = 0;
+          }
+        }
+      }
+
+      // Allow midtextures
+      sd->midtexture = R_SafeTextureNumForName(mid, i);
+
+      found = true;
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return found;
+}
+
 void P_PostProcessCompatibleSidedefSpecial(side_t *sd, const char *bottom, const char *mid, const char *top, sector_t *sec, int i)
 {
+  if (P_PostProcessID24MusicSidedefSpecial(sd, bottom, mid, top, sec, i))
+    return;
+
   // killough 4/4/98: allow sidedef texture names to be overloaded
   // killough 4/11/98: refined to allow colormaps to work as wall
   // textures if invalid as colormaps but valid as textures.

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -54,6 +54,7 @@
 #include "p_inter.h"
 #include "p_enemy.h"
 #include "s_sound.h"
+#include "s_advsound.h"
 #include "sounds.h"
 #include "i_sound.h"
 #include "m_bbox.h"                                         // phares 3/20/98
@@ -1378,6 +1379,30 @@ int P_CheckTag(line_t *line)
 
     case 48:                // Scrolling walls
     case 85:
+    case 2057:              // ID24 Music changers
+    case 2058:
+    case 2059:
+    case 2060:
+    case 2061:
+    case 2062:
+    case 2063:
+    case 2064:
+    case 2065:
+    case 2066:
+    case 2067:
+    case 2068:
+    case 2087:
+    case 2088:
+    case 2089:
+    case 2090:
+    case 2091:
+    case 2092:
+    case 2093:
+    case 2094:
+    case 2095:
+    case 2096:
+    case 2097:
+    case 2098:
       return 1;   // zero tag allowed
 
     default:
@@ -1568,6 +1593,71 @@ void P_CrossHexenSpecialLine(line_t *line, int side, mobj_t *thing, dboolean bos
   {
     P_ActivateLine(line, thing, side, SPAC_PCROSS);
   }
+}
+
+//
+// EV_ChangeMusic() -- ID24 Music Changers
+//
+// Generic solution for changing the currently playing music during play time.
+// There are four type of music changing behavior, all of them available in all
+// six major activation triggers (W1, WR, S1, SR, G1, GR) totalling 24 lines.
+// All specials can be triggered from either side of the line being activated.
+// Of the four categories, there are two conditions:
+//
+//  1. If the given music lump will loop or not
+//  2. If it will reset to the map's default when no music lump is defined
+//
+// Giving the four resulting categories:
+// * Change music and make it loop only if a track is defined.
+// * Change music and make it play only once and stop all music after.
+// * Change music and make it loop, reset to looping default if no track
+//    defined.
+// * Change music and make it play only once, reset to looping default if no
+//    track defined.
+//
+
+void EV_ChangeMusic(line_t *line, int side)
+{
+  dboolean once = false;
+  dboolean loops = false;
+  dboolean resets = false;
+
+  int music = side ? line->backmusic : line->frontmusic;
+
+  switch (line->special)
+  {
+    case 2057: case 2059: case 2061: case 2063:
+    case 2065: case 2067: case 2087: case 2089:
+    case 2091: case 2093: case 2095: case 2097:
+      once = true;
+      break;
+  }
+
+  switch (line->special)
+  {
+    case 2057: case 2058: case 2059: case 2060:
+    case 2061: case 2062: case 2087: case 2088:
+    case 2089: case 2090: case 2091: case 2092:
+      loops = true;
+      break;
+  }
+
+  switch (line->special)
+  {
+    case 2087: case 2088: case 2089: case 2090:
+    case 2091: case 2092: case 2093: case 2094:
+    case 2095: case 2096: case 2097: case 2098:
+      resets = true;
+      break;
+  }
+
+  if (music)
+    S_ChangeMusInfoMusic(music, loops);
+  else if (resets)
+    S_ChangeMusInfoMusic(musinfo.items[0], true); // Always loops when defaulting
+
+  if (once)
+    line->special = 0;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -2191,6 +2281,12 @@ void P_CrossCompatibleSpecialLine(line_t *line, int side, mobj_t *thing, dboolea
       EV_DoFloor(line,raiseFloorTurbo);
       break;
 
+    case 2057: case 2063: case 2087: case 2093:
+    case 2058: case 2064: case 2088: case 2094:
+      // ID24 Music Changers
+      EV_ChangeMusic(line, side);
+      break;
+
       // Extended walk triggers
 
       // jff 1/29/98 added new linedef types to fill all functions out so that
@@ -2538,7 +2634,7 @@ void P_CrossZDoomSpecialLine(line_t *line, int side, mobj_t *thing, dboolean bos
 // impacted. Change is qualified by demo_compatibility.
 //
 
-void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
+void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line, int side)
 {
   //jff 02/04/98 add check here for generalized linedef
   if (!demo_compatibility)
@@ -2680,6 +2776,17 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
         P_ChangeSwitchTexture(line,0);
       break;
 
+   // ID24 Music Changers
+    case 2061: case 2067: case 2091: case 2097:
+      P_ChangeSwitchTexture(line,0);
+      EV_ChangeMusic(line, side);
+      break;
+
+    case 2062: case 2068: case 2092: case 2098:
+      P_ChangeSwitchTexture(line,1);
+      EV_ChangeMusic(line, side);
+      break;
+
     //jff 1/30/98 added new gun linedefs here
     // killough 1/31/98: added demo_compatibility check, added inner switch
 
@@ -2710,9 +2817,9 @@ void P_ShootCompatibleSpecialLine(mobj_t *thing, line_t *line)
   }
 }
 
-void P_ShootHexenSpecialLine(mobj_t *thing, line_t *line)
+void P_ShootHexenSpecialLine(mobj_t *thing, line_t *line, int side)
 {
-  P_ActivateLine(line, thing, 0, SPAC_IMPACT);
+  P_ActivateLine(line, thing, 0, SPAC_IMPACT); // Ignore side for now
 }
 
 static void P_ApplySectorDamage(player_t *player, int damage, int leak)
@@ -5176,6 +5283,11 @@ void P_CrossHereticSpecialLine(line_t * line, int side, mobj_t * thing, dboolean
             break;
         case 98:               // Lower Floor (TURBO)
             EV_DoFloor(line, turboLower);
+            break;
+        case 2057: case 2063: case 2087: case 2093:
+        case 2058: case 2064: case 2088: case 2094:
+            // ID24 Music Changers
+            EV_ChangeMusic(line, side);
             break;
     }
 }

--- a/prboom2/src/p_spec.h
+++ b/prboom2/src/p_spec.h
@@ -1231,6 +1231,9 @@ int EV_DoGenDoor
 int EV_DoGenLockedDoor
 ( line_t* line );
 
+// ID24
+void EV_ChangeMusic(line_t* line, int side);
+
 ////////////////////////////////////////////////////////////////
 //
 // Linedef and sector special thinker spawning

--- a/prboom2/src/p_switch.c
+++ b/prboom2/src/p_switch.c
@@ -803,6 +803,17 @@ P_UseSpecialLine
         P_ChangeSwitchTexture(line,0);
       return true;
 
+    // ID24 Music Changers
+    case 2059: case 2065: case 2089: case 2095:
+      P_ChangeSwitchTexture(line,0);
+      EV_ChangeMusic(line, side);
+      return true;
+
+    case 2060: case 2066: case 2090: case 2096:
+      P_ChangeSwitchTexture(line,1);
+      EV_ChangeMusic(line, side);
+      return true;
+
       // killough 1/31/98: factored out compatibility check;
       // added inner switch, relaxed check to demo_compatibility
 
@@ -1564,6 +1575,15 @@ dboolean Heretic_P_UseSpecialLine(mobj_t * thing, line_t * line, int side, dbool
             if (EV_DoFloor(line, turboLower))
                 P_ChangeSwitchTexture(line, 1);
             break;
+        // ID24 Music Changers
+        case 2059: case 2065: case 2089: case 2095:
+          P_ChangeSwitchTexture(line,0);
+          EV_ChangeMusic(line, side);
+          break;
+        case 2060: case 2066: case 2090: case 2096:
+          P_ChangeSwitchTexture(line,1);
+          EV_ChangeMusic(line, side);
+          break;
     }
 
     return true;

--- a/prboom2/src/r_defs.h
+++ b/prboom2/src/r_defs.h
@@ -346,6 +346,10 @@ typedef struct line_s
   int healthgroup;
   const byte* tranmap;
   float alpha;
+
+  // ID24 line specials
+  int frontmusic; // Front upper texture -- activated from the front side
+  int backmusic;  // Front lower texture -- activated from the back side
 } line_t;
 
 #define LINE_ARG_COUNT 5


### PR DESCRIPTION
Does what it says.

Included Elf on the commit because the code is based off his Woof implementation

Also tweaked console commands to allow distinguishing the front / backside of a linedef.