### PR TITLE
Add support for "TrueColor" OpenGL light fade

### DIFF
--- a/prboom2/data/lumps/gls_main.lmp
+++ b/prboom2/data/lumps/gls_main.lmp
@@ -48,6 +48,28 @@ vec3 indexRGB(float ci, float li)
   return texture2D(colormap, vec2(ci, li)).rgb;
 }
 
+// [PN+JN] TrueColor smooth fade mode.
+// Interpolates directly between COLORMAP row 0 (brightest)
+// and row 31 (darkest), bypassing the intermediate 30 rows.
+vec3 indexRGB_TrueColor(float ci, float li)
+{
+  // Strictly clamp li to 0..31 range (excluding the 32nd invulnerability row!)
+  li = clamp(li, 0.0, 31.0);
+
+  // Normalize to 0.0 .. 1.0
+  float t = li / 31.0;
+
+  // V coordinates for rows 0 and 31 (texel centers)
+  float v_bright = 0.0  / 32.0;
+  float v_dark   = 31.0 / 32.0;
+
+  vec3 color_bright = texture2D(colormap, vec2(ci, v_bright)).rgb;
+  vec3 color_dark   = texture2D(colormap, vec2(ci, v_dark)).rgb;
+
+  // Interpolate between the brightest and darkest colors
+  return mix(color_bright, color_dark, t);
+}
+
 uniform sampler2D tex;
 uniform int fade_mode;
 
@@ -63,6 +85,11 @@ void main()
   {
     // Smooth fade mode.
     color = mix(indexRGB(ci, floor(li)), indexRGB(ci, floor(li + 1.0)), fract(li));
+  }
+  else if (fade_mode == 2)
+  {
+    // Full TrueColor mode.
+    color = indexRGB_TrueColor(ci, li);
   }
   else
   {

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1262,7 +1262,7 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_gl_fade_mode] = {
     "gl_fade_mode", dsda_config_gl_fade_mode,
-    dsda_config_int, 0, 1, { 0 }
+    dsda_config_int, 0, 2, { 0 }
   },
   [dsda_config_translucent_sprites] = {
     "boom_translucent_sprites", dsda_config_translucent_sprites,

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3197,7 +3197,7 @@ static const char* fake_contrast_list[] =
   NULL
 };
 
-static const char *gl_fade_mode_list[] = { "Normal", "Smooth", NULL };
+static const char *gl_fade_mode_list[] = { "Normal", "Smooth", "TrueColor", NULL };
 
 setup_menu_t gen_video_settings[] = {
   { "Video mode", S_CHOICE | S_STR, m_conf, G_X, dsda_config_videomode, 0, videomodes },


### PR DESCRIPTION
This shader mode implements a TrueColor-style smooth fade by interpolating directly between `COLORMAP` rows 0 and 31, bypassing the intermediate 32-level banding. Must be equivalent of implementation from Inter/Nugget, producing seamless lighting transitions without visible steps.

I suppose this might not be entirely canonical, but I'm more than confident there will be those who appreciate this mode.

<img width="2560" height="1440" alt="doom02" src="https://github.com/user-attachments/assets/d936323a-a5ef-47a2-8246-5cfbaec38e27" />
