### PR TITLE
Add back support for Windows 7

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         config:
           - name: "MSVC x64 (vcpkg)"
-            os: windows-latest
+            os: windows-2022
             build_type: "Release"
             vcpkg: true
             triplet: x64-windows-static-release
@@ -48,7 +48,7 @@ jobs:
               -DVCPKG_LIBRARY_LINKAGE=static
 
           - name: "MSYS2 UCRT64"
-            os: windows-latest
+            os: windows-2022
             build_type: "Release"
             extra_options: "-G Ninja"
             package_name: "windows_x64_mingw"


### PR DESCRIPTION
I have a friend who has Windows 7 and `windows-latest` makes it so they can't use the latest CI builds.