### PR TITLE
Do pre-tic interpolation for all mobjs (Take II)

### DIFF
--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -1866,11 +1866,7 @@ dboolean P_ThingHeightClip (mobj_t* thing)
       (thing->z - thing->floorz < 9 * FRACUNIT) ||
       (thing->flags & MF_NOGRAVITY)
     )
-    {
-      thing->PrevZ = thing->z;
       thing->z = thing->floorz;
-      thing->intflags |= MIF_NOINTERPOLATEZ;
-    }
 
     /* killough 11/98: Possibly upset balance of objects hanging off ledges */
     if (thing->intflags & MIF_FALLING && thing->gear >= MAXGEAR)
@@ -1881,11 +1877,7 @@ dboolean P_ThingHeightClip (mobj_t* thing)
     // don't adjust a floating monster unless forced to
 
     if (thing->z+thing->height > thing->ceilingz)
-    {
-      thing->PrevZ = thing->z;
       thing->z = thing->ceilingz - thing->height;
-      thing->intflags |= MIF_NOINTERPOLATEZ;
-    }
   }
 
   return thing->ceilingz - thing->floorz >= thing->height;

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -1845,6 +1845,8 @@ dboolean P_ThingHeightClip (mobj_t* thing)
 {
   dboolean   onfloor;
 
+  P_MobjInterpolation(thing);
+
   onfloor = (thing->z == thing->floorz);
 
   P_CheckPosition (thing, thing->x, thing->y);

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1278,9 +1278,7 @@ void P_MobjThinker (mobj_t* mobj)
 
   mobj->PrevX = mobj->x;
   mobj->PrevY = mobj->y;
-  if (!(mobj->intflags & MIF_NOINTERPOLATEZ))
-      mobj->PrevZ = mobj->z;
-  mobj->intflags &= ~MIF_NOINTERPOLATEZ;
+  mobj->PrevZ = mobj->z;
 
   // momentum movement
   BlockingMobj = NULL;
@@ -3018,9 +3016,7 @@ void P_BlasterMobjThinker(mobj_t * mobj)
 
     mobj->PrevX = mobj->x;
     mobj->PrevY = mobj->y;
-    if (!(mobj->intflags & MIF_NOINTERPOLATEZ))
-        mobj->PrevZ = mobj->z;
-    mobj->intflags &= ~MIF_NOINTERPOLATEZ;
+    mobj->PrevZ = mobj->z;
 
     // Handle movement
     if (mobj->momx || mobj->momy || (mobj->z != mobj->floorz) || mobj->momz)

--- a/prboom2/src/p_mobj.c
+++ b/prboom2/src/p_mobj.c
@@ -1259,6 +1259,33 @@ fixed_t FloatBobOffsets[64] = {
 };
 
 //
+// P_MobjInterpolation
+//
+
+static dboolean mobj_interp_capture;
+
+void P_UpdateMobjInterpolations(void)
+{
+  mobj_interp_capture = !mobj_interp_capture;
+}
+
+// [AR] Save mobj interpolation once per tic
+// This fixes out-of-sync thinker order of operations (i.e. lift thinkers)
+void P_MobjInterpolation(mobj_t *mobj)
+{
+  dboolean captured = !!(mobj->intflags & MIF_INTERP_CAPTURE);
+
+  if (captured == mobj_interp_capture)
+    return;
+
+  mobj->PrevX = mobj->x;
+  mobj->PrevY = mobj->y;
+  mobj->PrevZ = mobj->z;
+
+  mobj->intflags ^= MIF_INTERP_CAPTURE;
+}
+
+//
 // P_MobjThinker
 //
 
@@ -1276,9 +1303,7 @@ void P_MobjThinker (mobj_t* mobj)
     return;
   }
 
-  mobj->PrevX = mobj->x;
-  mobj->PrevY = mobj->y;
-  mobj->PrevZ = mobj->z;
+  P_MobjInterpolation(mobj);
 
   // momentum movement
   BlockingMobj = NULL;
@@ -1819,6 +1844,9 @@ mobj_t* P_SpawnMobj(fixed_t x,fixed_t y,fixed_t z,mobjtype_t type)
   mobj->PrevX = mobj->x;
   mobj->PrevY = mobj->y;
   mobj->PrevZ = mobj->z;
+
+  if (mobj_interp_capture)
+    mobj->intflags |= MIF_INTERP_CAPTURE;
 
   mobj->thinker.function = P_MobjThinker;
 
@@ -3014,9 +3042,7 @@ void P_BlasterMobjThinker(mobj_t * mobj)
     fixed_t z;
     dboolean changexy;
 
-    mobj->PrevX = mobj->x;
-    mobj->PrevY = mobj->y;
-    mobj->PrevZ = mobj->z;
+    P_MobjInterpolation(mobj);
 
     // Handle movement
     if (mobj->momx || mobj->momy || (mobj->z != mobj->floorz) || mobj->momz)

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -240,14 +240,13 @@
 // (some degree of opaqueness is good, to avoid compatibility woes)
 
 enum {
-  MIF_FALLING               = (1<<0), // Object is falling
-  MIF_ARMED                 = (1<<1), // Object is armed (for MF_TOUCHY objects)
-  MIF_SCROLLING             = (1<<2), // Object is affected by scroller / pusher / puller
-  MIF_PLAYER_DAMAGED_BARREL = (1<<3),
-  MIF_SPAWNED_BY_ICON       = (1<<4),
-  MIF_FAKE                  = (1<<5), // Not a real thing, transient (e.g., for cheats)
-  MIF_LINEDONE              = (1<<6), // Object has activated W1 or S1 linedef via DEH frame
-  MIF_NOINTERPOLATEZ        = (1<<7), // [AR] Prevent mobj thinker from overwriting an updated PrevZ (example: lift thinker)
+  MIF_FALLING = 1,      // Object is falling
+  MIF_ARMED = 2,        // Object is armed (for MF_TOUCHY objects)
+  MIF_SCROLLING = 4,    // Object is affected by scroller / pusher / puller
+  MIF_PLAYER_DAMAGED_BARREL = 8,
+  MIF_SPAWNED_BY_ICON = 16,
+  MIF_FAKE = 32, // Not a real thing, transient (e.g., for cheats)
+  MIF_LINEDONE              = 0x00000040, // Object has activated W1 or S1 linedef via DEH frame
 };
 
 // heretic

--- a/prboom2/src/p_mobj.h
+++ b/prboom2/src/p_mobj.h
@@ -240,13 +240,14 @@
 // (some degree of opaqueness is good, to avoid compatibility woes)
 
 enum {
-  MIF_FALLING = 1,      // Object is falling
-  MIF_ARMED = 2,        // Object is armed (for MF_TOUCHY objects)
-  MIF_SCROLLING = 4,    // Object is affected by scroller / pusher / puller
-  MIF_PLAYER_DAMAGED_BARREL = 8,
-  MIF_SPAWNED_BY_ICON = 16,
-  MIF_FAKE = 32, // Not a real thing, transient (e.g., for cheats)
-  MIF_LINEDONE              = 0x00000040, // Object has activated W1 or S1 linedef via DEH frame
+  MIF_FALLING               = (1<<0), // Object is falling
+  MIF_ARMED                 = (1<<1), // Object is armed (for MF_TOUCHY objects)
+  MIF_SCROLLING             = (1<<2), // Object is affected by scroller / pusher / puller
+  MIF_PLAYER_DAMAGED_BARREL = (1<<3),
+  MIF_SPAWNED_BY_ICON       = (1<<4),
+  MIF_FAKE                  = (1<<5), // Not a real thing, transient (e.g., for cheats)
+  MIF_LINEDONE              = (1<<6), // Object has activated W1 or S1 linedef via DEH frame
+  MIF_INTERP_CAPTURE        = (1<<7), // [AR] Capture interpolation once per tic
 };
 
 // heretic
@@ -447,6 +448,8 @@ mobj_t  *P_SpawnMobj(fixed_t x, fixed_t y, fixed_t z, mobjtype_t type);
 void    P_RemoveMobj(mobj_t *th);
 dboolean P_SetMobjState(mobj_t *mobj, statenum_t state);
 void    P_MobjThinker(mobj_t *mobj);
+void    P_UpdateMobjInterpolations(void);
+void    P_MobjInterpolation(mobj_t *mobj);
 void    P_SpawnPuff(fixed_t x, fixed_t y, fixed_t z);
 void    P_SpawnBlood(fixed_t x, fixed_t y, fixed_t z, int damage, mobj_t *bleeder);
 mobj_t  *P_SpawnMissile(mobj_t *source, mobj_t *dest, mobjtype_t type);

--- a/prboom2/src/r_fps.c
+++ b/prboom2/src/r_fps.c
@@ -333,6 +333,9 @@ static void R_DoAnInterpolation (int i, fixed_t smoothratio)
 void R_UpdateInterpolations()
 {
   int i;
+
+  P_UpdateMobjInterpolations();
+
   if (!movement_smooth)
     return;
   for (i = numinterpolations-1; i >= 0; --i)


### PR DESCRIPTION
The last method (#957) fixed things on lifts, but added extra jitter to everything else.

This approach is probably better, fixes that issue and avoids checking the thinkerlist every tic.