### PR TITLE
Teleporters optimization to fix lethal Oversaturation lag

### DIFF
--- a/prboom2/src/p_telept.c
+++ b/prboom2/src/p_telept.c
@@ -144,14 +144,8 @@ static mobj_t* P_TeleportDestination(short thing_id, int tag)
 
   FIND_SECTORS(id_p, tag)
   {
-    register thinker_t* th = NULL;
-    while ((th = P_NextThinker(th,th_misc)) != NULL)
-      if (th->function == P_MobjThinker) {
-        register mobj_t* m = (mobj_t*)th;
-        if (m->type == MT_TELEPORTMAN  &&
-            m->subsector->sector->iSectorID == *id_p)
-            return m;
-      }
+    register teleport_t* teleport = P_FindTeleport(*id_p);
+    if (teleport) return teleport->mobj;
   }
   return NULL;
 }

--- a/prboom2/src/p_tick.c
+++ b/prboom2/src/p_tick.c
@@ -68,6 +68,8 @@ int init_thinkers_count = 0;
 
 void P_InitThinkers(void)
 {
+  P_CleanTeleports();
+
   int i;
 
   for (i=0; i<NUMTHCLASS; i++)  // killough 8/29/98: initialize threaded lists
@@ -120,6 +122,13 @@ void P_UpdateThinker(thinker_t *thinker)
 
 void P_AddThinker(thinker_t* thinker)
 {
+  if (thinker->function == P_MobjThinker)
+  {
+    mobj_t* m = thinker;
+    if (m->type == MT_TELEPORTMAN)
+      P_CleanTeleports();
+  }
+
   thinkercap.prev->next = thinker;
   thinker->next = &thinkercap;
   thinker->prev = thinkercap.prev;
@@ -188,6 +197,13 @@ void P_RemoveThinkerDelayed(thinker_t *thinker)
 
 void P_RemoveThinker(thinker_t *thinker)
 {
+  if (thinker->function == P_MobjThinker)
+  {
+    mobj_t* m = thinker;
+    if (m->type == MT_TELEPORTMAN)
+      P_CleanTeleports();
+  }
+
   R_StopInterpolationIfNeeded(thinker);
   thinker->function = P_RemoveThinkerDelayed;
 
@@ -267,6 +283,8 @@ static void P_RunThinkers (void)
 
 void P_CleanThinkers (void)
 {
+  P_CleanTeleports();
+
   for (currentthinker = thinkercap.next;
        currentthinker != &thinkercap;
        currentthinker = currentthinker->next)
@@ -364,4 +382,90 @@ void P_Ticker (void)
   }
 
   leveltime++;                       // for par times
+}
+
+teleport_t* teleports;
+int numTeleports = -1;
+int maxTeleports = 64;
+
+static int C_DECL cmp_teleportSectorIdIndex(const teleport_t* a, const teleport_t* b) 
+{
+  register int diff;
+  if (diff = (a->sectorId - b->sectorId)) return diff;
+  return a->index - b->index;
+}
+
+static int C_DECL find_teleportSectorId(const int* key, const teleport_t* t) 
+{
+  return *key - t->sectorId;
+}
+
+void P_InitTeleports(void)
+{
+  numTeleports = 0;
+  maxTeleports = 64;
+
+  if (!teleports) teleports = Z_Malloc(maxTeleports * sizeof(teleport_t));
+
+  // Collect all teleports
+  register thinker_t* th = NULL;
+  while ((th = P_NextThinker(th, th_misc)) != NULL)
+    if (th->function == P_MobjThinker) {
+      register mobj_t* m = (mobj_t*)th;
+      if (m->type == MT_TELEPORTMAN)
+      {
+        if (numTeleports >= maxTeleports)
+        {
+          maxTeleports *= 2;
+          teleports = Z_Realloc(teleports, maxTeleports * sizeof(teleport_t));
+        }
+
+        teleport_t* newTeleport = &teleports[numTeleports];
+        newTeleport->index = numTeleports; // index for stable sort
+        newTeleport->sectorId = m->subsector->sector->iSectorID;
+        newTeleport->mobj = m;
+        numTeleports++;
+      }
+    }
+
+  if (!numTeleports) return;
+
+  // Sort teleports by sectorId and index
+  qsort(teleports, numTeleports, sizeof(teleport_t), &cmp_teleportSectorIdIndex);
+
+  int headTeleports = 1;
+  int headSectorId = teleports[0].sectorId;
+  for (int pos = 1; pos < numTeleports; pos++)
+  {
+    teleport_t* curTeleport = &teleports[pos];
+    int curSectorId = curTeleport->sectorId;
+    if (curSectorId != headSectorId)
+    {
+      // Swap head & cur to get first teleport of each sector to the start of the list
+      teleport_t tmpTeleport;
+      teleport_t* headTeleport = &teleports[headTeleports];
+      memcpy(&tmpTeleport, curTeleport, sizeof(teleport_t));
+      memcpy(curTeleport, headTeleport, sizeof(teleport_t));
+      memcpy(headTeleport, &tmpTeleport, sizeof(teleport_t));
+      headTeleport->index = 0;
+      headTeleports++;
+      curSectorId = headSectorId;
+    }
+  }
+
+  numTeleports = headTeleports;
+}
+
+void P_CleanTeleports(void)
+{
+  if (teleports) Z_Free(teleports);
+  teleports = NULL;
+  numTeleports = -1;
+}
+
+teleport_t* P_FindTeleport(int sectorId)
+{
+  if (numTeleports < 0) P_InitTeleports();
+  if (!numTeleports) return NULL;
+  return bsearch(&sectorId, teleports, numTeleports, sizeof(teleport_t), &find_teleportSectorId);
 }

--- a/prboom2/src/p_tick.c
+++ b/prboom2/src/p_tick.c
@@ -68,9 +68,9 @@ int init_thinkers_count = 0;
 
 void P_InitThinkers(void)
 {
-  P_CleanTeleports();
-
   int i;
+
+  P_CleanTeleports();
 
   for (i=0; i<NUMTHCLASS; i++)  // killough 8/29/98: initialize threaded lists
     thinkerclasscap[i].cprev = thinkerclasscap[i].cnext = &thinkerclasscap[i];
@@ -124,7 +124,7 @@ void P_AddThinker(thinker_t* thinker)
 {
   if (thinker->function == P_MobjThinker)
   {
-    mobj_t* m = thinker;
+    mobj_t* m = (mobj_t *)thinker;
     if (m->type == MT_TELEPORTMAN)
       P_CleanTeleports();
   }
@@ -199,7 +199,7 @@ void P_RemoveThinker(thinker_t *thinker)
 {
   if (thinker->function == P_MobjThinker)
   {
-    mobj_t* m = thinker;
+    mobj_t* m = (mobj_t*)thinker;
     if (m->type == MT_TELEPORTMAN)
       P_CleanTeleports();
   }
@@ -388,39 +388,44 @@ teleport_t* teleports;
 int numTeleports = -1;
 int maxTeleports = 64;
 
-static int C_DECL cmp_teleportSectorIdIndex(const teleport_t* a, const teleport_t* b) 
+static int C_DECL cmp_teleportSectorIdIndex(const void* a, const void* b) 
 {
   register int diff;
-  if (diff = (a->sectorId - b->sectorId)) return diff;
-  return a->index - b->index;
+  if ((diff = ((const teleport_t*)a)->sectorId - ((const teleport_t*)b)->sectorId)) return diff;
+  return ((const teleport_t*)a)->index - ((const teleport_t*)a)->index;
 }
 
-static int C_DECL find_teleportSectorId(const int* key, const teleport_t* t) 
+static int C_DECL find_teleportSectorId(const void* key, const void* t) 
 {
-  return *key - t->sectorId;
+  return *((const int*)key) - ((const teleport_t*)t)->sectorId;
 }
 
 void P_InitTeleports(void)
 {
+  int headTeleports;
+  int headSectorId;
+  register thinker_t* th = NULL;
+
   numTeleports = 0;
   maxTeleports = 64;
 
   if (!teleports) teleports = Z_Malloc(maxTeleports * sizeof(teleport_t));
 
   // Collect all teleports
-  register thinker_t* th = NULL;
   while ((th = P_NextThinker(th, th_misc)) != NULL)
     if (th->function == P_MobjThinker) {
       register mobj_t* m = (mobj_t*)th;
       if (m->type == MT_TELEPORTMAN)
       {
+        teleport_t* newTeleport;
+
         if (numTeleports >= maxTeleports)
         {
           maxTeleports *= 2;
           teleports = Z_Realloc(teleports, maxTeleports * sizeof(teleport_t));
         }
 
-        teleport_t* newTeleport = &teleports[numTeleports];
+        newTeleport = &teleports[numTeleports];
         newTeleport->index = numTeleports; // index for stable sort
         newTeleport->sectorId = m->subsector->sector->iSectorID;
         newTeleport->mobj = m;
@@ -433,8 +438,8 @@ void P_InitTeleports(void)
   // Sort teleports by sectorId and index
   qsort(teleports, numTeleports, sizeof(teleport_t), &cmp_teleportSectorIdIndex);
 
-  int headTeleports = 1;
-  int headSectorId = teleports[0].sectorId;
+  headTeleports = 1;
+  headSectorId = teleports[0].sectorId;
   for (int pos = 1; pos < numTeleports; pos++)
   {
     teleport_t* curTeleport = &teleports[pos];

--- a/prboom2/src/p_tick.h
+++ b/prboom2/src/p_tick.h
@@ -71,4 +71,17 @@ thinker_t* P_NextThinker(thinker_t*,th_class);
 
 void P_CleanThinkers(void);
 
+typedef struct teleport_s {
+  int index;
+  int sectorId;
+  mobj_t* mobj;
+} teleport_t;
+
+extern teleport_t *teleports;
+
+teleport_t* P_FindTeleport(int sectorId);
+
+void P_InitTeleports(void);
+void P_CleanTeleports(void);
+
 #endif


### PR DESCRIPTION
After ZomB1986's pull request in https://github.com/kraflab/dsda-doom/pull/514 wasn't merged, it always bugged me that MAP04 of Oversaturation basically turns into a slideshow at about two thirds in.

After looking at the situation for a bit, I fixed the problem by leaving the `MT_TELEPORTMAN`-type thinkers where they are, but instead building a separate list of just those thinkers that gets tossed as soon as such a thinker is added or removed, and rebuilt the next time `P_TeleportDestination` is looking for a teleport target.

While i was at it, I also sorted those collected thinkers by their sector-id (and am only using the one with the lowest index in the thinkers list per sector-id), allowing the linear scan across all thinkers in `P_TeleportDestination` to be replaced with a binary search in just the array of all teleport-thinkers. In the case of Oversaturation, that means doing a binary lookup in an array of 959 entries instead of scanning 90000+ thinkers each and every time.

To test this, I ran [JonOfAllGames' ITYTD-max demo of Oversaturation MAP04](https://dsdarchive.com/wads/oversat?level=Map+04) at full tilt until about 208 minutes in, then made [a save file](https://drive.google.com/file/d/1FoDJ8NVTCQQV7oqOftjQ63FuTUlmlwho/view?usp=drive_link) - just hit the button, dispatch the Pain Elementals, drop down, go left, kill the Spider Demon and shoot the recessed button to [start the slideshow](https://youtu.be/fzdMrEXks5Y) (less than 1 FPS on my machine), or [with my changes go on killing things normally](https://youtu.be/Ej2Rk29ewlk) (50-100 FPS depending on which part of the horde you stare down).

I'm pretty confident this should not cause any demo desyncs, and while it probably won't matter much on smaller maps (though it also shouldn't worsen performance) it will probably make a difference on other big slaughtermaps.,