### PR TITLE
Fix tntfast cheat not toggling fast monsters

### DIFF
--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -815,8 +815,8 @@ static void cheat_hom()
 // killough 3/6/98: -fast parameter toggle
 static void cheat_fast()
 {
-  dsda_AddMessage((fastparm = !fastparm) ? "Fast Monsters On" : "Fast Monsters Off");
-  dsda_RefreshGameSkill(); // refresh fast monsters
+  dsda_AddMessage(dsda_ToggleConfig(dsda_config_fast_monsters, true) ? "Fast Monsters On" : "Fast Monsters Off");
+  dsda_RefreshGameSkill();
 }
 
 // killough 2/16/98: keycard/skullkey cheat functions

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -816,7 +816,7 @@ static void cheat_hom()
 static void cheat_fast()
 {
   dsda_AddMessage(dsda_ToggleConfig(dsda_config_fast_monsters, true) ? "Fast Monsters On" : "Fast Monsters Off");
-  dsda_RefreshGameSkill();
+  dsda_RefreshGameSkill(); // refresh fast monsters
 }
 
 // killough 2/16/98: keycard/skullkey cheat functions


### PR DESCRIPTION
The `tntfast` cheat was broken: it always printed "Fast Monsters On" and had no effect on monster speed.

**Root cause:** `cheat_fast()` in `m_cheat.c` was toggling `fastparm` directly, then calling `dsda_RefreshGameSkill()`. That function calls `dsda_ResetGameModifiers()` when `allow_incompatibility` is true (normal gameplay), which reads `fastparm` back from `dsda_config_fast_monsters` - overwriting the toggle immediately.

**Fix:** Use `dsda_ToggleConfig(dsda_config_fast_monsters, true)` instead, consistent with the pattern used by `cheat_hom()` and other cheats. This updates the config value so `dsda_ResetGameModifiers()` reads the toggled state correctly.

Fixes #676