### PR TITLE
Fix "Always Pistol Start" from breaking args when recording demos

### DIFF
--- a/prboom2/src/dsda/skill_info.c
+++ b/prboom2/src/dsda/skill_info.c
@@ -227,6 +227,8 @@ void dsda_InitSkills(void) {
 // "Always Pistol Start" is the only persistent cfg (saved in cfg file)
 //
 
+static void dsda_ResetGameModifiers(void);
+
 void dsda_InitGameModifiers(void)
 {
   if (dsda_Flag(dsda_arg_pistol_start) || dsda_IntConfig(dsda_config_always_pistol_start))
@@ -239,6 +241,10 @@ void dsda_InitGameModifiers(void)
       dsda_UpdateIntConfig(dsda_config_no_monsters, true, true);
   if (dsda_Flag(dsda_arg_coop_spawns))
       dsda_UpdateIntConfig(dsda_config_coop_spawns, true, true);
+
+  // Pistol-start config can reset other modifier configs
+  // Explicitly refresh everything for configs to match args
+  dsda_ResetGameModifiers();
 }
 
 // if "Pistol Start" is disabled, disable "Always Pistol Start" (avoid impossible condition)

--- a/prboom2/src/dsda/skill_info.c
+++ b/prboom2/src/dsda/skill_info.c
@@ -247,6 +247,16 @@ void dsda_InitGameModifiers(void)
   dsda_ResetGameModifiers();
 }
 
+// During demo recording/playback only use args, else use cfgs
+static void dsda_ResetGameModifiers(void)
+{
+  pistolstart = (allow_incompatibility ? dsda_IntConfig(dsda_config_pistol_start)     : false);   // pistolstart not allowed in demos
+  respawnparm = (allow_incompatibility ? dsda_IntConfig(dsda_config_respawn_monsters) : dsda_Flag(dsda_arg_respawn));
+  fastparm    = (allow_incompatibility ? dsda_IntConfig(dsda_config_fast_monsters)    : dsda_Flag(dsda_arg_fast));
+  nomonsters  = (allow_incompatibility ? dsda_IntConfig(dsda_config_no_monsters)      : dsda_Flag(dsda_arg_nomonsters));
+  coop_spawns = (allow_incompatibility ? dsda_IntConfig(dsda_config_coop_spawns)      : dsda_Flag(dsda_arg_coop_spawns));
+}
+
 // if "Pistol Start" is disabled, disable "Always Pistol Start" (avoid impossible condition)
 void dsda_RefreshPistolStart(void)
 {
@@ -273,16 +283,6 @@ void dsda_RefreshAlwaysPistolStart(void)
 
   // Refresh pistolstart status
   dsda_ResetGameModifiers();
-}
-
-// During demo recording/playback only use args, else use cfgs
-void dsda_ResetGameModifiers(void)
-{
-  pistolstart = (allow_incompatibility ? dsda_IntConfig(dsda_config_pistol_start)     : false);   // pistolstart not allowed in demos
-  respawnparm = (allow_incompatibility ? dsda_IntConfig(dsda_config_respawn_monsters) : dsda_Flag(dsda_arg_respawn));
-  fastparm    = (allow_incompatibility ? dsda_IntConfig(dsda_config_fast_monsters)    : dsda_Flag(dsda_arg_fast));
-  nomonsters  = (allow_incompatibility ? dsda_IntConfig(dsda_config_no_monsters)      : dsda_Flag(dsda_arg_nomonsters));
-  coop_spawns = (allow_incompatibility ? dsda_IntConfig(dsda_config_coop_spawns)      : dsda_Flag(dsda_arg_coop_spawns));
 }
 
 void dsda_RefreshGameSkill(void) {

--- a/prboom2/src/dsda/skill_info.c
+++ b/prboom2/src/dsda/skill_info.c
@@ -227,7 +227,15 @@ void dsda_InitSkills(void) {
 // "Always Pistol Start" is the only persistent cfg (saved in cfg file)
 //
 
-static void dsda_ResetGameModifiers(void);
+// During demo recording/playback only use args, else use cfgs
+static void dsda_ResetGameModifiers(void)
+{
+  pistolstart = (allow_incompatibility ? dsda_IntConfig(dsda_config_pistol_start)     : false);   // pistolstart not allowed in demos
+  respawnparm = (allow_incompatibility ? dsda_IntConfig(dsda_config_respawn_monsters) : dsda_Flag(dsda_arg_respawn));
+  fastparm    = (allow_incompatibility ? dsda_IntConfig(dsda_config_fast_monsters)    : dsda_Flag(dsda_arg_fast));
+  nomonsters  = (allow_incompatibility ? dsda_IntConfig(dsda_config_no_monsters)      : dsda_Flag(dsda_arg_nomonsters));
+  coop_spawns = (allow_incompatibility ? dsda_IntConfig(dsda_config_coop_spawns)      : dsda_Flag(dsda_arg_coop_spawns));
+}
 
 void dsda_InitGameModifiers(void)
 {
@@ -245,16 +253,6 @@ void dsda_InitGameModifiers(void)
   // Pistol-start config can reset other modifier configs
   // Explicitly refresh everything for configs to match args
   dsda_ResetGameModifiers();
-}
-
-// During demo recording/playback only use args, else use cfgs
-static void dsda_ResetGameModifiers(void)
-{
-  pistolstart = (allow_incompatibility ? dsda_IntConfig(dsda_config_pistol_start)     : false);   // pistolstart not allowed in demos
-  respawnparm = (allow_incompatibility ? dsda_IntConfig(dsda_config_respawn_monsters) : dsda_Flag(dsda_arg_respawn));
-  fastparm    = (allow_incompatibility ? dsda_IntConfig(dsda_config_fast_monsters)    : dsda_Flag(dsda_arg_fast));
-  nomonsters  = (allow_incompatibility ? dsda_IntConfig(dsda_config_no_monsters)      : dsda_Flag(dsda_arg_nomonsters));
-  coop_spawns = (allow_incompatibility ? dsda_IntConfig(dsda_config_coop_spawns)      : dsda_Flag(dsda_arg_coop_spawns));
 }
 
 // if "Pistol Start" is disabled, disable "Always Pistol Start" (avoid impossible condition)

--- a/prboom2/src/dsda/skill_info.h
+++ b/prboom2/src/dsda/skill_info.h
@@ -59,9 +59,9 @@ extern int num_skills;
 void dsda_InitSkills(void);
 void dsda_RefreshGameSkill(void);
 void dsda_UpdateGameSkill(int skill);
+
 void dsda_AlterGameFlags(void);
 void dsda_InitGameModifiers(void);
-void dsda_ResetGameModifiers(void);
 void dsda_RefreshPistolStart(void);
 void dsda_RefreshAlwaysPistolStart(void);
 


### PR DESCRIPTION
Yay. Took like a year to figure this one out. :/

Seems that this only happened when you had "Always Pistol Start" on.

Basically the pistol start configs kinda overwrote the flags, and then later on, they were never updated... So this makes sure that flags are always respected.