### PR TITLE
Add a track_reality_kill option which causes all player damage to be fatal

### DIFF
--- a/prboom2/src/dsda/args.c
+++ b/prboom2/src/dsda/args.c
@@ -273,6 +273,11 @@ static arg_config_t arg_config[dsda_arg_count] = {
     "tracks reality and almost reality categories restrictions",
     arg_null,
   },
+  [dsda_arg_track_reality_kill] = {
+    "-track_reality_kill", NULL, NULL,
+    "causes any player damage to be fatal",
+    arg_null,
+  },
   [dsda_arg_time_keys] = {
     "-time_keys", NULL, "105",
     "announces the time when keys are picked up",

--- a/prboom2/src/dsda/args.h
+++ b/prboom2/src/dsda/args.h
@@ -65,6 +65,7 @@ typedef enum {
   dsda_arg_track_pacifist,
   dsda_arg_track_100k,
   dsda_arg_track_reality,
+  dsda_arg_track_reality_kill,
   dsda_arg_time_keys,
   dsda_arg_time_use,
   dsda_arg_time_secrets,

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -53,6 +53,7 @@
 #include "e6y.h"//e6y
 
 #include "dsda.h"
+#include "dsda/args.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
 #include "dsda/messenger.h"
@@ -1517,6 +1518,9 @@ void P_DamageMobj(mobj_t *target,mobj_t *inflictor, mobj_t *source, int damage)
   // player specific
   if (player)
   {
+    if (dsda_Flag(dsda_arg_track_reality_kill) && (raven || target->subsector->sector->special != 11))
+      damage = 500;
+
     // end of game hell hack
     if (!raven && target->subsector->sector->special == 11 && damage >= target->health)
       damage = target->health - 1;


### PR DESCRIPTION
This was suggested by PJPlaysDoom who is one of the most prolific reality players/streamers. He thought it would be useful to have a mode where any damage kills the player, as it would be more exciting (for viewers) and more immediate than the track_reality notification.

This PR adds a command line option `-track_reality_kill` which causes any player damage to be increased to 500. It does this after the knockback happens, and it prevents it from happening in sector 11 for almost reality runs on maps like e1m8, so it should be demo compatible for reality runs.
