### PR TITLE
OpenGL: Fix textures using old boom colormap while under invulnerabilty

### DIFF
--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -194,8 +194,8 @@ static void gld_GetTextureTexID(GLTexture *gltexture, int cm)
       bcm = 0;
     }
   }
-  gltexture->texflags_p = &gltexture->texflags[cm][gltexture->player_cm];
-  gltexture->texid_p = &gltexture->glTexExID[cm][gltexture->player_cm][bcm];
+  gltexture->texflags_p = &gltexture->texflags[cm][player_cm];
+  gltexture->texid_p = &gltexture->glTexExID[cm][player_cm][bcm];
   return;
 }
 

--- a/prboom2/src/gl_texture.c
+++ b/prboom2/src/gl_texture.c
@@ -189,8 +189,10 @@ static void gld_GetTextureTexID(GLTexture *gltexture, int cm)
     if (cm == CR_LIMIT)
       cm = CR_DEFAULT;
     if (player_cm != INVULN_PLAYER_CM)
+    {
       player_cm = 0;
-    bcm = 0;
+      bcm = 0;
+    }
   }
   gltexture->texflags_p = &gltexture->texflags[cm][gltexture->player_cm];
   gltexture->texid_p = &gltexture->glTexExID[cm][gltexture->player_cm][bcm];


### PR DESCRIPTION
Fixes #925.

Depending on how a texture was first seen, if it was first seen under a boom colormap, it wouldn't update the texture under the invulnerability colormap