### PR TITLE
Fix view jolting up/down too much when running across tiny height varariations

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1041,9 +1041,9 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "dsda_weaponbob_pct", dsda_config_weaponbob,
     dsda_config_int, 0, 4, { 4 }
   },
-  [dsda_config_viewbob_floor_jolt] = {
-    "dsda_viewbob_floor_jolt", dsda_config_viewbob_floor_jolt,
-    CONF_BOOL(0)
+  [dsda_config_fix_viewbob_floor_jolt] = {
+    "dsda_fix_viewbob_floor_jolt", dsda_config_fix_viewbob_floor_jolt,
+    CONF_BOOL(1)
   },
   [dsda_config_quake_intensity] = {
     "dsda_quake_intensity", dsda_config_quake_intensity,

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -1041,6 +1041,10 @@ dsda_config_t dsda_config[dsda_config_count] = {
     "dsda_weaponbob_pct", dsda_config_weaponbob,
     dsda_config_int, 0, 4, { 4 }
   },
+  [dsda_config_viewbob_floor_jolt] = {
+    "dsda_viewbob_floor_jolt", dsda_config_viewbob_floor_jolt,
+    CONF_BOOL(0)
+  },
   [dsda_config_quake_intensity] = {
     "dsda_quake_intensity", dsda_config_quake_intensity,
     dsda_config_int, 0, 100, { 100 }

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -229,7 +229,7 @@ typedef enum {
   dsda_config_switch_weapon_on_pickup,
   dsda_config_viewbob,
   dsda_config_weaponbob,
-  dsda_config_viewbob_floor_jolt,
+  dsda_config_fix_viewbob_floor_jolt,
   dsda_config_quake_intensity,
   dsda_config_map_blinking_locks,
   dsda_config_map_secret_after,

--- a/prboom2/src/dsda/configuration.h
+++ b/prboom2/src/dsda/configuration.h
@@ -229,6 +229,7 @@ typedef enum {
   dsda_config_switch_weapon_on_pickup,
   dsda_config_viewbob,
   dsda_config_weaponbob,
+  dsda_config_viewbob_floor_jolt,
   dsda_config_quake_intensity,
   dsda_config_map_blinking_locks,
   dsda_config_map_secret_after,

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -130,6 +130,10 @@ int dsda_WeaponBob(void) {
   return dsda_IntConfig(dsda_config_weaponbob);
 }
 
+dboolean dsda_ViewBobFloorJolt(void) {
+  return dsda_IntConfig(dsda_config_viewbob_floor_jolt);
+}
+
 dboolean dsda_ShowMessages(void) {
   return dsda_IntConfig(dsda_config_show_messages);
 }

--- a/prboom2/src/dsda/settings.c
+++ b/prboom2/src/dsda/settings.c
@@ -130,8 +130,8 @@ int dsda_WeaponBob(void) {
   return dsda_IntConfig(dsda_config_weaponbob);
 }
 
-dboolean dsda_ViewBobFloorJolt(void) {
-  return dsda_IntConfig(dsda_config_viewbob_floor_jolt);
+dboolean dsda_FixViewBobFloorJolt(void) {
+  return dsda_IntConfig(dsda_config_fix_viewbob_floor_jolt);
 }
 
 dboolean dsda_ShowMessages(void) {

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -27,6 +27,7 @@ int dsda_CompatibilityLevel(void);
 void dsda_SetTas(dboolean t);
 int dsda_ViewBob(void);
 int dsda_WeaponBob(void);
+dboolean dsda_ViewBobFloorJolt(void);
 dboolean dsda_ShowMessages(void);
 dboolean dsda_AutoRun(void);
 dboolean dsda_MouseLook(void);

--- a/prboom2/src/dsda/settings.h
+++ b/prboom2/src/dsda/settings.h
@@ -27,7 +27,7 @@ int dsda_CompatibilityLevel(void);
 void dsda_SetTas(dboolean t);
 int dsda_ViewBob(void);
 int dsda_WeaponBob(void);
-dboolean dsda_ViewBobFloorJolt(void);
+dboolean dsda_FixViewBobFloorJolt(void);
 dboolean dsda_ShowMessages(void);
 dboolean dsda_AutoRun(void);
 dboolean dsda_MouseLook(void);

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3556,6 +3556,7 @@ setup_menu_t display_options_settings[] = {
   { "View Bobbing", S_CHOICE, m_conf, G_X, dsda_config_viewbob, 0, viewbob_list },
   { "Weapon Bobbing", S_CHOICE, m_conf, G_X, dsda_config_weaponbob, 0, weaponbob_list },
   { "Weapon Attack Alignment", S_CHOICE, m_conf, G_X, dsda_config_weapon_attack_alignment, 0, weapon_attack_alignment_strings },
+  { "Shallow Floors Jolt View Bob", S_YESNO, m_conf, G_X, dsda_config_viewbob_floor_jolt },
   { "Linear Sky Scrolling", S_YESNO, m_conf, G_X, dsda_config_render_linearsky },
   { "Quake Intensity", S_NUM, m_conf, G_X, dsda_config_quake_intensity },
   { "OpenGL Show Health Bars", S_YESNO, m_conf, G_X, dsda_config_gl_health_bar },

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -3556,7 +3556,7 @@ setup_menu_t display_options_settings[] = {
   { "View Bobbing", S_CHOICE, m_conf, G_X, dsda_config_viewbob, 0, viewbob_list },
   { "Weapon Bobbing", S_CHOICE, m_conf, G_X, dsda_config_weaponbob, 0, weaponbob_list },
   { "Weapon Attack Alignment", S_CHOICE, m_conf, G_X, dsda_config_weapon_attack_alignment, 0, weapon_attack_alignment_strings },
-  { "Shallow Floors Jolt View Bob", S_YESNO, m_conf, G_X, dsda_config_viewbob_floor_jolt },
+  { "Fix Shallow Floor View Bob Jolt", S_YESNO, m_conf, G_X, dsda_config_fix_viewbob_floor_jolt },
   { "Linear Sky Scrolling", S_YESNO, m_conf, G_X, dsda_config_render_linearsky },
   { "Quake Intensity", S_NUM, m_conf, G_X, dsda_config_quake_intensity },
   { "OpenGL Show Health Bars", S_YESNO, m_conf, G_X, dsda_config_gl_health_bar },

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -321,7 +321,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_switch_weapon_on_pickup),
   MIGRATED_SETTING(dsda_config_viewbob),
   MIGRATED_SETTING(dsda_config_weaponbob),
-  MIGRATED_SETTING(dsda_config_viewbob_floor_jolt),
+  MIGRATED_SETTING(dsda_config_fix_viewbob_floor_jolt),
   MIGRATED_SETTING(dsda_config_quake_intensity),
   MIGRATED_SETTING(dsda_config_organize_failed_demos),
   MIGRATED_SETTING(dsda_config_demo_end_quit),

--- a/prboom2/src/m_misc.c
+++ b/prboom2/src/m_misc.c
@@ -321,6 +321,7 @@ cfg_def_t cfg_defs[] =
   MIGRATED_SETTING(dsda_config_switch_weapon_on_pickup),
   MIGRATED_SETTING(dsda_config_viewbob),
   MIGRATED_SETTING(dsda_config_weaponbob),
+  MIGRATED_SETTING(dsda_config_viewbob_floor_jolt),
   MIGRATED_SETTING(dsda_config_quake_intensity),
   MIGRATED_SETTING(dsda_config_organize_failed_demos),
   MIGRATED_SETTING(dsda_config_demo_end_quit),

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -256,7 +256,7 @@ void P_CalcHeight (player_t* player)
 
   offgroundtics = onground ? 0 : offgroundtics + 1;
 
-  if (!onground && !raven && offgroundtics > AIRBOBFADETICS)
+  if (!onground && !raven && (offgroundtics > AIRBOBFADETICS || dsda_ViewBobFloorJolt()) )
   {
     player->viewz = player->mo->z + g_viewheight;
 

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -73,6 +73,8 @@
 #define MAXBOB  0x100000
 
 dboolean onground; // whether player is on ground or in air
+int offgroundtics; // how many tics player has been in air
+#define AIRBOBFADETICS 4 // num tics to scale bobbing to 0 in midair
 
 // heretic
 int newtorch;      // used in the torch flicker effect.
@@ -191,7 +193,7 @@ static void P_Bob(player_t *player, angle_t angle, fixed_t move)
 void P_CalcHeight (player_t* player)
 {
   int     angle;
-  fixed_t bob;
+  fixed_t bob, totalviewoffset;
 
   // Regular movement bobbing
   // (needs to be calculated for gun swing
@@ -252,7 +254,9 @@ void P_CalcHeight (player_t* player)
     player->bob = FRACUNIT / 2;
   }
 
-  if (!onground && !raven)
+  offgroundtics = onground ? 0 : offgroundtics + 1;
+
+  if (!onground && !raven && offgroundtics > AIRBOBFADETICS)
   {
     player->viewz = player->mo->z + g_viewheight;
 
@@ -268,7 +272,7 @@ void P_CalcHeight (player_t* player)
 
   // move viewheight
 
-  if (player->playerstate == PST_LIVE)
+  if (player->playerstate == PST_LIVE && (onground || raven) )
   {
     player->viewheight += player->deltaviewheight;
 
@@ -299,7 +303,12 @@ void P_CalcHeight (player_t* player)
   }
   else
   {
-    player->viewz = player->mo->z + player->viewheight + bob;
+    totalviewoffset = player->viewheight + bob - g_viewheight;
+
+    if (!onground && !raven)
+      totalviewoffset = totalviewoffset * (AIRBOBFADETICS + 1 - offgroundtics) / AIRBOBFADETICS;
+
+    player->viewz = player->mo->z + g_viewheight + totalviewoffset;
   }
 
   if (player->playerstate != PST_DEAD && player->mo->z <= player->mo->floorz)

--- a/prboom2/src/p_user.c
+++ b/prboom2/src/p_user.c
@@ -256,7 +256,7 @@ void P_CalcHeight (player_t* player)
 
   offgroundtics = onground ? 0 : offgroundtics + 1;
 
-  if (!onground && !raven && (offgroundtics > AIRBOBFADETICS || dsda_ViewBobFloorJolt()) )
+  if (!onground && !raven && (offgroundtics > AIRBOBFADETICS || !dsda_FixViewBobFloorJolt()) )
   {
     player->viewz = player->mo->z + g_viewheight;
 


### PR DESCRIPTION
Players and mappers may have noticed that when running around on sectors which are just 1px or 2px higher than surroundings, the view jolts around up and down a lot, way more than the actual height difference. In some wads with a lot of details on the floor this can be very distracting.

This is caused by the viewbobbing getting reset to 0 when the players enter midair. When running off of a 1px or 2px high ledge, (such as rugs, loose tiles, etc. or other small floor details in maps) the player does enter midair for just 1 tic, so the viewbobbing instantly snaps to 0. Then, on the next tic when the player touches the ground again, the view immediately snaps back to the full bob magnitude. This causes quite a spike (depending on where view was in the bob cycle).

Some example WADs to see this prominently:
The left & right rooms at the start of 10x10.wad MAP01
When Them Demons Cry (onicry.wad)

This is fixed by tracking how long the player has been in midair, and uses this to scale the viewbobbing down to 0 across a few tics instead of instantly. This buffer time absorbs the sudden jolt when running off of 1px/2px/etc high sectors.

This part of the view code affects only the camera view height, and does not affect the weapon sprite, so demo compatibility should be unaffected.

I made sure that the raven nuances are unaffected (in raven the player viewbobbing continues as long as the player is in midair)

Here's a before and after clip of a particularly rough example (running up stairs which have very slightly elevated planks at the edge of each step) and you can also see the phenomenon when walking into and out of the 1px deep dirt areas.

Before:

https://github.com/user-attachments/assets/897bc1d6-b146-47da-b13e-30edcf966c21

After:

https://github.com/user-attachments/assets/f9b3c8e6-1f79-463a-8808-f9368df7b02a

Doom Retro and Z/GZ/UZDoom also address this (by having the player bob continue indefinitely in midair just like raven) but this PR keeps the behavior a lot closer to Doom's (where bobbing does stop in midair - now its just after a couple tics). [A PR is also open for Woof with this same change.](https://github.com/fabiangreffrath/woof/pull/2815)
