### PR TITLE
fix non-repeatable `A_LineEffect` behavior being session based, instead of map based

### DIFF
--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -3160,26 +3160,28 @@ void A_RandomJump(mobj_t *mo)
 
 void A_LineEffect(mobj_t *mo)
 {
-  static line_t junk;
-  player_t player;
-  player_t *oldplayer;
-
   if (compatibility_level < lxdoom_1_compatibility &&
       !prboom_comp[PC_APPLY_MBF_CODEPOINTERS_TO_ANY_COMPLEVEL].state)
     return;
 
-  junk = *lines;
-  oldplayer = mo->player;
-  mo->player = &player;
-  player.health = 100;
-  junk.special = (short)mo->state->misc1;
-  if (!junk.special)
-    return;
-  junk.special_args[0] = (short)mo->state->misc2;
-  if (!P_UseSpecialLine(mo, &junk, 0, false))
-    map_format.cross_special_line(&junk, 0, mo, false);
-  mo->state->misc1 = junk.special;
-  mo->player = oldplayer;
+  if (!(mo->intflags & MIF_LINEDONE)) // Unless already used up
+  {
+    line_t junk = *lines;                                   // Fake linedef set to 1st
+    if ((junk.special = (short)mo->state->misc1))           // Linedef type
+    {
+      // [FG] made static
+      static player_t player;                               // Remember player status
+      player_t *oldplayer = mo->player;                     // Remember player status
+      mo->player = &player;                                 // Fake player
+      player.health = 100;                                  // Alive player
+      junk.special_args[0] = (short)mo->state->misc2;       // Sector tag for linedef
+      if (!P_UseSpecialLine(mo, &junk, 0, false))           // Try using it
+        map_format.cross_special_line(&junk, 0, mo, false); // Try crossing it
+      if (!junk.special)                                    // If type cleared,
+        mo->intflags |= MIF_LINEDONE;                       // no more for this thing
+      mo->player = oldplayer;                               // Restore player status
+    }
+  }
 }
 
 //

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -246,6 +246,7 @@ enum {
   MIF_PLAYER_DAMAGED_BARREL = 8,
   MIF_SPAWNED_BY_ICON = 16,
   MIF_FAKE = 32, // Not a real thing, transient (e.g., for cheats)
+  MIF_LINEDONE              = 0x00000040, // Object has activated W1 or S1 linedef via DEH frame
 };
 
 // heretic


### PR DESCRIPTION
As reported on the Discord server, this PR was tested and compared with DSDA, Woof and Eternity on the map posted there:
https://discord.com/channels/218106532406099969/776233266411339786/1522739662895054961

The buggy behavior in question:
https://youtu.be/WtP0gfkOFGg

Changes pulled from Woof:
https://github.com/team-eternity/WinMBF/blob/3af60d718b1fe272769ee9eeb768b88e29a6cd7e/Source/p_enemy.c#L2548-L2563

This same logic is also in Eternity, so it can be presumed to be have been fixed early on by Quasar, since it is also present in WinMBF:
https://github.com/fabiangreffrath/woof/blob/49f14665d5aee8b0bcf2441056e6e06ce56b56ce/src/p_enemy.c#L2843-L2862

Eternity itself also has some additional changes, but I can only presume these to be due to EE-specific reasons:
https://github.com/team-eternity/eternity/blob/0b5760ee475dfb9bc72c82154a2b7661678ad9a7/source/a_general.cpp#L371-L399