### PR TITLE
Better MUSINFO/UMAPINFO Fix

### DIFF
--- a/prboom2/src/dsda/music.c
+++ b/prboom2/src/dsda/music.c
@@ -96,6 +96,10 @@ void dsda_InitializeMusic(musicinfo_t* source, int count) {
 
   S_music = source;
 
+  // Prevent MUSINFO from treating lump 0 (PLAYPAL) as music.
+  musinfo.current_item = -1;
+  S_music[mus_musinfo].lumpnum = -1;
+
   // S_music = malloc(num_music * sizeof(*S_music));
   // memcpy(S_music, source, num_music * sizeof(*S_music));
 

--- a/prboom2/src/s_advsound.c
+++ b/prboom2/src/s_advsound.c
@@ -120,9 +120,13 @@ void S_ParseMusInfo(const char *mapid)
 
     SC_Close();
   }
-  else
+  else // No MUSINFO lump -> clear MUSINFO music state (without restarting music)
   {
+    memset(musinfo.items, 0, sizeof(musinfo.items));
     musinfo.items[0] = -1;
+    musinfo.mapthing = NULL;
+    musinfo.lastmapthing = NULL;
+    musinfo.tics = 0;
   }
 }
 
@@ -158,9 +162,15 @@ void T_MAPMusic(void)
       {
         int lumpnum = musinfo.items[arraypt];
 
-        if (lumpnum >= 0 && lumpnum < numlumps)
+        if (lumpnum > 0 && lumpnum < numlumps)
         {
           S_ChangeMusInfoMusic(lumpnum, true);
+        }
+        else // missing musinfo entry -> silence
+        {
+          lprintf(LO_WARN, "T_MAPMusic: MUSINFO entry %d not defined\n", arraypt);
+          S_StopMusic();
+          musinfo.current_item = -1;
         }
       }
 

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -686,6 +686,9 @@ void S_ChangeMusic(int musicnum, int looping)
 
   music = &S_music[musicnum];
 
+  if (mus_playing == music)
+    return;
+
   // shutdown old music
   S_StopMusic();
 
@@ -745,6 +748,10 @@ void S_ChangeMusInfoMusic(int lumpnum, int looping)
     return;
 
   music = &S_music[mus_musinfo];
+
+  // Allow MUSINFO music to restart after MIDI player changes
+  if (music->lumpnum == lumpnum && mus_playing)
+    return;
 
   // shutdown old music
   S_StopMusic();


### PR DESCRIPTION
In Nyan Doom, I had to rework this slightly to get switching between midi players / soundfonts, to work.

(It's worth noting that in Nyan Doom, in Fluidsynth switching soundfonts does NOT restart the music track, it just changes the soundfont wherever the midi is).

But this also fixes MUSINFO tracks from getting lost when restarted. Also seems to fix UMAPINFO music as well.

I wasn't a fan of #812 nor #951.

Edit: I did make the choice to have unknown MUSINFO track to play "silence". My thought process was as a mapper, it makes it easier to tell when I've made a mistake with MUSINFO.