### PR TITLE
Revert "Don't use Colormap for duplicate palette detection (#880)"

### DIFF
--- a/prboom2/src/dsda/palette.c
+++ b/prboom2/src/dsda/palette.c
@@ -83,12 +83,18 @@ void dsda_FreePlayPal(void) {
 }
 
 static dboolean dsda_DuplicatePaletteEntry(const byte *playpal, int i, int j) {
+  int colormap_i;
+
   if (
     playpal[3 * i + 0] != playpal[3 * j + 0] ||
     playpal[3 * i + 1] != playpal[3 * j + 1] ||
     playpal[3 * i + 2] != playpal[3 * j + 2]
   )
     return false;
+
+  for (colormap_i = 0; colormap_i < NUMCOLORMAPS; ++colormap_i)
+    if (colormaps[0][colormap_i * 256 + i] != colormaps[0][colormap_i * 256 + j])
+      return false;
 
   return true;
 }


### PR DESCRIPTION
We need to revert this commit.

It breaks wads like this that do custom stuff with the palette / colourmap:
[VXS](https://www.doomworld.com/forum/topic/158858)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/717cc4a0-1a27-463c-be0f-eaebbad254c7" />

_(Sky is supposed to be black here)_

I had this fix in Nyan (which I updated yesterday with this revert), but it seems we need to approach this differently.