### PR TITLE
Allow to toggle full screen by pressing alt + kp_enter

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -329,7 +329,8 @@ static void I_GetEvent(void)
             break;
           }
           // Switch windowed<->fullscreen if pressed Alt-Enter
-          else if (Event->key.keysym.sym == SDLK_RETURN)
+          else if (Event->key.keysym.sym == SDLK_RETURN ||
+                   Event->key.keysym.sym == SDLK_KP_ENTER)
           {
             V_ToggleFullscreen();
             break;


### PR DESCRIPTION
This allows to toggle full screen mode by not just `Alt+Enter`, but also by `Alt+KPEnter` keys.