### PR TITLE
Fix zlib for MSVC static build

### DIFF
--- a/prboom2/cmake/DsdaDependencies.cmake
+++ b/prboom2/cmake/DsdaDependencies.cmake
@@ -26,6 +26,11 @@ find_package(SndFile 1.0.29 REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(libzip REQUIRED)
 
+# ZLIB 1.3.2 static now requires explicit ZLIBSTATIC
+if(NOT TARGET ZLIB::ZLIB AND TARGET ZLIB::ZLIBSTATIC)
+  add_library(ZLIB::ZLIB ALIAS ZLIB::ZLIBSTATIC)
+endif()
+
 if(SndFile_VERSION VERSION_GREATER_EQUAL "1.1.0")
    set(HAVE_SNDFILE_MPEG TRUE)
 endif()


### PR DESCRIPTION
Ok, so I'm a bit more confident about this now... Although it required me to understand cmake a bit...

Basically the reason builds are failing is because the latest ZLIB update to 1.3.2 changed how static builds are referenced. I'm still a little unclear who's at fault here, vcpkg or zlib...

But the main point is that for static builds, we must now use `ZLIB::ZLIBSTATIC` instead of just `ZLIB::ZLIB`.