### PR TITLE
Add Customizable secret message via Dehacked

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -515,6 +515,9 @@ const char *bgcastcall   = "BOSSBACK"; // Panel behind cast call
  * cph - updated for prboom */
 const char *savegamename = PROJECT_TARNAME"-savegame";
 
+// secret messages
+const char *s_HUSTR_SECRETFOUND = HUSTR_SECRETFOUND;
+
 // end d_deh.h variable declarations
 // ====================================================================
 
@@ -828,6 +831,9 @@ static deh_strs deh_strlookup[] = {
   {&bgflat31,"BGFLAT31"},
   {&bgcastcall,"BGCASTCALL"},
   {&savegamename,"SAVEGAMENAME"},  // Ty 05/03/98
+
+  // secret messages
+  {&s_HUSTR_SECRETFOUND,"HUSTR_SECRETFOUND"},
 };
 
 static int deh_numstrlookup = sizeof(deh_strlookup) / sizeof(deh_strlookup[0]);

--- a/prboom2/src/d_deh.h
+++ b/prboom2/src/d_deh.h
@@ -1063,6 +1063,9 @@ extern const char* bgcastcall;
 // from g_game.c, prefix for savegame name like "boomsav"
 extern const char* savegamename;
 
+// secret messages
+extern const char* s_HUSTR_SECRETFOUND;
+
 uint64_t deh_stringToMBF21MobjFlags(char *strval);
 uint64_t deh_stringToMobjFlags(char *strval);
 void deh_changeCompTranslucency(void);

--- a/prboom2/src/d_englsh.h
+++ b/prboom2/src/d_englsh.h
@@ -348,6 +348,9 @@
 #define STSTR_COMPON    "Compatibility Mode On"            /* phares */
 #define STSTR_COMPOFF   "Compatibility Mode Off"           /* phares */
 
+// secret messages
+#define HUSTR_SECRETFOUND "A secret is revealed!"
+
 /* f_finale.c */
 
 #define E1TEXT \

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -1465,7 +1465,7 @@ void P_PlayerCollectSecret(player_t *player)
   {
     int sfx_id = raven ? g_sfx_secret :
                  I_GetSfxLumpNum(&S_sfx[g_sfx_secret]) < 0 ? sfx_itmbk : g_sfx_secret;
-    SetCustomMessage(player - players, "A secret is revealed!", 2 * TICRATE, sfx_id);
+    SetCustomMessage(player - players, s_HUSTR_SECRETFOUND, 2 * TICRATE, sfx_id);
   }
 }
 


### PR DESCRIPTION
Part of #883 .

This is pretty straight forward.

I don't really like that we allow parsing deh files in Heretic here (secret message shows in Heretic). In Nyan, the dehacked / hehacked is completely rewritten, so there is a distinct difference in what's allowed (altho I do allow [some](https://github.com/andrikpowell/nyan-doom/blob/master/docs/hehacked.md#extra-non-hehacked-nyan-doom-strings) doom strings in Heretic, which this secret message will be one of them).