### PR TITLE
Fix keypad Enter displaying as empty string in key bindings menu

### DIFF
--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4259,8 +4259,11 @@ static int M_GetKeyString(int c,int offset)
     // cph - Keypad keys, general code reorganisation to
     //  make this smaller and neater.
     if ((0x100 <= c) && (c < 0x200)) {
-      if (c == KEYD_KEYPADENTER)
+      if (c == KEYD_KEYPADENTER) {
   s = "PADE";
+  strcpy(&menu_buffer[offset], s);
+  offset+=4;
+      }
       else {
   strcpy(&menu_buffer[offset], "PAD");
   offset+=4;


### PR DESCRIPTION
A tiny patch. The pointer `s` was assigned the string "PADE", but it was never copied into `menu_buffer`. The code fell through without updating the buffer or the offset, resulting in an empty display for Keypad Enter. This fix adds the missing `strcpy` and necessary offset increment. 

Before and after:
<img width="964" height="153" alt="pade" src="https://github.com/user-attachments/assets/ce8cea92-1c90-4fd1-afce-42679addd8e8" />
