### PR TITLE
MBF21: Add Weapon Recoil Customisation

### DIFF
--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1351,6 +1351,7 @@ static const char *deh_weapon[] = // CPhipps - static const*
   "Shooting frame", // .atkstate
   "Firing frame",   // .flashstate
   "Ammo per shot",  // .ammopershot [XA] new to mbf21
+  "Weapon recoil",  // .recoil [AR] new to mbf21
   "MBF21 Bits",     // .flags
 };
 
@@ -2525,7 +2526,12 @@ static void deh_procWeapon(DEHFILE *fpin, char *line)
       weaponinfo[indexnum].ammopershot = (int)value;
       weaponinfo[indexnum].intflags |= WIF_ENABLEAPS;
     }
-    else if (!deh_strcasecmp(key, deh_weapon[7]))  // MBF21 Bits
+    else if (!deh_strcasecmp(key, deh_weapon[7]))  // Weapon recoil
+    {
+      weaponinfo[indexnum].recoil = (int)value;
+      weaponinfo[indexnum].intflags |= WIF_ENABLERECOIL;
+    }
+    else if (!deh_strcasecmp(key, deh_weapon[8]))  // MBF21 Bits
     {
       if (bGetData == 1)
       {

--- a/prboom2/src/d_items.c
+++ b/prboom2/src/d_items.c
@@ -64,6 +64,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     1,
     0,
+    0,
     WPF_FLEEMELEE | WPF_AUTOSWITCHFROM | WPF_NOAUTOSWITCHTO
   },
   {
@@ -76,6 +77,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_PISTOLFLASH,
     1,
+    0,
     0,
     WPF_AUTOSWITCHFROM
   },
@@ -90,6 +92,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_SGUNFLASH1,
     1,
     0,
+    0,
     WPF_NOFLAG
   },
   {
@@ -102,6 +105,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_CHAINFLASH1,
     1,
+    0,
     0,
     WPF_NOFLAG
   },
@@ -116,6 +120,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_MISSILEFLASH1,
     1,
     0,
+    0,
     WPF_NOAUTOFIRE
   },
   {
@@ -128,6 +133,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_PLASMAFLASH1,
     1,
+    0,
     0,
     WPF_NOFLAG
   },
@@ -142,6 +148,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_BFGFLASH1,
     40,
     0,
+    0,
     WPF_NOAUTOFIRE
   },
   {
@@ -155,6 +162,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     1,
     0,
+    0,
     WPF_NOTHRUST | WPF_FLEEMELEE | WPF_NOAUTOSWITCHTO
   },
   {
@@ -167,6 +175,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_DSGUNFLASH1,
     2,
+    0,
     0,
     WPF_NOFLAG
   },
@@ -189,6 +198,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     0,
     0,
+    0,
     WPF_NOFLAG
   },
   {
@@ -200,6 +210,7 @@ weaponinfo_t doom_weaponinfo[NUMWEAPONS+2] =
     S_NULL,
     S_NULL,
     S_NULL,
+    0,
     0,
     0,
     WPF_NOFLAG
@@ -220,6 +231,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_STAFFATK1_1,             // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     0,                                 // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -232,6 +244,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_GOLDWANDATK1_1,          // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_GWND_AMMO_1,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -244,6 +257,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_CRBOWATK1_1,             // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_CBOW_AMMO_1,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -256,6 +270,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_BLASTERATK1_3,           // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_BLSR_AMMO_1,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -268,6 +283,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_HORNRODATK1_1,           // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_SKRD_AMMO_1,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -280,6 +296,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_PHOENIXATK1_1,           // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_PHRD_AMMO_1,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOAUTOFIRE
   },
@@ -292,6 +309,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_MACEATK1_2,              // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_MACE_AMMO_1,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -304,6 +322,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_GAUNTLETATK1_3,          // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     0,                                 // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOTHRUST
   },
@@ -316,6 +335,7 @@ weaponinfo_t wpnlev1info[NUMWEAPONS] = {
     HERETIC_S_BEAKATK1_1,              // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     0,                                 // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   }
@@ -331,6 +351,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_STAFFATK2_1,             // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     0,                                 // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -343,6 +364,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_GOLDWANDATK2_1,          // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_GWND_AMMO_2,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -355,6 +377,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_CRBOWATK2_1,             // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_CBOW_AMMO_2,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -367,6 +390,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_BLASTERATK2_3,           // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_BLSR_AMMO_2,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -379,6 +403,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_HORNRODATK2_1,           // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_SKRD_AMMO_2,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -391,6 +416,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_PHOENIXATK2_2,           // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_PHRD_AMMO_2,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOAUTOFIRE
   },
@@ -403,6 +429,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_MACEATK2_1,              // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     USE_MACE_AMMO_2,                   // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   },
@@ -415,6 +442,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_GAUNTLETATK2_3,          // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     0,                                 // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOTHRUST
   },
@@ -427,6 +455,7 @@ weaponinfo_t wpnlev2info[NUMWEAPONS] = {
     HERETIC_S_BEAKATK2_1,              // holdatkstate
     HERETIC_S_NULL,                    // flashstate
     0,                                 // ammopershot
+    0,                                 // recoil
     0,                                 // intflags
     WPF_NOFLAG
   }
@@ -445,6 +474,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_PUNCHATK1_1,            // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -457,6 +487,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_CMACEATK_1,             // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -469,6 +500,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_MWANDATK_1,             // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -481,6 +513,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_SNOUTATK1,              // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     }
@@ -495,6 +528,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_FAXEATK_1,              // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       2,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -507,6 +541,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_CSTAFFATK_1,            // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       1,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -519,6 +554,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_CONEATK1_3,             // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       3,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -531,6 +567,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_SNOUTATK1,              // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     }
@@ -545,6 +582,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_FHAMMERATK_1,           // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       3,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -557,6 +595,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_CFLAMEATK_1,            // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       4,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -569,6 +608,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_MLIGHTNINGATK_1,        // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       5,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -581,6 +621,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_SNOUTATK1,              // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     }
@@ -595,6 +636,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_FSWORDATK_1,            // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       14,                             // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -607,6 +649,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_CHOLYATK_1,             // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       18,                             // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -619,6 +662,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_MSTAFFATK_1,            // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       15,                             // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     },
@@ -631,6 +675,7 @@ weaponinfo_t hexen_weaponinfo[HEXEN_NUMWEAPONS][NUMCLASSES] = {
       HEXEN_S_SNOUTATK1,              // holdatkstate
       HEXEN_S_NULL,                   // flashstate
       0,                              // ammopershot
+      0,                              // recoil
       0,                              // intflags
       WPF_NOFLAG
     }

--- a/prboom2/src/d_items.h
+++ b/prboom2/src/d_items.h
@@ -41,6 +41,7 @@
 // Internal weapon flags
 //
 #define WIF_ENABLEAPS 0x00000001 // [XA] enable "ammo per shot" field for native Doom weapon codepointers
+#define WIF_ENABLERECOIL 0x00000002 // [AR] enable custom weapon recoil
 
 // haleyjd 09/11/07: weapon flags
 //
@@ -63,6 +64,7 @@ typedef struct
   int         holdatkstate;
   int         flashstate;
   int         ammopershot;
+  int         recoil;
   int         intflags;
   int         flags;
 } weaponinfo_t;

--- a/prboom2/src/p_pspr.c
+++ b/prboom2/src/p_pspr.c
@@ -89,6 +89,15 @@ static const int recoil_values[] = {    // phares
   80  // wp_supershotgun
 };
 
+static int P_RecoilValue(weapontype_t weapon)
+{
+  // MBF21 recoil
+  if (weaponinfo[weapon].intflags & WIF_ENABLERECOIL)
+    return weaponinfo[weapon].recoil;
+
+  return recoil_values[weapon];
+}
+
 //
 // P_SetPsprite
 //
@@ -773,16 +782,21 @@ void A_Raise(player_t *player, pspdef_t *psp)
 // muzzle flash, rather than the pressing of the trigger.
 // The BFG delay caused this to be necessary.
 
+static void A_WeaponRecoil(player_t* player)
+{
+  // killough 3/27/98: prevent recoil in no-clipping mode
+  if (!(player->mo->flags & MF_NOCLIP))
+    if (!compatibility && weapon_recoil) // phares
+      P_ForwardThrust(player, ANG180 + player->mo->angle,
+                      2048 * P_RecoilValue(player->readyweapon));
+}
+
 static void A_FireSomething(player_t* player,int adder)
 {
   P_SetPsprite(player, ps_flash,
                weaponinfo[player->readyweapon].flashstate+adder);
 
-  // killough 3/27/98: prevent recoil in no-clipping mode
-  if (!(player->mo->flags & MF_NOCLIP))
-    if (!compatibility && weapon_recoil) // phares
-      P_ForwardThrust(player, ANG180 + player->mo->angle,
-                      2048 * recoil_values[player->readyweapon]);
+  A_WeaponRecoil(player);
 }
 
 //
@@ -948,7 +962,7 @@ void A_FireOldBFG(player_t *player, pspdef_t *psp)
 
   if (weapon_recoil && !(player->mo->flags & MF_NOCLIP))
     P_ForwardThrust(player, ANG180 + player->mo->angle,
-                    512 * recoil_values[wp_plasma]);
+                    512 * recoil_values[wp_plasma]); // [AR] Don't allow mbf21 to change this
 
   P_SubtractAmmo(player, 1);
 
@@ -1510,6 +1524,7 @@ void A_GunFlashTo(player_t *player, pspdef_t *psp)
     P_SetMobjState(player->mo, S_PLAY_ATK2);
 
   P_SetPsprite(player, ps_flash, psp->state->args[0]);
+  A_WeaponRecoil(player);
 }
 
 //


### PR DESCRIPTION
## Fixing Weapon Recoil for MBF21

_Note: I tested demos with this, and had no desyncs._

"Weapon Recoil" has been added as a weapon property similar like "Ammo per Shot" that allows you to customise the amount of recoil in MBF21.

Currently regarding MBF21 codepointers, I've only added recoil to `A_GunFlashTo` to match `A_GunFlash`

## Current Recoil Breakdown
MBF does apply recoil to:
```
A_GunFlash
A_FirePlasma
A_FirePistol
A_FireShotgun
A_FireShotgun2
A_FireCGun
```

MBF does NOT apply recoil to:
```
A_Punch
A_Saw
A_FireMissile
A_FireBFG
```

I added recoil to:
```
A_GunFlashTo
```

I did NOT add recoil to:
```
A_WeaponProjectile
A_WeaponBulletAttack
A_WeaponMeleeAttack
```

## Ways to deal with this
I think the most important part is to figure out how we wanna deal with recoil in the future...

MBF's implemention is jank because it doesn't apply recoil to the fist, or the chainsaw (note that the default recoil value for the saw was 0 anyway, but the fist has the same recoil value as the pistol, but since it doesn't call a flash, it doesn't have recoil by default). Technically it also doesn't apply to the rocket launcher or BFG, but those indirectly get recoil from the `A_GunFlash`. This is why I'm iffy about adding recoil to MBF21 attack codepointers, because it's already missing from the rocket launcher and BFG.

We could do a clean slate approach by removing the recoil from weapon attack codepointers in MBF21, or we could retroactively add recoil to missing attack codepointers for MBF21.

Another completely separate approach we could do is add a whole new codepointer called like "A_WeaponCustomRecoil" and allow any value as well as direct control over recoil (regardless of OPTIONS `weapon_recoil`). If we did this, I'd connect it with the "Weapon Recoil" property, and if that property isn't used, just go with the default recoil set for that weapon.