### PR TITLE
m_menu: fix crash when pressing backspace in save dialog without binding

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5773,7 +5773,18 @@ static dboolean M_SaveResponder(int ch, int action, event_t* ev)
     }
     else if (ch > 0)
     {
-      if (ch >= 32 && ch <= 127 &&
+      if (ch == KEYD_BACKSPACE)
+      {
+        if (saveCharIndex > 0)
+        {
+          if (!strcmp(savegamestrings[saveSlot], dsda_MapLumpName(gameepisode, gamemap)))
+            saveCharIndex = 0;
+          else
+            saveCharIndex--;
+          savegamestrings[saveSlot][saveCharIndex] = 0;
+        }
+      }
+      else if (ch >= 32 && ch < KEYD_BACKSPACE &&
           saveCharIndex < SAVESTRINGSIZE-1 &&
           M_StringWidth(savegamestrings[saveSlot]) < (SAVESTRINGSIZE-2)*8)
       {


### PR DESCRIPTION
Pressing backspace while editing a save name crashes with `createPatch: Unknown patch format PLAYPAL` if `input_menu_backspace` isn't bound to the physical backspace key.

The character filter in `M_SaveResponder` accepts `ch >= 32 && ch <= 127`. Since `KEYD_BACKSPACE = 127` and `HU_FONTEND = 0x7f`, the character lands inside the font array bounds but with no valid lump — it defaults to lump 0 (PLAYPAL), which `createPatch` can't parse.

Handle `KEYD_BACKSPACE` explicitly before the printable character check, and tighten the filter to `ch < KEYD_BACKSPACE`. Backspace now also works as a delete key in the save name field regardless of the binding.

Closes #833