### PR TITLE
Name the screenshots "dsda" instead of the generic "doom"

### DIFF
--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -912,9 +912,9 @@ void M_ScreenShot(void)
     startshot = shot; // CPhipps - prevent infinite loop
 
     do {
-      int size = snprintf(NULL, 0, "%s/dsda%02d" SCREENSHOT_EXT, shot_dir, shot);
+      int size = snprintf(NULL, 0, "%s/dsda%04d" SCREENSHOT_EXT, shot_dir, shot);
       lbmname = Z_Realloc(lbmname, size+1);
-      snprintf(lbmname, size+1, "%s/dsda%02d" SCREENSHOT_EXT, shot_dir, shot);
+      snprintf(lbmname, size+1, "%s/dsda%04d" SCREENSHOT_EXT, shot_dir, shot);
       shot++;
     } while (M_FileExists(lbmname) && (shot != startshot) && (shot < 10000));
 

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -912,9 +912,9 @@ void M_ScreenShot(void)
     startshot = shot; // CPhipps - prevent infinite loop
 
     do {
-      int size = snprintf(NULL, 0, "%s/doom%02d" SCREENSHOT_EXT, shot_dir, shot);
+      int size = snprintf(NULL, 0, "%s/dsda%02d" SCREENSHOT_EXT, shot_dir, shot);
       lbmname = Z_Realloc(lbmname, size+1);
-      snprintf(lbmname, size+1, "%s/doom%02d" SCREENSHOT_EXT, shot_dir, shot);
+      snprintf(lbmname, size+1, "%s/dsda%02d" SCREENSHOT_EXT, shot_dir, shot);
       shot++;
     } while (M_FileExists(lbmname) && (shot != startshot) && (shot < 10000));
 


### PR DESCRIPTION
Fixes #933 