### PR TITLE
Allow base optional sounds to work in heretic and hexen

### DIFF
--- a/docs/optional_sounds.md
+++ b/docs/optional_sounds.md
@@ -1,0 +1,39 @@
+# Optional Sounds
+
+These are sound lumps that can be optionally provided and will be used instead of the game's default. For example instead of forcing the menu opening sound to be the same sound as as switch, it can be its own.
+
+In Heretic and Hexen, even though there is not a requirement for base game sounds to be prefixed by `ds`, these sounds **are** prefixed by it, and will not be recognized without.
+
+### Menu Sounds
+
+Sounds to be played in menu interactions.
+
+| Lump Name 	| Meaning               |
+| ----------- | --------------------- |
+| DSMNUOPN  	| Open Menu             |
+| DSMNUCLS  	| Close Menu            |
+| DSMNUACT  	| Activate Item         |
+| DSMNUBAK  	| Back                  |
+| DSMNUMOV  	| Move                  |
+| DSMNUSLI  	| Slide                 |
+| DSMNUSEL  	| Select (Setup Items)  |
+| DSMNUERR  	| Error                 |
+
+### Intermission Sounds
+
+Sounds to be played during intermissions.
+
+| Lump Name 	| Meaning               |
+| ----------- | --------------------- |
+| DSINTTIC  	| Tic                   |
+| DSINTTOT  	| Total                 |
+| DSINTNEX  	| Next                  |
+| DSINTNET  	| Net                   |
+| DSINTDMS  	| Deathmatch            |
+
+
+### Misc Sounds
+
+| Lump Name 	| Meaning               |
+| ----------- | --------------------- |
+| DSSECRET  	| Secret Found          |

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -116,7 +116,6 @@ int g_sfx_pistol;
 int g_sfx_oof;
 int g_sfx_menu;
 int g_sfx_respawn;
-int g_sfx_secret;
 int g_sfx_revive;
 int g_sfx_console;
 
@@ -188,7 +187,6 @@ static void dsda_InitDoom(void) {
   g_sfx_pistol = sfx_pistol;
   g_sfx_oof = sfx_oof;
   g_sfx_menu = sfx_pstop;
-  g_sfx_secret = sfx_secret;
   g_sfx_revive = sfx_slop;
   g_sfx_console = sfx_radio;
 
@@ -361,7 +359,6 @@ static void dsda_InitHeretic(void) {
   g_sfx_oof = heretic_sfx_plroof;
   g_sfx_menu = heretic_sfx_dorcls;
   g_sfx_respawn = heretic_sfx_respawn;
-  g_sfx_secret = heretic_sfx_chat;
   g_sfx_revive = heretic_sfx_telept;
   g_sfx_console = heretic_sfx_chat;
 
@@ -416,7 +413,7 @@ static void dsda_InitHeretic(void) {
     mobjinfo[j].infighting_group = IG_DEFAULT;
     mobjinfo[j].projectile_group = PG_DEFAULT;
     mobjinfo[j].splash_group = SG_DEFAULT;
-    mobjinfo[j].ripsound = heretic_sfx_None;
+    mobjinfo[j].ripsound = sfx_None;
     mobjinfo[j].altspeed = NO_ALTSPEED;
     mobjinfo[j].meleerange = MELEERANGE;
 
@@ -515,7 +512,6 @@ static void dsda_InitHexen(void) {
   g_sfx_oof = hexen_sfx_player_fighter_grunt;
   g_sfx_menu = hexen_sfx_door_light_close;
   g_sfx_respawn = hexen_sfx_respawn;
-  g_sfx_secret = hexen_sfx_chat;
   g_sfx_revive = hexen_sfx_teleport;
   g_sfx_console = hexen_sfx_chat;
 
@@ -566,7 +562,7 @@ static void dsda_InitHexen(void) {
     mobjinfo[j].infighting_group = IG_DEFAULT;
     mobjinfo[j].projectile_group = PG_DEFAULT;
     mobjinfo[j].splash_group = SG_DEFAULT;
-    mobjinfo[j].ripsound = hexen_sfx_None;
+    mobjinfo[j].ripsound = sfx_None;
     mobjinfo[j].altspeed = NO_ALTSPEED;
     mobjinfo[j].meleerange = MELEERANGE;
 

--- a/prboom2/src/dsda/global.h
+++ b/prboom2/src/dsda/global.h
@@ -88,7 +88,6 @@ extern int g_sfx_pistol;
 extern int g_sfx_oof;
 extern int g_sfx_menu;
 extern int g_sfx_respawn;
-extern int g_sfx_secret;
 extern int g_sfx_revive;
 extern int g_sfx_console;
 

--- a/prboom2/src/dsda/music.c
+++ b/prboom2/src/dsda/music.c
@@ -139,7 +139,7 @@ dboolean dsda_StartQueuedMusic(void) {
   if (music_queue == -1)
     return false;
 
-  S_ChangeMusInfoMusic(music_queue, true, false);
+  S_ChangeMusInfoMusic(music_queue, true);
   music_queue = -1;
 
   return true;

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -106,11 +106,11 @@ void F_StartFinale (void)
 
   if (muslump >= 0)
   {
-    S_ChangeMusInfoMusic(muslump, true, false);
+    S_ChangeMusInfoMusic(muslump, true);
   }
   else
   {
-    S_ChangeMusic(mnum, true, false);
+    S_ChangeMusic(mnum, true);
   }
 
   // Okay - IWAD dependend stuff.
@@ -480,7 +480,7 @@ static void F_StartCastMusic(const char* music, dboolean loop_music)
   }
   else if (gamemode == commercial)
   {
-    S_ChangeMusic(mus_evil, loop_music, false);
+    S_ChangeMusic(mus_evil, loop_music);
   }
   else
   {
@@ -735,7 +735,7 @@ static void F_StartScrollMusic(const char* music, dboolean loop_music)
       lprintf(LO_WARN, "Finale scroll music not found: %s\n", music);
   }
   else if (W_LumpNameExists("D_BUNNY"))
-    S_ChangeMusic(mus_bunny, loop_music, false);
+    S_ChangeMusic(mus_bunny, loop_music);
   else {
     lprintf(LO_WARN, "Finale scroll music unspecified\n");
     S_StopMusic();

--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -81,7 +81,7 @@ void Heretic_F_StartFinale(void)
   finalestage = 0;
   finalecount = 0;
   FontABaseLump = W_GetNumForName("FONTA_S") + 1;
-  S_ChangeMusic(heretic_mus_cptd, true, false);
+  S_ChangeMusic(heretic_mus_cptd, true);
 }
 
 static dboolean F_BlockingInput(void)   // Avoid bringing up menu when loading Heretic's custom E2 palette

--- a/prboom2/src/heretic/in_lude.c
+++ b/prboom2/src/heretic/in_lude.c
@@ -233,7 +233,7 @@ void IN_Start(wbstartstruct_t* wbstartstruct)
     intertime = 0;
     oldintertime = 0;
     AM_Stop(false);
-    S_ChangeMusic(heretic_mus_intr, true, false);
+    S_ChangeMusic(heretic_mus_intr, true);
 }
 
 //========================================================================

--- a/prboom2/src/heretic/info.c
+++ b/prboom2/src/heretic/info.c
@@ -1254,24 +1254,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ITEM_PTN1_1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1281,24 +1281,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ITEM_SHLD1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1308,24 +1308,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ITEM_SHD2_1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1335,24 +1335,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ITEM_BAGH1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1362,24 +1362,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ITEM_SPMP1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1389,24 +1389,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_INVS1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_SHADOW | MF_COUNTITEM,     // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1416,24 +1416,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_PTN2_1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1443,24 +1443,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_SOAR1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1470,24 +1470,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_INVU1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1497,24 +1497,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_PWBK1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1524,24 +1524,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_EGGC1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1553,10 +1553,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -1568,7 +1568,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -1578,24 +1578,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_SPHL1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1605,24 +1605,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_TRCH1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1632,24 +1632,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_FBMB1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1659,12 +1659,12 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_FIREBOMB1,               // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -1676,7 +1676,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -1686,24 +1686,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_ARTI_ATLP1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_COUNTITEM, // flags
      MF2_FLOATBOB               // flags2
      },
@@ -1713,12 +1713,12 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_POD_WAIT1,               // spawnstate
      45,                        // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_POD_PAIN1,               // painstate
      255,                       // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -1730,7 +1730,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      54 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_NOBLOOD | MF_SHOOTABLE | MF_DROPOFF, // flags
      MF2_WINDTHRUST | MF2_PUSHABLE | MF2_SLIDE | MF2_PASSMOBJ | MF2_TELESTOMP   // flags2
      },
@@ -1740,24 +1740,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_PODGOO1,                 // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_PODGOOX,                 // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_CANNOTPUSH       // flags2
      },
@@ -1767,24 +1767,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_PODGENERATOR,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      },
@@ -1794,24 +1794,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SPLASH1,                 // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_SPLASHX,                 // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_CANNOTPUSH       // flags2
      },
@@ -1821,24 +1821,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SPLASHBASE1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -1848,24 +1848,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_LAVASPLASH1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -1875,24 +1875,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_LAVASMOKE1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -1902,24 +1902,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SLUDGECHUNK1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_SLUDGECHUNKX,            // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_CANNOTPUSH       // flags2
      },
@@ -1929,24 +1929,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SLUDGESPLASH1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -1956,24 +1956,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SKULLHANG70_1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      70 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -1983,24 +1983,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SKULLHANG60_1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      60 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -2010,24 +2010,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SKULLHANG45_1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      45 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -2037,24 +2037,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SKULLHANG35_1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      35 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -2064,24 +2064,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_CHANDELIER1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      60 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -2091,24 +2091,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SERPTORCH1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      54 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2118,24 +2118,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SMALLPILLAR,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      34 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2145,24 +2145,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STALAGMITESMALL,         // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2172,24 +2172,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STALAGMITELARGE,         // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2199,24 +2199,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STALACTITESMALL,         // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      36 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -2226,24 +2226,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STALACTITELARGE,         // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      68 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -2253,24 +2253,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_FIREBRAZIER1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      44 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2280,24 +2280,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BARREL,                  // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2307,24 +2307,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BRPILLAR,                // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      128 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2334,24 +2334,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_MOSS1,                   // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      23 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -2361,24 +2361,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_MOSS2,                   // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      27 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -2388,24 +2388,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_WALLTORCH1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOGRAVITY,              // flags
      0                          // flags2
      },
@@ -2415,24 +2415,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_HANGINGCORPSE,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      104 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -2442,24 +2442,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_KEYGIZMO1,               // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2469,24 +2469,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_KEYGIZMO1,               // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2496,24 +2496,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_KEYGIZMO1,               // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2523,24 +2523,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_KGZ_START,               // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_NOGRAVITY,   // flags
      0                          // flags2
      },
@@ -2550,24 +2550,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_VOLCANO1,                // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -2577,12 +2577,12 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_VOLCANOBALL1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -2594,7 +2594,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_LOGRAV | MF2_NOTELEPORT | MF2_FIREDAMAGE       // flags2
      },
@@ -2604,24 +2604,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_VOLCANOTBALL1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_VOLCANOTBALLX1,          // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      2 * FRACUNIT,              // speed
      8 * FRACUNIT,              // radius
      6 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_LOGRAV | MF2_NOTELEPORT | MF2_FIREDAMAGE       // flags2
      },
@@ -2631,24 +2631,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_TELEGLITGEN1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_NOSECTOR,        // flags
      0                          // flags2
      },
@@ -2658,24 +2658,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_TELEGLITGEN2,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_NOSECTOR,        // flags
      0                          // flags2
      },
@@ -2685,24 +2685,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_TELEGLITTER1_1,          // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      0                          // flags2
      },
@@ -2712,24 +2712,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_TELEGLITTER2_1,          // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      0                          // flags2
      },
@@ -2739,24 +2739,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_TFOG1,                   // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -2766,24 +2766,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      },
@@ -2793,24 +2793,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STAFFPUFF1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
      heretic_sfx_stfhit,                // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -2820,24 +2820,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STAFFPUFF2_1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
      heretic_sfx_stfpow,                // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -2847,24 +2847,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_STAFFPUFF1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
      heretic_sfx_chicatk,               // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -2874,24 +2874,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_WGNT,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -2901,24 +2901,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_GAUNTLETPUFF1_1,         // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -2928,24 +2928,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_GAUNTLETPUFF2_1,         // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -2955,24 +2955,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLSR,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -2982,12 +2982,12 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLASTERFX1_1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -2999,7 +2999,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3009,24 +3009,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLASTERSMOKE1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH    // flags2
      },
@@ -3038,10 +3038,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3053,7 +3053,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_RIP   // flags2
      },
@@ -3063,24 +3063,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLASTERPUFF1_1,          // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -3090,24 +3090,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLASTERPUFF2_1,          // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -3117,24 +3117,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_WMCE,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -3146,10 +3146,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      heretic_sfx_lobsht,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3161,7 +3161,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_FLOORBOUNCE | MF2_THRUGHOST | MF2_NOTELEPORT   // flags2
      },
@@ -3173,10 +3173,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3188,7 +3188,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      6,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_LOGRAV | MF2_FLOORBOUNCE | MF2_THRUGHOST | MF2_NOTELEPORT      // flags2
      },
@@ -3200,10 +3200,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3215,7 +3215,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      4,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_LOGRAV | MF2_FLOORBOUNCE | MF2_THRUGHOST | MF2_NOTELEPORT      // flags2
      },
@@ -3227,10 +3227,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3242,7 +3242,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      18,                        // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_LOGRAV | MF2_FLOORBOUNCE | MF2_THRUGHOST | MF2_TELESTOMP       // flags2
      },
@@ -3252,24 +3252,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_WSKL,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -3281,10 +3281,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      heretic_sfx_hrnsht,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3296,7 +3296,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_NOTELEPORT    // flags2
      },
@@ -3308,10 +3308,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      heretic_sfx_hrnsht,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3323,7 +3323,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      10,                        // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3335,10 +3335,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3350,7 +3350,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      12 * FRACUNIT,             // height
      100,                       // mass
      5,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3362,10 +3362,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3377,7 +3377,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      12 * FRACUNIT,             // height
      100,                       // mass
      5,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3389,10 +3389,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3404,7 +3404,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      12 * FRACUNIT,             // height
      100,                       // mass
      5,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3416,10 +3416,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3431,7 +3431,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      12 * FRACUNIT,             // height
      100,                       // mass
      5,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3443,10 +3443,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3458,7 +3458,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3470,10 +3470,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3485,7 +3485,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3495,24 +3495,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_GWANDPUFF1_1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -3522,24 +3522,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_GWANDFXI1_1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -3549,24 +3549,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_WPHX,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -3578,10 +3578,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      heretic_sfx_phosht,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3593,7 +3593,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      20,                        // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_THRUGHOST | MF2_NOTELEPORT     // flags2
      },
@@ -3607,24 +3607,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_PHOENIXFXIX_1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                // seesound
+     sfx_None,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_PHOENIXFXIX_3,           // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT     // flags2
      },
@@ -3634,24 +3634,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_PHOENIXPUFF1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH    // flags2
      },
@@ -3663,10 +3663,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3678,7 +3678,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -3688,24 +3688,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_WBOW,                    // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -3717,10 +3717,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      heretic_sfx_bowsht,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3732,7 +3732,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      10,                        // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3744,10 +3744,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      heretic_sfx_bowsht,                // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3759,7 +3759,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      6,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3771,10 +3771,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -3786,7 +3786,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_THRUGHOST | MF2_NOTELEPORT    // flags2
      },
@@ -3796,24 +3796,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_CRBOWFX4_1,              // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      MF2_LOGRAV                 // flags2
      },
@@ -3823,24 +3823,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLOOD1,                  // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -3850,24 +3850,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLOODSPLATTER1,          // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_BLOODSPLATTERX,          // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH    // flags2
      },
@@ -3877,9 +3877,9 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_PLAY,                    // spawnstate
      100,                       // spawnhealth
      HERETIC_S_PLAY_RUN1,               // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      0,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_PLAY_PAIN,               // painstate
      255,                       // painchance
      heretic_sfx_plrpai,                // painsound
@@ -3894,7 +3894,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      56 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_DROPOFF | MF_PICKUP | MF_NOTDMATCH,   // flags
      MF2_WINDTHRUST | MF2_FOOTCLIP | MF2_SLIDE | MF2_PASSMOBJ | MF2_TELESTOMP   // flags2
      },
@@ -3904,24 +3904,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BLOODYSKULL1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF,        // flags
      MF2_LOGRAV | MF2_CANNOTPUSH        // flags2
      },
@@ -3931,9 +3931,9 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_CHICPLAY,                // spawnstate
      100,                       // spawnhealth
      HERETIC_S_CHICPLAY_RUN1,           // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      0,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_CHICPLAY_PAIN,           // painstate
      255,                       // painchance
      heretic_sfx_chicpai,               // painsound
@@ -3948,7 +3948,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      24 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_DROPOFF | MF_NOTDMATCH,       // flags
      MF2_WINDTHRUST | MF2_SLIDE | MF2_PASSMOBJ | MF2_FOOTCLIP | MF2_LOGRAV | MF2_TELESTOMP      // flags2
      },
@@ -3985,24 +3985,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_FEATHER1,                // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_FEATHERX,                // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_CANNOTPUSH | MF2_WINDTHRUST      // flags2
      },
@@ -4120,24 +4120,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_MUMMY_SOUL1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -4149,10 +4149,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4164,7 +4164,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      14 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4203,10 +4203,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4218,7 +4218,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      4,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_NOTELEPORT    // flags2
      },
@@ -4230,10 +4230,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4245,7 +4245,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4257,10 +4257,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4272,7 +4272,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4284,10 +4284,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4299,7 +4299,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4338,10 +4338,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4353,7 +4353,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_NOTELEPORT    // flags2
      },
@@ -4365,10 +4365,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4380,7 +4380,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4419,10 +4419,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4434,7 +4434,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_THRUGHOST     // flags2
      },
@@ -4446,10 +4446,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4461,7 +4461,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4473,10 +4473,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4488,7 +4488,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      12 * FRACUNIT,             // height
      100,                       // mass
      5,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_NOTELEPORT    // flags2
      },
@@ -4500,10 +4500,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4515,7 +4515,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      74 * FRACUNIT,             // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_SHADOW,        // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4581,10 +4581,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4596,7 +4596,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4660,24 +4660,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_IMP_CHUNKA1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -4687,24 +4687,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_IMP_CHUNKB1,             // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -4716,10 +4716,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4731,7 +4731,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_NOTELEPORT    // flags2
      },
@@ -4797,10 +4797,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4812,7 +4812,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_WINDTHRUST | MF2_NOTELEPORT | MF2_THRUGHOST    // flags2
      },
@@ -4824,10 +4824,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4839,7 +4839,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      7,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_THRUGHOST     // flags2
      },
@@ -4878,10 +4878,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4893,7 +4893,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      10,                        // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -4932,10 +4932,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -4947,7 +4947,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4957,24 +4957,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SOR2FXSPARK1,            // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH    // flags2
      },
@@ -4986,10 +4986,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -5001,7 +5001,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      10,                        // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -5011,24 +5011,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SOR2TELEFADE1,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -5067,10 +5067,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -5082,7 +5082,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -5094,10 +5094,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -5109,7 +5109,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      12 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -5121,10 +5121,10 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
@@ -5136,7 +5136,7 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      16 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -5146,24 +5146,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AKYY1,                   // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOTDMATCH, // flags
      0                          // flags2
      },
@@ -5173,24 +5173,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_BKYY1,                   // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOTDMATCH, // flags
      0                          // flags2
      },
@@ -5200,24 +5200,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_CKYY1,                   // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOTDMATCH, // flags
      0                          // flags2
      },
@@ -5227,24 +5227,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMG1,                    // spawnstate
      AMMO_GWND_WIMPY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5254,24 +5254,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMG2_1,                  // spawnstate
      AMMO_GWND_HEFTY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5281,24 +5281,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMM1,                    // spawnstate
      AMMO_MACE_WIMPY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5308,24 +5308,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMM2,                    // spawnstate
      AMMO_MACE_HEFTY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5335,24 +5335,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMC1,                    // spawnstate
      AMMO_CBOW_WIMPY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5362,24 +5362,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMC2_1,                  // spawnstate
      AMMO_CBOW_HEFTY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5389,24 +5389,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMS1_1,                  // spawnstate
      AMMO_SKRD_WIMPY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5416,24 +5416,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMS2_1,                  // spawnstate
      AMMO_SKRD_HEFTY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5443,24 +5443,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMP1_1,                  // spawnstate
      AMMO_PHRD_WIMPY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5470,24 +5470,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMP2_1,                  // spawnstate
      AMMO_PHRD_HEFTY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5497,24 +5497,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMB1_1,                  // spawnstate
      AMMO_BLSR_WIMPY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5524,24 +5524,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_AMB2_1,                  // spawnstate
      AMMO_BLSR_HEFTY,           // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -5551,24 +5551,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SND_WIND,                // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      },
@@ -5578,24 +5578,24 @@ raven_mobjinfo_t heretic_mobjinfo[HERETIC_NUMMOBJTYPES] = {
      HERETIC_S_SND_WATERFALL,           // spawnstate
      1000,                      // spawnhealth
      HERETIC_S_NULL,                    // seestate
-     heretic_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     heretic_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HERETIC_S_NULL,                    // painstate
      0,                         // painchance
-     heretic_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HERETIC_S_NULL,                    // meleestate
      HERETIC_S_NULL,                    // missilestate
      HERETIC_S_NULL,                    // crashstate
      HERETIC_S_NULL,                    // deathstate
      HERETIC_S_NULL,                    // xdeathstate
-     heretic_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     heretic_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      }

--- a/prboom2/src/heretic/sounds.c
+++ b/prboom2/src/heretic/sounds.c
@@ -82,6 +82,25 @@ musicinfo_t heretic_S_music[] = {
 
 sfxinfo_t heretic_S_sfx[] = {
     { "", 0, 0, -1, 0, 0, 0, "" },
+
+    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
+
+    // Heretic sounds
     { "gldhit", 32, 0, -1, 0, 0, 2, "" },
     { "gntful", 32, 0, -1, 0, 0, -1, "" },
     { "gnthit", 32, 0, -1, 0, 0, -1, "" },

--- a/prboom2/src/hexen/info.c
+++ b/prboom2/src/hexen/info.c
@@ -3138,24 +3138,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MAPSPOT,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR | MF_NOGRAVITY,        // flags
      0                          // flags2
      },
@@ -3165,24 +3165,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MAPSPOT,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      MF2_DONTDRAW               // flags2
      },
@@ -3192,12 +3192,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIREBALL1_1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -3209,7 +3209,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -3219,24 +3219,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARROW_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ARROW_X1,                // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      6 * FRACUNIT,              // speed
      8 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3246,24 +3246,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DART_1,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DART_X1,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      6 * FRACUNIT,              // speed
      8 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3273,24 +3273,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_POISONDART_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_POISONDART_X1,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      6 * FRACUNIT,              // speed
      8 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3300,24 +3300,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_RIPPERBALL_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_RIPPERBALL_X1,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      6 * FRACUNIT,              // speed
      8 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      2,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_RIP   // flags2
      },
@@ -3327,24 +3327,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_PRJ_BLADE1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_PRJ_BLADE_X1,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      6 * FRACUNIT,              // speed
      6 * FRACUNIT,              // radius
      6 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3354,12 +3354,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICESHARD1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -3371,7 +3371,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_ICEDAMAGE     // flags2
      },
@@ -3381,24 +3381,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FLAME_TSMALL1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3408,24 +3408,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FLAME_TLARGE1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3435,24 +3435,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FLAME_SMALL1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      MF2_NOTELEPORT | MF2_DONTDRAW      // flags2
      },
@@ -3462,24 +3462,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FLAME_LARGE1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      MF2_NOTELEPORT | MF2_DONTDRAW      // flags2
      },
@@ -3489,24 +3489,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ITEM_PTN1_1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -3516,24 +3516,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_PTN2_1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -3543,24 +3543,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_SOAR1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -3570,24 +3570,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_INVU1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -3597,24 +3597,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_SUMMON,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -3624,24 +3624,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SUMMON_FX1_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SUMMON_FX2_1,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      20 * FRACUNIT,             // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_DROPOFF | MF_NOBLOCKMAP,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3651,24 +3651,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_THRUSTINIT2_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      128 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -3678,24 +3678,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_THRUSTINIT1_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      128 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP | MF2_DONTDRAW      // flags2
      },
@@ -3705,24 +3705,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_TELOTHER1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -3732,24 +3732,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TELO_FX1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_TELO_FX9,                // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      20 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      10001,                     // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3759,24 +3759,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TELO_FX2_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_TELO_FX9,                // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      16 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      10001,                     // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3786,24 +3786,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TELO_FX3_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_TELO_FX9,                // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      16 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      10001,                     // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3813,24 +3813,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TELO_FX4_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_TELO_FX9,                // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      16 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      10001,                     // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3840,24 +3840,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TELO_FX5_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_TELO_FX9,                // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      16 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      10001,                     // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY | MF_NOBLOCKMAP,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3867,24 +3867,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRT1_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DIRT1_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3894,24 +3894,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRT2_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DIRT2_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3921,24 +3921,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRT3_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DIRT3_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -3948,24 +3948,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRT4_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DIRT4_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -3975,24 +3975,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRT5_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DIRT5_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -4002,24 +4002,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRT6_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DIRT6_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -4029,24 +4029,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DIRTCLUMP1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4056,24 +4056,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ROCK1_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ROCK1_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4083,24 +4083,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ROCK2_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ROCK2_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4110,24 +4110,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ROCK3_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ROCK3_D,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4137,24 +4137,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SPAWNFOG1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      MF2_DONTDRAW | MF2_FLOATBOB        // flags2
      },
@@ -4164,24 +4164,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FOGPATCHS1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FOGPATCHS0,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      FRACUNIT,                  // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_FLOAT | MF_NOGRAVITY | MF_SHADOW | MF_NOCLIP,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4191,24 +4191,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FOGPATCHM1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FOGPATCHM0,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      FRACUNIT,                  // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_FLOAT | MF_NOGRAVITY | MF_SHADOW | MF_NOCLIP,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4218,24 +4218,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FOGPATCHL1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FOGPATCHL0,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      FRACUNIT,                  // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_FLOAT | MF_NOGRAVITY | MF_SHADOW | MF_NOCLIP,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4245,24 +4245,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_QUAKE_ACTIVE1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      MF2_DONTDRAW               // flags2
      },
@@ -4272,24 +4272,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD1_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD1_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4299,24 +4299,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD2_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD2_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4326,24 +4326,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD3_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD3_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4353,24 +4353,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD4_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD4_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4380,24 +4380,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD5_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD5_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4407,24 +4407,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD6_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD6_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4434,24 +4434,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD7_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD7_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4461,24 +4461,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD8_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD8_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4488,24 +4488,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD9_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD9_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4515,24 +4515,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SGSHARD0_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SGSHARD0_D,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -4542,24 +4542,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_EGGC1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -4571,10 +4571,10 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -4586,7 +4586,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -4596,24 +4596,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_SPHL1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -4623,24 +4623,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZWINGEDSTATUENOSKULL,    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -4650,24 +4650,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZGEMPEDESTAL1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      40 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -4677,24 +4677,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZSKULL,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4704,24 +4704,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEMBIG,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4731,24 +4731,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEMRED,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4758,24 +4758,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEMGREEN1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4785,24 +4785,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEMGREEN2,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4812,24 +4812,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEMBLUE1,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4839,24 +4839,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEMBLUE2,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4866,24 +4866,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZBOOK1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4893,24 +4893,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZBOOK2,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4920,24 +4920,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZSKULL2,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4947,24 +4947,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZFWEAPON,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -4974,24 +4974,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZCWEAPON,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -5001,24 +5001,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZMWEAPON,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -5028,24 +5028,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEAR_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -5055,24 +5055,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEAR2_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -5082,24 +5082,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEAR3_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -5109,24 +5109,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTIPUZZGEAR4_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -5136,24 +5136,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_TRCH1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5163,12 +5163,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIREBOMB1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -5180,7 +5180,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOGRAVITY | MF_ALTSHADOW,       // flags
      MF2_FIREDAMAGE             // flags2
      },
@@ -5190,24 +5190,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_ATLP1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5217,24 +5217,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_PSBG1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5244,24 +5244,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_POISONBAG1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOGRAVITY | MF_NOBLOCKMAP,      // flags
      0                          // flags2
      },
@@ -5271,12 +5271,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_POISONCLOUD1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -5288,7 +5288,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      1,                         // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOGRAVITY | MF_NOBLOCKMAP | MF_SHADOW | MF_NOCLIP | MF_DROPOFF, // flags
      MF2_NODMGTHRUST            // flags2
      },
@@ -5300,10 +5300,10 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_flechette_bounce,      // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -5315,7 +5315,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_FLOORBOUNCE | MF2_FIREDAMAGE   // flags2
      },
@@ -5325,24 +5325,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_BOOTS1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5352,24 +5352,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_MANA,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5379,24 +5379,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_ARMOR1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5406,24 +5406,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_BLAST1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5433,24 +5433,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARTI_HEALRAD1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -5460,24 +5460,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SPLASH1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SPLASHX,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_CANNOTPUSH       // flags2
      },
@@ -5487,24 +5487,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SPLASHBASE1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -5514,24 +5514,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LAVASPLASH1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -5541,24 +5541,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LAVASMOKE1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -5568,24 +5568,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SLUDGECHUNK1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SLUDGECHUNKX,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_CANNOTPUSH       // flags2
      },
@@ -5595,24 +5595,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SLUDGESPLASH1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -5622,24 +5622,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZWINGEDSTATUE1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5649,24 +5649,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCK1_1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -5676,24 +5676,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCK2_1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -5703,24 +5703,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCK3_1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -5730,24 +5730,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCK4_1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5757,24 +5757,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHANDELIER1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      60 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -5784,24 +5784,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHANDELIER_U,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      60 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -5811,24 +5811,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREEDEAD1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      96 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5838,24 +5838,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREE,                   // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      128 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5865,12 +5865,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREEDESTRUCTIBLE1,      // spawnstate
      70,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -5882,7 +5882,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      180 * FRACUNIT,            // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -5892,24 +5892,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREESWAMP182_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      150 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5919,24 +5919,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREESWAMP172_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      120 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5946,24 +5946,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTUMPBURNED1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -5973,24 +5973,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTUMPBARE1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6000,24 +6000,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTUMPSWAMP1_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6027,24 +6027,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTUMPSWAMP2_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6054,24 +6054,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMLARGE1_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6081,24 +6081,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMLARGE2_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6108,24 +6108,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMLARGE3_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6135,24 +6135,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMSMALL1_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6162,24 +6162,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMSMALL2_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6189,24 +6189,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMSMALL3_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6216,24 +6216,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMSMALL4_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6243,24 +6243,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHROOMSMALL5_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6270,24 +6270,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITEPILLAR1,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      138 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6297,24 +6297,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITELARGE1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      48 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6324,24 +6324,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITEMEDIUM1,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      6 * FRACUNIT,              // radius
      40 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6351,24 +6351,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITESMALL1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      36 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6378,24 +6378,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITELARGE1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      66 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -6405,24 +6405,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITEMEDIUM1,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      6 * FRACUNIT,              // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -6432,24 +6432,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITESMALL1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      40 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -6459,24 +6459,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZMOSSCEILING1_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -6486,24 +6486,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZMOSSCEILING2_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      24 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPAWNCEILING | MF_NOGRAVITY,    // flags
      0                          // flags2
      },
@@ -6513,24 +6513,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSWAMPVINE1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      52 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6540,24 +6540,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCORPSEKABOB1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      92 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6567,24 +6567,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCORPSESLEEPING1,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -6594,24 +6594,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONERIP1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      46 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6621,24 +6621,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONESHANE1,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      46 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6648,24 +6648,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONEBIGCROSS1,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      46 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6675,24 +6675,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONEBRIANR1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      52 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6702,24 +6702,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONECROSSCIRCLE1,  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      52 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6729,24 +6729,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONESMALLCROSS1,   // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      46 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6756,24 +6756,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTOMBSTONEBRIANP1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      46 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6783,24 +6783,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CORPSEHANGING_1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      6 * FRACUNIT,              // radius
      75 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -6810,24 +6810,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEGREENTALL_1,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6837,24 +6837,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEBLUETALL_1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6864,24 +6864,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEGREENSHORT_1,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6891,24 +6891,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEBLUESHORT_1,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6918,24 +6918,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLESTRIPETALL_1,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6945,24 +6945,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEDARKREDTALL_1,    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6972,24 +6972,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEREDTALL_1,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -6999,24 +6999,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLETANTALL_1,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7026,24 +7026,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLERUSTTALL_1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      108 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7053,24 +7053,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEDARKREDSHORT_1,   // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7080,24 +7080,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLEREDSHORT_1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7107,24 +7107,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLETANSHORT_1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7134,24 +7134,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTATUEGARGOYLERUSTSHORT_1,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      14 * FRACUNIT,             // radius
      62 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7161,24 +7161,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZBANNERTATTERED_1,       // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      120 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7188,24 +7188,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREELARGE1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ZTREELARGE1,             // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      180 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7215,24 +7215,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREELARGE2,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ZTREELARGE2,             // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      180 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7242,24 +7242,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREEGNARLED1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      22 * FRACUNIT,             // radius
      100 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7269,24 +7269,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTREEGNARLED2,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      22 * FRACUNIT,             // radius
      100 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7296,24 +7296,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZLOG,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      25 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7323,24 +7323,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITEICELARGE,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      66 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -7350,24 +7350,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITEICEMEDIUM,    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -7377,24 +7377,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITEICESMALL,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -7404,24 +7404,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALACTITEICETINY,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -7431,24 +7431,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITEICELARGE,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      66 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7458,24 +7458,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITEICEMEDIUM,    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7485,24 +7485,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITEICESMALL,     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7512,24 +7512,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSTALAGMITEICETINY,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7539,24 +7539,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCKBROWN1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      17 * FRACUNIT,             // radius
      72 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7566,24 +7566,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCKBROWN2,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      50 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7593,24 +7593,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZROCKBLACK,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      40 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7620,24 +7620,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZRUBBLE1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -7647,24 +7647,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZRUBBLE2,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -7674,24 +7674,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZRUBBLE3,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -7701,24 +7701,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZVASEPILLAR,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      54 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -7728,24 +7728,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZPOTTERY1,               // spawnstate
      15,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ZPOTTERY_EXPLODE,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD | MF_DROPOFF, // flags
      MF2_SLIDE | MF2_PUSHABLE | MF2_TELESTOMP | MF2_PASSMOBJ    // flags2
      },
@@ -7755,24 +7755,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZPOTTERY2,               // spawnstate
      15,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ZPOTTERY_EXPLODE,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      25 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD | MF_DROPOFF, // flags
      MF2_SLIDE | MF2_PUSHABLE | MF2_TELESTOMP | MF2_PASSMOBJ    // flags2
      },
@@ -7782,24 +7782,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZPOTTERY3,               // spawnstate
      15,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ZPOTTERY_EXPLODE,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      25 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD | MF_DROPOFF, // flags
      MF2_SLIDE | MF2_PUSHABLE | MF2_TELESTOMP | MF2_PASSMOBJ    // flags2
      },
@@ -7809,24 +7809,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_POTTERYBIT_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_POTTERYBIT_EX0,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE,                // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -7836,24 +7836,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCORPSELYNCHED1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      11 * FRACUNIT,             // radius
      95 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -7863,24 +7863,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCORPSELYNCHED2,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      100 * FRACUNIT,            // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -7890,24 +7890,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCORPSESITTING,          // spawnstate
      30,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ZCORPSESITTING_X,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      35 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -7917,24 +7917,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CORPSEBIT_1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      MF2_TELESTOMP              // flags2
      },
@@ -7944,12 +7944,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CORPSEBLOODDRIP,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -7961,7 +7961,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE,                // flags
      MF2_LOGRAV                 // flags2
      },
@@ -7971,24 +7971,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BLOODPOOL,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -7998,24 +7998,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCANDLE1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -8025,24 +8025,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZLEAFSPAWNER,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      MF2_DONTDRAW               // flags2
      },
@@ -8052,24 +8052,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LEAF1_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_LEAF_X1,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE,        // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -8079,24 +8079,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LEAF2_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_LEAF_X1,                 // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE,        // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -8106,24 +8106,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTWINEDTORCH_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8133,24 +8133,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZTWINEDTORCH_UNLIT,      // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      10 * FRACUNIT,             // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8160,24 +8160,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BRIDGE1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      32 * FRACUNIT,             // radius
      2 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_NOGRAVITY,   // flags
      MF2_DONTDRAW               // flags2
      },
@@ -8187,24 +8187,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BBALL1,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -8214,24 +8214,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZWALLTORCH1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -8241,24 +8241,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZWALLTORCH_U,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -8268,24 +8268,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZBARREL1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8295,12 +8295,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHRUB1,                 // spawnstate
      20,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_ZSHRUB1_X1,              // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -8312,7 +8312,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      24 * FRACUNIT,             // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -8322,12 +8322,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSHRUB2,                 // spawnstate
      10,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_ZSHRUB2_X1,              // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -8339,7 +8339,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      40 * FRACUNIT,             // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -8349,24 +8349,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZBUCKET1,                // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      72 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SPAWNCEILING | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -8376,9 +8376,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZPOISONSHROOM1,          // spawnstate
      30,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_ZPOISONSHROOM_P1,        // painstate
      255,                       // painchance
      hexen_sfx_poisonshroom_pain,     // painsound
@@ -8393,7 +8393,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      20 * FRACUNIT,             // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SHOOTABLE | MF_SOLID | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -8403,24 +8403,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZFIREBULL1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      80 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8430,24 +8430,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZFIREBULL_U,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      80 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8457,24 +8457,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZFIRETHING1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      10 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8484,24 +8484,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZBRASSTORCH1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      6 * FRACUNIT,              // radius
      35 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8511,12 +8511,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZSUITOFARMOR,            // spawnstate
      60,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -8528,7 +8528,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      72 * FRACUNIT,             // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -8538,24 +8538,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZARMORCHUNK1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      0,                         // flags
      0                          // flags2
      },
@@ -8565,12 +8565,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZBELL,                   // spawnstate
      5,                         // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -8582,7 +8582,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      120 * FRACUNIT,            // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD | MF_NOGRAVITY | MF_SPAWNCEILING,     // flags
      0                          // flags2
      },
@@ -8592,24 +8592,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZBLUE_CANDLE1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -8619,24 +8619,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZIRON_MAIDEN,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      60 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8646,12 +8646,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZXMAS_TREE,              // spawnstate
      20,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_ZXMAS_TREE_X1,           // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -8663,7 +8663,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      130 * FRACUNIT,            // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_NOBLOOD,      // flags
      0                          // flags2
      },
@@ -8673,24 +8673,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCAULDRON1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      26 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8700,24 +8700,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCAULDRON_U,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      12 * FRACUNIT,             // radius
      26 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID,                  // flags
      0                          // flags2
      },
@@ -8727,24 +8727,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINBIT32,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8754,24 +8754,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINBIT64,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8781,24 +8781,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINEND_HEART,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8808,24 +8808,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINEND_HOOK1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8835,24 +8835,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINEND_HOOK2,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8862,24 +8862,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINEND_SPIKE,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8889,24 +8889,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ZCHAINEND_SKULL,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      32 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SPAWNCEILING,    // flags
      0                          // flags2
      },
@@ -8916,24 +8916,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -8943,24 +8943,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT2,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -8970,24 +8970,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT3,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -8997,24 +8997,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT4,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9024,24 +9024,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT5,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9051,24 +9051,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT6,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9078,24 +9078,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT7,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9105,24 +9105,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT8,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9132,24 +9132,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT9,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9159,24 +9159,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TABLE_SHIT10,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -9186,24 +9186,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TFOG1,                   // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -9213,24 +9213,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_TELESMOKE1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -9240,24 +9240,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      },
@@ -9272,19 +9272,19 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_fighter_punch_hitwall, // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -9294,24 +9294,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_AXE,                     // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -9326,19 +9326,19 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_fighter_hammer_hitwall,        // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -9353,19 +9353,19 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_fighter_hammer_hitwall,        // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -9375,24 +9375,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_AXEBLOOD1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_AXEBLOOD6,               // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF, // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH    // flags2
      },
@@ -9402,24 +9402,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HAMM,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -9429,12 +9429,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HAMMER_MISSILE_1,        // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -9446,7 +9446,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      20 * FRACUNIT,             // height
      100,                       // mass
      10,                        // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
@@ -9461,19 +9461,19 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_fighter_hammer_hitwall,        // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -9483,12 +9483,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FSWORD_MISSILE1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -9500,7 +9500,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      8,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
@@ -9510,24 +9510,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FSWORD_FLAME1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -9537,24 +9537,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CSTAFF,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -9564,12 +9564,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CSTAFF_MISSILE1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -9581,7 +9581,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      5,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
@@ -9593,22 +9593,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_cleric_cstaff_hitthing,        // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -9618,24 +9618,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CFLAME1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -9645,24 +9645,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CFLAMEFLOOR1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -9677,19 +9677,19 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_cleric_flame_explode,  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      FRACUNIT,                  // radius
      FRACUNIT,                  // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -9704,19 +9704,19 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_cleric_flame_explode,  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      FRACUNIT,                  // radius
      FRACUNIT,                  // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -9726,12 +9726,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CIRCLE_FLAME1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -9743,7 +9743,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      16 * FRACUNIT,             // height
      100,                       // mass
      2,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -9753,24 +9753,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CFLAME_MISSILE1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_CFLAME_MISSILE_X,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      200 * FRACUNIT,            // speed
      14 * FRACUNIT,             // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      8,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_DONTDRAW | MF2_FIREDAMAGE   // flags2
      },
@@ -9780,12 +9780,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HOLY_FX1,                // spawnstate
      105,                       // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -9797,7 +9797,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE,     // flags
      MF2_NOTELEPORT | MF2_SEEKERMISSILE | MF2_RIP | MF2_IMPACT | MF2_PCROSS     // flags2
      },
@@ -9807,24 +9807,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HOLY_TAIL1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      FRACUNIT,                  // radius
      FRACUNIT,                  // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_NOCLIP | MF_ALTSHADOW,      // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -9834,24 +9834,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HOLY_PUFF1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -9861,24 +9861,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HOLY_MISSILE1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_HOLY_MISSILE_X,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      30 * FRACUNIT,             // speed
      15 * FRACUNIT,             // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_MISSILE,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -9888,24 +9888,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_HOLY_MISSILE_P1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW,  // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -9915,24 +9915,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MWANDPUFF1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH | MF2_NODMGTHRUST  // flags2
      },
@@ -9942,24 +9942,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MWANDSMOKE1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH | MF2_NODMGTHRUST  // flags2
      },
@@ -9969,24 +9969,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MWAND_MISSILE1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_MWANDPUFF1,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      184 * FRACUNIT,            // speed
      12 * FRACUNIT,             // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      2,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_RIP | MF2_IMPACT | MF2_PCROSS | MF2_NODMGTHRUST | MF2_CANNOTPUSH      // flags2
      },
@@ -9996,24 +9996,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MW_LIGHTNING1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -10023,24 +10023,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LIGHTNING_CEILING1,      // spawnstate
      144,                       // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_LIGHTNING_C_X1,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      25 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      40 * FRACUNIT,             // height
      100,                       // mass
      8,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
@@ -10050,24 +10050,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LIGHTNING_FLOOR1,        // spawnstate
      144,                       // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_LIGHTNING_F_X1,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      25 * FRACUNIT,             // speed
      16 * FRACUNIT,             // radius
      40 * FRACUNIT,             // height
      100,                       // mass
      8,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
@@ -10077,24 +10077,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_LIGHTNING_ZAP1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_LIGHTNING_ZAP_X8,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      35 * FRACUNIT,             // height
      100,                       // mass
      2,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
      0                          // flags2
      },
@@ -10104,12 +10104,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MSTAFF_FX1_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -10121,7 +10121,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      6,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_RIP | MF2_IMPACT | MF2_PCROSS        // flags2
      },
@@ -10131,12 +10131,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MSTAFF_FX2_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -10148,7 +10148,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_IMPACT | MF2_PCROSS | MF2_SEEKERMISSILE      // flags2
      },
@@ -10158,24 +10158,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FSWORD1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10185,24 +10185,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FSWORD2,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10212,24 +10212,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FSWORD3,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10239,24 +10239,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CHOLY1,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10266,24 +10266,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CHOLY2,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10293,24 +10293,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CHOLY3,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10320,24 +10320,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MSTAFF1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10347,24 +10347,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MSTAFF2,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10374,24 +10374,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MSTAFF3,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -10401,24 +10401,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_PUNCHPUFF1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -10428,24 +10428,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_COS1,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -10455,12 +10455,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SHARDFX1_1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -10472,7 +10472,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_ICEDAMAGE   // flags2
      },
@@ -10482,24 +10482,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BLOOD1,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      0                          // flags2
      },
@@ -10509,24 +10509,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BLOODSPLATTER1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_BLOODSPLATTERX,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF,   // flags
      MF2_NOTELEPORT | MF2_CANNOTPUSH    // flags2
      },
@@ -10536,24 +10536,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_GIBS1,                   // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_CORPSE,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -10563,9 +10563,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FPLAY,                   // spawnstate
      100,                       // spawnhealth
      HEXEN_S_FPLAY_RUN1,              // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      0,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_FPLAY_PAIN,              // painstate
      255,                       // painchance
      hexen_sfx_player_fighter_pain,   // painsound
@@ -10574,13 +10574,13 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FPLAY_DIE1,              // deathstate
      HEXEN_S_FPLAY_XDIE1,             // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_DROPOFF | MF_PICKUP | MF_NOTDMATCH,   // flags
      MF2_WINDTHRUST | MF2_FOOTCLIP | MF2_SLIDE | MF2_PASSMOBJ | MF2_TELESTOMP | MF2_PUSHWALL   // flags2
      },
@@ -10590,24 +10590,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BLOODYSKULL1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      4 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF,        // flags
      MF2_LOGRAV | MF2_CANNOTPUSH        // flags2
      },
@@ -10617,24 +10617,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_PLAYER_SPEED1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_ALTSHADOW,       // flags
      0                          // flags2
      },
@@ -10644,24 +10644,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICECHUNK1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF,        // flags
      MF2_LOGRAV | MF2_CANNOTPUSH | MF2_FOOTCLIP        // flags2
      },
@@ -10671,9 +10671,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CPLAY,                   // spawnstate
      100,                       // spawnhealth
      HEXEN_S_CPLAY_RUN1,              // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      0,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_CPLAY_PAIN,              // painstate
      255,                       // painchance
      hexen_sfx_player_cleric_pain,    // painsound
@@ -10682,13 +10682,13 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_CPLAY_DIE1,              // deathstate
      HEXEN_S_CPLAY_XDIE1,             // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_DROPOFF | MF_PICKUP | MF_NOTDMATCH,   // flags
      MF2_WINDTHRUST | MF2_FOOTCLIP | MF2_SLIDE | MF2_PASSMOBJ | MF2_TELESTOMP | MF2_PUSHWALL   // flags2
      },
@@ -10698,9 +10698,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MPLAY,                   // spawnstate
      100,                       // spawnhealth
      HEXEN_S_MPLAY_RUN1,              // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      0,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_MPLAY_PAIN,              // painstate
      255,                       // painchance
      hexen_sfx_player_mage_pain,      // painsound
@@ -10709,13 +10709,13 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_MPLAY_DIE1,              // deathstate
      HEXEN_S_MPLAY_XDIE1,             // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      16 * FRACUNIT,             // radius
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_DROPOFF | MF_PICKUP | MF_NOTDMATCH,   // flags
      MF2_WINDTHRUST | MF2_FOOTCLIP | MF2_SLIDE | MF2_PASSMOBJ | MF2_TELESTOMP | MF2_PUSHWALL   // flags2
      },
@@ -10725,9 +10725,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_PIGPLAY,                 // spawnstate
      100,                       // spawnhealth
      HEXEN_S_PIGPLAY_RUN1,            // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      0,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_PIGPLAY_PAIN,            // painstate
      255,                       // painchance
      hexen_sfx_pig_pain,              // painsound
@@ -10742,7 +10742,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      24 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_DROPOFF | MF_NOTDMATCH,       // flags
      MF2_WINDTHRUST | MF2_SLIDE | MF2_PASSMOBJ | MF2_FOOTCLIP | MF2_TELESTOMP | MF2_PUSHWALL   // flags2
      },
@@ -10754,7 +10754,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_PIG_WALK1,               // seestate
      hexen_sfx_pig_active1,           // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_PIG_PAIN,                // painstate
      128,                       // painchance
      hexen_sfx_pig_pain,              // painsound
@@ -10833,12 +10833,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CENTAUR_FX1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -10850,7 +10850,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      16 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS   // flags2
      },
@@ -10860,24 +10860,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CENTAUR_SHIELD1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_CENTAUR_SHIELD_X1,       // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_DROPOFF | MF_CORPSE,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -10887,24 +10887,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CENTAUR_SWORD1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_CENTAUR_SWORD_X1,        // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_DROPOFF | MF_CORPSE,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -10941,24 +10941,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMONCHUNK1_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMONCHUNK1_4,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -10968,24 +10968,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMONCHUNK2_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMONCHUNK2_4,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -10995,24 +10995,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMONCHUNK3_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMONCHUNK3_4,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11022,24 +11022,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMONCHUNK4_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMONCHUNK4_4,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11049,24 +11049,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMONCHUNK5_1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMONCHUNK5_4,           // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11076,12 +11076,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMONFX_MOVE1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11093,7 +11093,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      5,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
@@ -11130,24 +11130,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMON2CHUNK1_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMON2CHUNK1_4,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11157,24 +11157,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMON2CHUNK2_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMON2CHUNK2_4,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11184,24 +11184,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMON2CHUNK3_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMON2CHUNK3_4,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11211,24 +11211,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMON2CHUNK4_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMON2CHUNK4_4,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11238,24 +11238,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMON2CHUNK5_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_DEMON2CHUNK5_4,          // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_CORPSE,       // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11265,12 +11265,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DEMON2FX_MOVE1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11282,7 +11282,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      5,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE | MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FIREDAMAGE  // flags2
      },
@@ -11346,12 +11346,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_WRTHFX_MOVE1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11363,7 +11363,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      5,                         // mass
      5,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FOOTCLIP | MF2_FIREDAMAGE  // flags2
      },
@@ -11373,24 +11373,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_WRTHFX_SIZZLE1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      2 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF,        // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11400,12 +11400,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_WRTHFX_DROP1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11417,7 +11417,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      5 * FRACUNIT,              // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -11427,12 +11427,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_WRTHFX_ADROP1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11444,7 +11444,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      5 * FRACUNIT,              // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -11454,12 +11454,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_WRTHFX_BDROP1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11471,7 +11471,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      5 * FRACUNIT,              // height
      5,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -11508,24 +11508,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MNTRFX1_1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_MNTRFXI1_1,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      20 * FRACUNIT,             // speed
      10 * FRACUNIT,             // radius
      6 * FRACUNIT,              // height
      100,                       // mass
      3,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -11535,24 +11535,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MNTRFX2_1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_MNTRFXI2_1,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      14 * FRACUNIT,             // speed
      5 * FRACUNIT,              // radius
      12 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -11564,22 +11564,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_MNTRFXI2_1,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -11589,24 +11589,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MINOSMOKE1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -11616,24 +11616,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MINOSMOKEX1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -11660,7 +11660,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      70 * FRACUNIT,             // height
      INT_MAX,                    // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_COUNTKILL | MF_NOBLOOD,      // flags
      MF2_PASSMOBJ | MF2_DONTDRAW | MF2_CANTLEAVEFLOORPIC | MF2_NONSHOOTABLE | MF2_MCROSS        // flags2
      },
@@ -11687,7 +11687,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      70 * FRACUNIT,             // height
      200,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_COUNTKILL | MF_NOBLOOD,      // flags
      MF2_PASSMOBJ | MF2_DONTDRAW | MF2_CANTLEAVEFLOORPIC | MF2_NONSHOOTABLE | MF2_MCROSS        // flags2
      },
@@ -11699,10 +11699,10 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      0,                         // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11714,7 +11714,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      4,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -11724,24 +11724,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SERPENT_HEAD1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      10 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      MF2_LOGRAV                 // flags2
      },
@@ -11751,24 +11751,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SERPENT_GIB1_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      3 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -11778,24 +11778,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SERPENT_GIB2_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      3 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -11805,24 +11805,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SERPENT_GIB3_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      3 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      0                          // flags2
      },
@@ -11859,24 +11859,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BISHOP_PUFF1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SHADOW | MF_NOBLOCKMAP | MF_NOGRAVITY,  // flags
      0                          // flags2
      },
@@ -11886,24 +11886,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BISHOPBLUR1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -11913,24 +11913,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BISHOPPAINBLUR1,         // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW,  // flags
      0                          // flags2
      },
@@ -11940,12 +11940,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BISHFX1_1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -11957,7 +11957,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_SEEKERMISSILE // flags2
      },
@@ -11994,12 +11994,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DRAGON_FX1_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -12011,7 +12011,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      6,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE    // flags2
      },
@@ -12021,12 +12021,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_DRAGON_FX2_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -12038,7 +12038,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP,             // flags
      MF2_NOTELEPORT | MF2_FIREDAMAGE | MF2_DONTDRAW     // flags2
      },
@@ -12048,24 +12048,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARMOR_1,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -12075,24 +12075,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARMOR_2,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -12102,24 +12102,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARMOR_3,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -12129,24 +12129,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ARMOR_4,                 // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL | MF_NOGRAVITY, // flags
      0                          // flags2
      },
@@ -12156,24 +12156,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MANA1_1,                 // spawnstate
      10,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -12183,24 +12183,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MANA2_1,                 // spawnstate
      10,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -12210,24 +12210,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MANA3_1,                 // spawnstate
      20,                        // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      8 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      MF2_FLOATBOB               // flags2
      },
@@ -12237,24 +12237,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY1,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12264,24 +12264,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY2,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12291,24 +12291,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY3,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12318,24 +12318,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY4,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12345,24 +12345,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY5,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12372,24 +12372,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY6,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12399,24 +12399,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY7,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12426,24 +12426,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY8,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12453,24 +12453,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEY9,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12480,24 +12480,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEYA,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12507,24 +12507,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KEYB,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      8 * FRACUNIT,              // radius
      20 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SPECIAL,                // flags
      0                          // flags2
      },
@@ -12534,24 +12534,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SND_WIND1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      },
@@ -12561,24 +12561,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SND_WATERFALL,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR,       // flags
      0                          // flags2
      },
@@ -12615,24 +12615,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ETTIN_MACE1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ETTIN_MACE5,             // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_DROPOFF | MF_CORPSE,    // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -12644,7 +12644,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_LOOK4,             // seestate
      hexen_sfx_fired_spawn,           // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_FIRED_PAIN1,             // painstate
      1,                         // painchance
      hexen_sfx_fired_pain,            // painsound
@@ -12669,24 +12669,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_CORPSE1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_DROPOFF | MF_CORPSE,    // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -12696,24 +12696,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_CORPSE4,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_DROPOFF | MF_CORPSE,    // flags
      MF2_NOTELEPORT | MF2_FOOTCLIP     // flags2
      },
@@ -12723,24 +12723,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_RDROP1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FIRED_RDEAD1_1,          // deathstate
      HEXEN_S_FIRED_RDEAD1_2,          // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      16,                        // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -12750,24 +12750,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_RDROP2,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FIRED_RDEAD2_1,          // deathstate
      HEXEN_S_FIRED_RDEAD2_2,          // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      16,                        // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -12777,24 +12777,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_RDROP3,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FIRED_RDEAD3_1,          // deathstate
      HEXEN_S_FIRED_RDEAD3_2,          // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      16,                        // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -12804,24 +12804,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_RDROP4,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FIRED_RDEAD4_1,          // deathstate
      HEXEN_S_FIRED_RDEAD4_2,          // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      16,                        // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -12831,24 +12831,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_RDROP5,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_FIRED_RDEAD5_1,          // deathstate
      HEXEN_S_FIRED_RDEAD5_2,          // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      3 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      16,                        // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -12858,12 +12858,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIRED_FX6_1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -12875,7 +12875,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      6 * FRACUNIT,              // height
      15,                        // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_DROPOFF | MF_MISSILE,    // flags
      MF2_NOTELEPORT | MF2_IMPACT | MF2_PCROSS | MF2_FOOTCLIP | MF2_FIREDAMAGE  // flags2
      },
@@ -12890,13 +12890,13 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      hexen_sfx_iceguy_attack,         // attacksound
      HEXEN_S_ICEGUY_PAIN1,            // painstate
      144,                       // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      0,                         // meleestate
      HEXEN_S_ICEGUY_ATK1,             // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_ICEGUY_DEATH,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      14,                        // speed
      22 * FRACUNIT,             // radius
      75 * FRACUNIT,             // height
@@ -12912,12 +12912,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICEGUY_FX1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -12929,7 +12929,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_DROPOFF | MF_NOGRAVITY,    // flags
      MF2_NOTELEPORT | MF2_ICEDAMAGE     // flags2
      },
@@ -12939,24 +12939,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICEFX_PUFF1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      FRACUNIT,                  // radius
      FRACUNIT,                  // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_SHADOW | MF_DROPOFF,     // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -12966,24 +12966,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICEGUY_FX2_1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      10 * FRACUNIT,             // speed
      4 * FRACUNIT,              // radius
      4 * FRACUNIT,              // height
      100,                       // mass
      1,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_MISSILE,   // flags
      MF2_NOTELEPORT | MF2_LOGRAV | MF2_ICEDAMAGE        // flags2
      },
@@ -12993,24 +12993,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICEGUY_BIT1,             // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      FRACUNIT,                  // radius
      FRACUNIT,                  // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF,        // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -13020,24 +13020,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICEGUY_WISP1_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE,     // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13047,24 +13047,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_ICEGUY_WISP2_1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE,     // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13074,9 +13074,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_FIGHTER,                 // spawnstate
      800,                       // spawnhealth
      HEXEN_S_FIGHTER_RUN1,            // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_FIGHTER_PAIN,            // painstate
      50,                        // painchance
      hexen_sfx_player_fighter_pain,   // painsound
@@ -13091,7 +13091,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_COUNTKILL,    // flags
      MF2_FOOTCLIP | MF2_PASSMOBJ | MF2_TELESTOMP | MF2_PUSHWALL | MF2_MCROSS   // flags2
      },
@@ -13101,9 +13101,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_CLERIC,                  // spawnstate
      800,                       // spawnhealth
      HEXEN_S_CLERIC_RUN1,             // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_CLERIC_PAIN,             // painstate
      50,                        // painchance
      hexen_sfx_player_cleric_pain,    // painsound
@@ -13118,7 +13118,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_COUNTKILL,    // flags
      MF2_FOOTCLIP | MF2_PASSMOBJ | MF2_TELESTOMP | MF2_PUSHWALL | MF2_MCROSS   // flags2
      },
@@ -13128,9 +13128,9 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_MAGE,                    // spawnstate
      800,                       // spawnhealth
      HEXEN_S_MAGE_RUN1,               // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_MAGE_PAIN,               // painstate
      50,                        // painchance
      hexen_sfx_player_mage_pain,      // painsound
@@ -13145,7 +13145,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      64 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_SOLID | MF_SHOOTABLE | MF_COUNTKILL,    // flags
      MF2_FOOTCLIP | MF2_PASSMOBJ | MF2_TELESTOMP | MF2_PUSHWALL | MF2_MCROSS   // flags2
      },
@@ -13157,7 +13157,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SORC_WALK1,              // seestate
      hexen_sfx_sorcerer_sight,        // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_SORC_PAIN1,              // painstate
      10,                        // painchance
      hexen_sfx_sorcerer_pain,         // painsound
@@ -13184,22 +13184,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_sorcerer_ballbounce,   // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_SORCBALL1_D1,            // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SORCBALL1_D5,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      10 * FRACUNIT,             // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -13211,22 +13211,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_sorcerer_ballbounce,   // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_SORCBALL2_D1,            // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SORCBALL2_D5,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      10 * FRACUNIT,             // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -13238,22 +13238,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_sorcerer_ballbounce,   // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_SORCBALL3_D1,            // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SORCBALL3_D5,            // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      10 * FRACUNIT,             // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -13265,22 +13265,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_sorcerer_ballbounce,   // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SORCFX1_D1,              // deathstate
      HEXEN_S_SORCFX1_D1,              // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      7 * FRACUNIT,              // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE,        // flags
      MF2_NOTELEPORT | MF2_FLOORBOUNCE   // flags2
      },
@@ -13290,24 +13290,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SORCFX2_SPLIT1,          // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_SORCFX2T1,               // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      15 * FRACUNIT,             // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY,      // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13317,24 +13317,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SORCFX2T1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_ALTSHADOW,       // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13346,22 +13346,22 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_NULL,                    // seestate
      hexen_sfx_sorcerer_bishopspawn,  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_BISHMORPH1,              // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      15 * FRACUNIT,             // speed
      22 * FRACUNIT,             // radius
      65 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE,        // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13371,24 +13371,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SORCFX3_EXP1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_ALTSHADOW,       // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13398,12 +13398,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SORCFX4_1,               // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -13415,7 +13415,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      10 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_MISSILE | MF_NOGRAVITY, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13425,24 +13425,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SORCSPARK1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      5 * FRACUNIT,              // radius
      5 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF,        // flags
      MF2_NOTELEPORT | MF2_LOGRAV        // flags2
      },
@@ -13452,24 +13452,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BLASTEFFECT1,            // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_NOCLIP | MF_ALTSHADOW,   // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13479,12 +13479,12 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_WATERDRIP1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
@@ -13496,7 +13496,7 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      16 * FRACUNIT,             // height
      1,                         // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_MISSILE,                // flags
      MF2_LOGRAV | MF2_NOTELEPORT        // flags2
      },
@@ -13533,24 +13533,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KSPIRIT_ROAM1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      8 * FRACUNIT,              // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE | MF_NOCLIP, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13560,24 +13560,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KSPIRIT_ROAM1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      8 * FRACUNIT,              // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE | MF_NOCLIP, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13587,24 +13587,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KSPIRIT_ROAM1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      8 * FRACUNIT,              // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE | MF_NOCLIP, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13614,24 +13614,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KSPIRIT_ROAM1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      8 * FRACUNIT,              // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE | MF_NOCLIP, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13641,24 +13641,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KSPIRIT_ROAM1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      8 * FRACUNIT,              // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE | MF_NOCLIP, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13668,24 +13668,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KSPIRIT_ROAM1,           // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      8 * FRACUNIT,              // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_DROPOFF | MF_NOGRAVITY | MF_ALTSHADOW | MF_MISSILE | MF_NOCLIP, // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13803,24 +13803,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_KBOLT1,                  // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      15 * FRACUNIT,             // radius
      35 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE | MF_DROPOFF,    // flags
      MF2_NOTELEPORT             // flags2
      },
@@ -13830,24 +13830,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_SPAWNBATS1,              // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_NULL,                    // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      0,                         // speed
      20 * FRACUNIT,             // radius
      16 * FRACUNIT,             // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOSECTOR | MF_NOGRAVITY,        // flags
      MF2_DONTDRAW               // flags2
      },
@@ -13857,24 +13857,24 @@ raven_mobjinfo_t hexen_mobjinfo[HEXEN_NUMMOBJTYPES] = {
      HEXEN_S_BAT1,                    // spawnstate
      1000,                      // spawnhealth
      HEXEN_S_NULL,                    // seestate
-     hexen_sfx_None,                  // seesound
+     sfx_None,                  // seesound
      8,                         // reactiontime
-     hexen_sfx_None,                  // attacksound
+     sfx_None,                  // attacksound
      HEXEN_S_NULL,                    // painstate
      0,                         // painchance
-     hexen_sfx_None,                  // painsound
+     sfx_None,                  // painsound
      HEXEN_S_NULL,                    // meleestate
      HEXEN_S_NULL,                    // missilestate
      HEXEN_S_NULL,                    // crashstate
      HEXEN_S_BAT_DEATH,               // deathstate
      HEXEN_S_NULL,                    // xdeathstate
-     hexen_sfx_None,                  // deathsound
+     sfx_None,                  // deathsound
      5 * FRACUNIT,              // speed
      3 * FRACUNIT,              // radius
      3 * FRACUNIT,              // height
      100,                       // mass
      0,                         // damage
-     hexen_sfx_None,                  // activesound
+     sfx_None,                  // activesound
      MF_NOBLOCKMAP | MF_NOGRAVITY | MF_MISSILE, // flags
      MF2_PASSMOBJ | MF2_NOTELEPORT      // flags2
      }

--- a/prboom2/src/hexen/sounds.c
+++ b/prboom2/src/hexen/sounds.c
@@ -28,6 +28,25 @@ musicinfo_t hexen_S_music[HEXEN_NUMMUSIC] = {
 
 sfxinfo_t hexen_S_sfx[] = {
     { "", 0, 0, 0, 0, 0, 0, "" },
+
+    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
+
+    // Hexen sounds
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterNormalDeath" },
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterCrazyDeath" },
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterExtreme1Death" },

--- a/prboom2/src/m_cheat.c
+++ b/prboom2/src/m_cheat.c
@@ -295,11 +295,11 @@ static void cheat_mus(char buf[3])
 
     if (muslump != -1)
     {
-      S_ChangeMusInfoMusic(muslump, true, true);
+      S_ChangeMusInfoMusic(muslump, true);
     }
     else if (musnum != -1)
     {
-      S_ChangeMusic(musnum, 1, true);
+      S_ChangeMusic(musnum, 1);
     }
   }
   else

--- a/prboom2/src/p_enemy.c
+++ b/prboom2/src/p_enemy.c
@@ -4742,7 +4742,7 @@ void A_MakePod(mobj_t * actor)
 
 void A_ESound(mobj_t * mo)
 {
-    int sound = heretic_sfx_None;
+    int sound = sfx_None;
 
     switch (mo->type)
     {
@@ -5723,7 +5723,7 @@ void Hexen_A_Scream(mobj_t * actor)
                         sound = hexen_sfx_player_mage_normal_death;
                         break;
                     default:
-                        sound = hexen_sfx_None;
+                        sound = sfx_None;
                         break;
                 }
             }
@@ -5741,7 +5741,7 @@ void Hexen_A_Scream(mobj_t * actor)
                         sound = hexen_sfx_player_mage_crazy_death;
                         break;
                     default:
-                        sound = hexen_sfx_None;
+                        sound = sfx_None;
                         break;
                 }
             }
@@ -5759,7 +5759,7 @@ void Hexen_A_Scream(mobj_t * actor)
                         sound = hexen_sfx_player_mage_extreme1_death;
                         break;
                     default:
-                        sound = hexen_sfx_None;
+                        sound = sfx_None;
                         break;
                 }
                 sound += P_Random(pr_hexen) % 3;        // Three different extreme deaths

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2664,7 +2664,7 @@ dboolean PTR_UseTraverse (intercept_t* in)
             sound = hexen_sfx_pig_active1;
             break;
           default:
-            sound = hexen_sfx_None;
+            sound = sfx_None;
             break;
         }
         S_StartMobjSound(usething, sound);
@@ -2698,7 +2698,7 @@ dboolean PTR_UseTraverse (intercept_t* in)
             sound = hexen_sfx_pig_active1;
             break;
           default:
-            sound = hexen_sfx_None;
+            sound = sfx_None;
             break;
         }
         S_StartMobjSound(usething, sound);
@@ -4062,7 +4062,7 @@ dboolean PTR_PuzzleItemTraverse(intercept_t * in)
             P_LineOpening(in->d.line, NULL);
             if (line_opening.range <= 0)
             {
-                sound = hexen_sfx_None;
+                sound = sfx_None;
                 if (PuzzleItemUser->player)
                 {
                     switch (PuzzleItemUser->player->pclass)
@@ -4077,7 +4077,7 @@ dboolean PTR_PuzzleItemTraverse(intercept_t * in)
                             sound = hexen_sfx_puzzle_fail_mage;
                             break;
                         default:
-                            sound = hexen_sfx_None;
+                            sound = sfx_None;
                             break;
                     }
                 }

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -1464,8 +1464,11 @@ void P_PlayerCollectSecret(player_t *player)
 
   if (dsda_IntConfig(dsda_config_hudadd_secretarea))
   {
-    int sfx_id = raven ? g_sfx_secret :
-                 I_GetSfxLumpNum(&S_sfx[g_sfx_secret]) < 0 ? sfx_itmbk : g_sfx_secret;
+    int sfx_id = heretic ? heretic_sfx_chat : hexen ? hexen_sfx_chat : sfx_itmbk;
+
+    if (I_GetSfxLumpNum(&S_sfx[sfx_secret]) != -1)
+      sfx_id = sfx_secret;
+
     SetCustomMessage(player - players, s_HUSTR_SECRETFOUND, 2 * TICRATE, sfx_id);
   }
 }
@@ -7718,7 +7721,7 @@ dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int s
       {
         if (!args[1] || (mo->player && mo->player->mo == mo))
         {
-          S_ChangeMusInfoMusic(args[0], args[2], false);
+          S_ChangeMusInfoMusic(args[0], args[2]);
           buttonSuccess = 1;
         }
       }

--- a/prboom2/src/s_advsound.c
+++ b/prboom2/src/s_advsound.c
@@ -160,7 +160,7 @@ void T_MAPMusic(void)
 
         if (lumpnum >= 0 && lumpnum < numlumps)
         {
-          S_ChangeMusInfoMusic(lumpnum, true, false);
+          S_ChangeMusInfoMusic(lumpnum, true);
         }
       }
 

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -290,12 +290,12 @@ void S_Start(void)
   if (musinfo.items[0] != -1)
   {
     if (!dsda_StartQueuedMusic())
-      S_ChangeMusInfoMusic(musinfo.items[0], true, false);
+      S_ChangeMusInfoMusic(musinfo.items[0], true);
   }
   else
   {
     if (!dsda_StartQueuedMusic())
-      S_ChangeMusic(mnum, true, false);
+      S_ChangeMusic(mnum, true);
   }
 }
 
@@ -333,7 +333,7 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume, dboolean impor
     return;
 
   // killough 4/25/98
-  if (sfx_id == g_sfx_secret)
+  if (sfx_id == sfx_secret)
     params.sfx_class = sfx_class_secret;
   else if (important || sfx_id & PICKUP_SOUND || sfx_id == sfx_oof ||
       (compatibility_level >= prboom_2_compatibility && sfx_id == sfx_noway))
@@ -651,7 +651,7 @@ void S_UpdateSounds(void)
 //
 void S_StartMusic(int m_id)
 {
-  S_ChangeMusic(m_id, false, false);
+  S_ChangeMusic(m_id, false);
 }
 
 dboolean S_ChangeMusicByName(const char *name, dboolean looping)
@@ -664,11 +664,11 @@ dboolean S_ChangeMusicByName(const char *name, dboolean looping)
     return false;
   }
 
-  S_ChangeMusInfoMusic(lump, looping, false);
+  S_ChangeMusInfoMusic(lump, looping);
   return true;
 }
 
-void S_ChangeMusic(int musicnum, dboolean looping, dboolean force)
+void S_ChangeMusic(int musicnum, int looping)
 {
   musicinfo_t *music;
 
@@ -685,9 +685,6 @@ void S_ChangeMusic(int musicnum, dboolean looping, dboolean force)
     I_Error("S_ChangeMusic: Bad music number %d", musicnum);
 
   music = &S_music[musicnum];
-
-  if (mus_playing == music && !force)
-      return;
 
   // shutdown old music
   S_StopMusic();
@@ -719,18 +716,18 @@ void S_RestartMusic(void)
 {
   if (musinfo.current_item != -1)
   {
-    S_ChangeMusInfoMusic(musinfo.current_item, true, true);
+    S_ChangeMusInfoMusic(musinfo.current_item, true);
   }
   else
   {
     if (musicnum_current > mus_None && musicnum_current < num_music)
     {
-      S_ChangeMusic(musicnum_current, true, true);
+      S_ChangeMusic(musicnum_current, true);
     }
   }
 }
 
-void S_ChangeMusInfoMusic(int lumpnum, dboolean looping, dboolean force)
+void S_ChangeMusInfoMusic(int lumpnum, int looping)
 {
   musicinfo_t *music;
 
@@ -748,10 +745,6 @@ void S_ChangeMusInfoMusic(int lumpnum, dboolean looping, dboolean force)
     return;
 
   music = &S_music[mus_musinfo];
-
-
-  if (music->lumpnum == lumpnum && !force)
-    return;
 
   // shutdown old music
   S_StopMusic();
@@ -1175,7 +1168,7 @@ static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, 
   if (nosfxparm)
     return;
 
-  if (sound_id == heretic_sfx_None)
+  if (sound_id == sfx_None)
     return;
 
   if (origin == NULL)
@@ -1268,7 +1261,7 @@ void S_StartAmbientSound(void *_origin, int sound_id, int volume)
   if (nosfxparm)
     return;
 
-  if (sound_id == heretic_sfx_None || volume == 0)
+  if (sound_id == sfx_None || volume == 0)
     return;
 
   if (origin == NULL)
@@ -1400,5 +1393,5 @@ void S_StartSongName(const char *songLump, dboolean loop)
         break;
     }
 
-    S_ChangeMusic(musicnum, loop, false);
+    S_ChangeMusic(musicnum, loop);
 }

--- a/prboom2/src/s_sound.h
+++ b/prboom2/src/s_sound.h
@@ -96,8 +96,8 @@ void S_UnlinkSound(void *origin);
 void S_StartMusic(int music_id);
 
 // Start music using <music_id> from sounds.h, and set whether looping
-void S_ChangeMusic(int music_id, dboolean looping, dboolean force);
-void S_ChangeMusInfoMusic(int lumpnum, dboolean looping, dboolean force);
+void S_ChangeMusic(int music_id, int looping);
+void S_ChangeMusInfoMusic(int lumpnum, int looping);
 dboolean S_ChangeMusicByName(const char *name, dboolean looping);
 void S_RestartMusic(void);
 

--- a/prboom2/src/sounds.c
+++ b/prboom2/src/sounds.c
@@ -127,6 +127,25 @@ musicinfo_t doom_S_music[] = {
 sfxinfo_t doom_S_sfx[] = {
   // S_sfx[0] needs to be a dummy for odd reasons.
   { "dsnone", 0, 0, -1, 0, 0, 0, "" },
+
+  { "dssecret", 60, 0, -1, 0, 0, 0, "" },
+
+  // Optional menu/intermission sounds
+  { "dsmnuopn", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnucls", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnuact", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnubak", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnumov", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnusli", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnusel", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnuerr", 60, 0, -1, 0, 0, 0, "" },
+  { "dsinttic", 60, 0, -1, 0, 0, 0, "" },
+  { "dsinttot", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintnex", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintnet", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintdms", 60, 0, -1, 0, 0, 0, "" },
+
+  // Doom sounds
   { "dspistol", 64, 0, -1, 0, 0, 0, "" },
   { "dsshotgn", 64, 0, -1, 0, 0, 0, "" },
   { "dssgcock", 64, 0, -1, 0, 0, 0, "" },
@@ -242,24 +261,6 @@ sfxinfo_t doom_S_sfx[] = {
   { "dsdgact", 120, 0, -1, 0, 0, 0, "" },
   { "dsdgdth", 70, 0, -1, 0, 0, 0, "" },
   { "dsdgpain", 96, 0, -1, 0, 0, 0, "" },
-
-  //e6y
-  { "dssecret", 60, 0, -1, 0, 0, 0, "" },
-
-  // Optional menu/intermission sounds
-  { "dsmnuopn", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnucls", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnuact", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnubak", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnumov", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnusli", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnusel", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnuerr", 60, 0, -1, 0, 0, 0, "" },
-  { "dsinttic", 60, 0, -1, 0, 0, 0, "" },
-  { "dsinttot", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintnex", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintnet", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintdms", 60, 0, -1, 0, 0, 0, "" },
 
   // Everything from here up to 500 is reserved for future use.
 

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -268,7 +268,27 @@ typedef enum {
 
 typedef enum {
   sfx_None,
-  sfx_pistol,
+
+  sfx_secret,
+
+  // Optional menu/intermission sounds
+  sfx_mnuopn, // swtchn
+  sfx_mnucls, // swtchx
+  sfx_mnuact, // pistol
+  sfx_mnubak,
+  sfx_mnumov, // pstop
+  sfx_mnusli, // stnmov
+  sfx_mnusel, // itemup
+  sfx_mnuerr, // oof
+  sfx_inttic, // pistol
+  sfx_inttot, // barex
+  sfx_intnex, // sgcock
+  sfx_intnet, // pldeth
+  sfx_intdms, // slop
+
+  BASE_NUMSFX,
+
+  sfx_pistol = BASE_NUMSFX,
   sfx_shotgn,
   sfx_sgcock,
   sfx_dshtgn,
@@ -383,24 +403,6 @@ typedef enum {
   sfx_dgact,
   sfx_dgdth,
   sfx_dgpain,
-
-  //e6y
-  sfx_secret,
-
-  // Optional menu/intermission sounds
-  sfx_mnuopn, // swtchn
-  sfx_mnucls, // swtchx
-  sfx_mnuact, // pistol
-  sfx_mnubak,
-  sfx_mnumov, // pstop
-  sfx_mnusli, // stnmov
-  sfx_mnusel, // itemup
-  sfx_mnuerr, // oof
-  sfx_inttic, // pistol
-  sfx_inttot, // barex
-  sfx_intnex, // sgcock
-  sfx_intnet, // pldeth
-  sfx_intdms, // slop
 
   // Everything from here to 500 is reserved
 
@@ -609,8 +611,7 @@ typedef enum {
   DOOM_NUMSFX,
 
   // heretic
-  heretic_sfx_None = 0,
-  heretic_sfx_gldhit,
+  heretic_sfx_gldhit = BASE_NUMSFX,
   heretic_sfx_gntful,
   heretic_sfx_gnthit,
   heretic_sfx_gntpow,
@@ -757,8 +758,7 @@ typedef enum {
   HERETIC_NUMSFX,
 
   // hexen
-  hexen_sfx_None = 0,
-  hexen_sfx_player_fighter_normal_death,    // class specific death screams
+  hexen_sfx_player_fighter_normal_death = BASE_NUMSFX, // class specific death screams
   hexen_sfx_player_fighter_crazy_death,
   hexen_sfx_player_fighter_extreme1_death,
   hexen_sfx_player_fighter_extreme2_death,

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -2028,11 +2028,11 @@ void WI_Ticker(void)
 
     if (muslump >= 0)
     {
-      S_ChangeMusInfoMusic(muslump, true, false);
+      S_ChangeMusInfoMusic(muslump, true);
     }
     else
     {
-      S_ChangeMusic(mnum, true, false);
+      S_ChangeMusic(mnum, true);
     }
   }
 


### PR DESCRIPTION
Crispy doesnt allow this.

For simplicity, even in Heretic an Hexen the `ds` prefix is required for the sounds to be found.