### PR TITLE
Do not read patches that are outside the PNAMES table

### DIFF
--- a/prboom2/src/r_data.c
+++ b/prboom2/src/r_data.c
@@ -288,19 +288,33 @@ static void R_InitTextures (void)
       mpatch = mtexture->patches;
       patch = texture->patches;
 
-      for (j=0 ; j<texture->patchcount ; j++, mpatch++, patch++)
+      for (j=0 ; j<texture->patchcount ; j++, mpatch++)
         {
+          int patchindex = LittleShort(mpatch->patch);
+
+          // Check if patch is in PNAMES bounds
+          if (patchindex < 0 || patchindex >= nummappatches)
+            {
+              lprintf(LO_WARN, "\nR_InitTextures: Texture %.8s references patch index %d outside PNAMES table (%d entries)",
+                      texture->name, patchindex, nummappatches);
+              continue;
+            }
+
           patch->originx = LittleShort(mpatch->originx);
           patch->originy = LittleShort(mpatch->originy);
-          patch->patch = patchlookup[LittleShort(mpatch->patch)];
+          patch->patch = patchlookup[patchindex];
           if (patch->patch == -1)
             {
               //jff 8/3/98 use logical output routine
               lprintf(LO_ERROR,"\nR_InitTextures: Missing patch %d in texture %.8s",
-                     LittleShort(mpatch->patch), texture->name); // killough 4/17/98
+                     patchindex, texture->name); // killough 4/17/98
               ++errors;
             }
+
+          ++patch;
         }
+
+      texture->patchcount = (short)(patch - texture->patches);
 
       for (j=1; j*2 <= texture->width; j<<=1)
         ;


### PR DESCRIPTION
This is similar but also very different from #896 

Basically some wads can have malformed `TEXTUREX` / `PNAMES` set ups, that reference patch indexes outside the full `PNAMES` lookup...

This PR skips over them, and doesn't include such patches in the lookup

The previous behaviour was undefined and resulted in random crashes when loading wads like this (example: https://dsdarchive.com/wads/frost)

For demo testing especially, we need this behaviour to be consistent.