### PR TITLE
Fix window focus loss on minimize/restore

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -414,6 +414,9 @@ static void I_GetEvent(void)
           {
           case SDL_WINDOWEVENT_FOCUS_GAINED:
           case SDL_WINDOWEVENT_FOCUS_LOST:
+          case SDL_WINDOWEVENT_MINIMIZED:
+          case SDL_WINDOWEVENT_MAXIMIZED:
+          case SDL_WINDOWEVENT_RESTORED:
             UpdateFocus();
             break;
           case SDL_WINDOWEVENT_SIZE_CHANGED:


### PR DESCRIPTION
This fixes the game window losing focus when minimized and then restored.

Video example:

<details>

https://github.com/user-attachments/assets/c553fa77-4cdd-494c-b45f-2395686cd217

</details>