### PR TITLE
Automap / Minimap Fixes and Tweaks

### DIFF
--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -850,7 +850,7 @@ void AM_Stop (dboolean minimap)
   automap_full = false;
 
   if (minimap && dsda_ShowMinimap())
-    AM_Start(false);
+    AM_Start(AM_OPEN_MINIMAP);
 }
 
 //
@@ -1091,7 +1091,7 @@ dboolean AM_Responder
   {
     if (dsda_InputActivated(dsda_input_map))
     {
-      AM_Start(true);
+      AM_Start(AM_OPEN_FULLAUTOMAP);
       return true;
     }
   }

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -292,7 +292,7 @@ mline_t thingbox_guy[] =
 #undef R
 #define NUMTHINGBOXGUYLINES (sizeof(thingbox_guy)/sizeof(mline_t))
 
-int automap_active;
+int automap_full;
 int automap_overlay;
 int automap_rotate;
 int automap_follow;
@@ -627,7 +627,7 @@ static void AM_SetScale(dboolean keep_scale)
   if (keep_scale)
   {
     // Keep current zoom when changing resolution / renderer
-    if (automap_active && old_m_w > 0)
+    if (automap_full && old_m_w > 0)
     {
       scale_mtof = FixedDiv(f_w << FRACBITS, old_m_w);
       scale_mtof = BETWEEN(min_scale_mtof, max_scale_mtof, scale_mtof);
@@ -648,7 +648,7 @@ static void AM_SetScale(dboolean keep_scale)
 //
 void AM_SetPosition(void)
 {
-  if (automap_active)
+  if (automap_full)
   {
     f_x = f_y = 0;
     f_w = SCREENWIDTH;
@@ -767,7 +767,7 @@ static void AM_SetMinimapScale(void)
 
 void AM_RefreshMinimap(void)
 {
-  if (!dsda_ShowMinimap() || automap_active)
+  if (!dsda_ShowMinimap() || automap_full)
     return;
 
   // Refresh Minimap Coordinates / scale / center
@@ -847,7 +847,7 @@ void AM_ExchangeScales(int full_automap, int *last_full_automap)
 //
 void AM_Stop (dboolean minimap)
 {
-  automap_active = false;
+  automap_full = false;
 
   if (minimap && dsda_ShowMinimap())
     AM_Start(false);
@@ -863,14 +863,14 @@ void AM_Stop (dboolean minimap)
 //
 // Passed nothing, returns nothing
 //
-void AM_Start(dboolean full_automap)
+void AM_Start(dboolean open_full_automap)
 {
   static int lastlevel = -1, lastepisode = -1;
   static int last_full_automap;
 
   AM_InitParams();
 
-  automap_active = full_automap;
+  automap_full = open_full_automap;
 
   AM_SetPosition();
 
@@ -883,9 +883,9 @@ void AM_Start(dboolean full_automap)
     last_full_automap = true;
   }
 
-  AM_ExchangeScales(full_automap, &last_full_automap);
+  AM_ExchangeScales(open_full_automap, &last_full_automap);
 
-  if (dsda_ShowMinimap() && !full_automap)
+  if (dsda_ShowMinimap() && !open_full_automap)
     AM_RefreshMinimap();
 
   AM_initVariables();
@@ -2929,11 +2929,11 @@ static void AM_setFrameVariables(void)
 void AM_Drawer (dboolean minimap)
 {
   // if no automap
-  if (!automap_active && !minimap)
+  if (!automap_full && !minimap)
     return;
 
   // if minimap + overlay + no fade
-  if (automap_active && automap_overlay == 2 && minimap)
+  if (automap_full && automap_overlay == 2 && minimap)
     return;
 
   V_BeginAutomapDraw();

--- a/prboom2/src/am_map.c
+++ b/prboom2/src/am_map.c
@@ -604,25 +604,43 @@ static void AM_changeWindowLoc(void)
 //
 // AM_SetScale
 //
-void AM_SetScale(void)
+typedef enum
 {
+  AM_SCALE_RESET,
+  AM_SCALE_KEEP
+} am_scale_t;
+
+static void AM_SetScale(dboolean keep_scale)
+{
+  fixed_t a, b;
+  fixed_t scale_w, scale_h;
+  fixed_t old_m_w = m_w;
+
+  scale_w = SCREENWIDTH << FRACBITS;
+  scale_h = (SCREENHEIGHT - ST_SCALED_HEIGHT) << FRACBITS;
+
+  a = FixedDiv(scale_w, max_w);
+  b = FixedDiv(scale_h, max_h);
+  min_scale_mtof = a < b ? a : b;
+  max_scale_mtof = FixedDiv(scale_h, 2 * PLAYERRADIUS);
+
+  if (keep_scale)
   {
-    fixed_t a, b;
-    fixed_t scale_w, scale_h;
-
-    scale_w = SCREENWIDTH << FRACBITS;
-    scale_h = (SCREENHEIGHT - ST_SCALED_HEIGHT) << FRACBITS;
-
-    a = FixedDiv(scale_w, max_w);
-    b = FixedDiv(scale_h, max_h);
-    min_scale_mtof = a < b ? a : b;
-    max_scale_mtof = FixedDiv(scale_h, 2 * PLAYERRADIUS);
+    // Keep current zoom when changing resolution / renderer
+    if (automap_active && old_m_w > 0)
+    {
+      scale_mtof = FixedDiv(f_w << FRACBITS, old_m_w);
+      scale_mtof = BETWEEN(min_scale_mtof, max_scale_mtof, scale_mtof);
+      scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
+    }
   }
-
-  scale_mtof = FixedDiv(min_scale_mtof, (int) (0.7*FRACUNIT));
-  if (scale_mtof > max_scale_mtof)
-    scale_mtof = min_scale_mtof;
-  scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
+  else
+  {
+    scale_mtof = FixedDiv(min_scale_mtof, (int) (0.7*FRACUNIT));
+    if (scale_mtof > max_scale_mtof)
+      scale_mtof = min_scale_mtof;
+    scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
+  }
 }
 
 //
@@ -643,12 +661,6 @@ void AM_SetPosition(void)
     {
       f_h = SCREENHEIGHT - ST_SCALED_HEIGHT;
     }
-  }
-  else if (dsda_ShowMinimap())
-  {
-    void dsda_CopyMinimapCoordinates(int* f_x, int* f_y, int* f_w, int* f_h);
-
-    dsda_CopyMinimapCoordinates(&f_x, &f_y, &f_w, &f_h);
   }
 }
 
@@ -721,7 +733,8 @@ static void AM_initVariables(void)
 void AM_SetResolution(void)
 {
   AM_SetPosition();
-  AM_SetScale();
+  AM_SetScale(AM_SCALE_KEEP);
+  AM_activateNewScale();
 }
 
 static void AM_ResetTagHighlight(void)
@@ -730,6 +743,37 @@ static void AM_ResetTagHighlight(void)
   ZERO_DATA(highlight);
   highlight.x = INT_MIN;
   highlight.y = INT_MIN;
+}
+
+static void AM_UpdateMinimapCoordinates(void)
+{
+  if (dsda_ShowMinimap())
+  {
+    void dsda_CopyMinimapCoordinates(int* f_x, int* f_y, int* f_w, int* f_h);
+
+    dsda_CopyMinimapCoordinates(&f_x, &f_y, &f_w, &f_h);
+  }
+}
+
+static void AM_SetMinimapScale(void)
+{
+  int dsda_MinimapScale(void);
+
+  min_scale_mtof =
+  max_scale_mtof =
+  scale_mtof = FixedDiv(f_w << FRACBITS, dsda_MinimapScale() << MAPBITS);
+  scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
+}
+
+void AM_RefreshMinimap(void)
+{
+  if (!dsda_ShowMinimap() || automap_active)
+    return;
+
+  // Refresh Minimap Coordinates / scale / center
+  AM_UpdateMinimapCoordinates();
+  AM_SetMinimapScale();
+  AM_initVariables();
 }
 
 //
@@ -778,17 +822,10 @@ void AM_ExchangeScales(int full_automap, int *last_full_automap)
 
   if (*last_full_automap && !full_automap)
   {
-    int dsda_MinimapScale(void);
-
     full_min_scale_mtof = min_scale_mtof;
     full_max_scale_mtof = max_scale_mtof;
     full_scale_mtof = scale_mtof;
     full_scale_ftom = scale_ftom;
-
-    min_scale_mtof =
-    max_scale_mtof =
-    scale_mtof = FixedDiv(f_w << FRACBITS, dsda_MinimapScale() << MAPBITS);
-    scale_ftom = FixedDiv(FRACUNIT, scale_mtof);
   }
   else if (!*last_full_automap && full_automap)
   {
@@ -840,13 +877,16 @@ void AM_Start(dboolean full_automap)
   if (lastlevel != gamemap || lastepisode != gameepisode)
   {
     AM_findMinMaxBoundaries();
-    AM_SetScale();
+    AM_SetScale(AM_SCALE_RESET);
     lastlevel = gamemap;
     lastepisode = gameepisode;
     last_full_automap = true;
   }
 
   AM_ExchangeScales(full_automap, &last_full_automap);
+
+  if (dsda_ShowMinimap() && !full_automap)
+    AM_RefreshMinimap();
 
   AM_initVariables();
 }
@@ -2888,9 +2928,11 @@ static void AM_setFrameVariables(void)
 
 void AM_Drawer (dboolean minimap)
 {
+  // if no automap
   if (!automap_active && !minimap)
     return;
 
+  // if minimap + overlay + no fade
   if (automap_active && automap_overlay == 2 && minimap)
     return;
 

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -109,7 +109,7 @@ void AM_Stop (dboolean minimap);
 
 // killough 2/22/98: for saving automap information in savegame:
 
-void AM_Start(dboolean full_automap);
+void AM_Start(dboolean open_full_automap);
 
 //jff 4/16/98 make externally available
 

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -183,5 +183,6 @@ typedef enum
 extern map_trail_mode_t map_trail_mode;
 
 void AM_updatePlayerTrail(fixed_t x, fixed_t y);
+void AM_RefreshMinimap(void);
 
 #endif

--- a/prboom2/src/am_map.h
+++ b/prboom2/src/am_map.h
@@ -109,6 +109,12 @@ void AM_Stop (dboolean minimap);
 
 // killough 2/22/98: for saving automap information in savegame:
 
+typedef enum
+{
+  AM_OPEN_MINIMAP,
+  AM_OPEN_FULLAUTOMAP
+} am_start_t;
+
 void AM_Start(dboolean open_full_automap);
 
 //jff 4/16/98 make externally available

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -448,8 +448,8 @@ void D_Display (fixed_t frac)
     dboolean redrawborderstuff;
 
     // Work out if the player view is visible, and if there is a border
-    viewactive = automap_off && !inhelpscreens;
-    isborder = viewactive ? R_PartialView() : (!inhelpscreens && automap_active);
+    viewactive = !inhelpscreens && !automap_solid;
+    isborder = viewactive ? R_PartialView() : (!inhelpscreens && automap_full);
 
     if (oldgamestate != GS_LEVEL || must_fill_back_screen) {
       must_fill_back_screen = false;
@@ -503,7 +503,7 @@ void D_Display (fixed_t frac)
     use_boom_cm=false;
     frame_fixedcolormap = 0;
 
-    if (automap_active)
+    if (automap_full)
     {
       AM_Drawer(false);
     }

--- a/prboom2/src/doomstat.h
+++ b/prboom2/src/doomstat.h
@@ -197,17 +197,16 @@ extern int snd_MusicVolume;    // maximum volume for music
 // CPhipps - screen parameters
 extern int desired_screenwidth, desired_screenheight;
 
-extern int automap_active;
+extern int automap_full;
 extern int automap_overlay;
 extern int automap_rotate;
 extern int automap_follow;
 extern int automap_grid;
 
-#define automap_on (automap_active && !automap_overlay)
-#define automap_off (!automap_active && automap_overlay > 0)
-#define automap_stbar (automap_active && R_StatusBarVisible())
-#define automap_input (automap_active)
-#define automap_hud (automap_active && !automap_overlay)
+#define automap_on    (automap_full)
+#define automap_solid (automap_full && !automap_overlay)
+#define automap_input (automap_full)
+#define automap_stbar (automap_full && R_StatusBarVisible())
 
 typedef enum {
   mnact_nochange = -1,

--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -114,7 +114,7 @@ void M_ChangeMIDIPlayer(void);
 void HU_InitCrosshair(void);
 void HU_InitThresholds(void);
 void dsda_InitAutoKeyFrames(void);
-void dsda_SetupStretchParams(void);
+void dsda_UpdateStretchParams(void);
 void dsda_InitCommandHistory(void);
 void dsda_InitQuickstartCache(void);
 void dsda_InitParallelSFXFilter(void);
@@ -931,11 +931,11 @@ dsda_config_t dsda_config[dsda_config_count] = {
   },
   [dsda_config_ex_text_scale_x] = {
     "ex_text_scale_x", dsda_config_ex_text_scale_x,
-    dsda_config_int, 0, 4000, { 0 }, NULL, NOT_STRICT, dsda_SetupStretchParams
+    dsda_config_int, 0, 4000, { 0 }, NULL, NOT_STRICT, dsda_UpdateStretchParams
   },
   [dsda_config_ex_text_ratio_y] = {
     "ex_text_ratio_y", dsda_config_ex_text_ratio_y,
-    dsda_config_int, 0, 200, { 0 }, NULL, NOT_STRICT, dsda_SetupStretchParams
+    dsda_config_int, 0, 200, { 0 }, NULL, NOT_STRICT, dsda_UpdateStretchParams
   },
   [dsda_config_wipe_at_full_speed] = {
     "dsda_wipe_at_full_speed", dsda_config_wipe_at_full_speed,

--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -770,7 +770,7 @@ void dsda_RefreshExHudMinimap(void) {
     if (components[exhud_minimap].initialized)
       components[exhud_minimap].update(components[exhud_minimap].data);
 
-    if (in_game && gamestate == GS_LEVEL)
+    if (in_game && gamestate == GS_LEVEL && !automap_active)
       AM_Start(false);
   }
   else

--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -770,7 +770,7 @@ void dsda_RefreshExHudMinimap(void) {
     if (components[exhud_minimap].initialized)
       components[exhud_minimap].update(components[exhud_minimap].data);
 
-    if (in_game && gamestate == GS_LEVEL && !automap_active)
+    if (in_game && gamestate == GS_LEVEL && !automap_full)
       AM_Start(false);
   }
   else

--- a/prboom2/src/dsda/exhud.c
+++ b/prboom2/src/dsda/exhud.c
@@ -771,7 +771,7 @@ void dsda_RefreshExHudMinimap(void) {
       components[exhud_minimap].update(components[exhud_minimap].data);
 
     if (in_game && gamestate == GS_LEVEL && !automap_full)
-      AM_Start(false);
+      AM_Start(AM_OPEN_MINIMAP);
   }
   else
     dsda_TurnComponentOff(exhud_minimap);

--- a/prboom2/src/dsda/hud_components/minimap.c
+++ b/prboom2/src/dsda/hud_components/minimap.c
@@ -21,25 +21,25 @@
 
 typedef struct {
   int x, y, width, height, scale;
+
+  // backups of original values
+  // (so we can access them later)
+  int xx, yy, ww, hh;
+  int yy_offset, flags;
 } local_component_t;
 
 static local_component_t* local;
 
-// backups of original values
-// (so we can access them later)
-static int xx, yy, ww, hh;
-static int yy_offset, flags;
-
 static void dsda_UpdateMinimapCoordinates(void) {
 
   // Must recalculate y each update
-  yy = dsda_HudComponentY(yy_offset, flags, 0);
+  local->yy = dsda_HudComponentY(local->yy_offset, local->flags, 0);
 
   // Varables
-  local->x      = xx;
-  local->y      = yy;
-  local->width  = ww;
-  local->height = hh;
+  local->x      = local->xx;
+  local->y      = local->yy;
+  local->width  = local->ww;
+  local->height = local->hh;
 
   if (local->x < 0)
     local->x = 0;
@@ -59,7 +59,7 @@ static void dsda_UpdateMinimapCoordinates(void) {
   if (local->y + local->height > 200)
     local->y = 200 - local->height;
 
-  V_GetWideRect(&local->x, &local->y, &local->width, &local->height, flags);
+  V_GetWideRect(&local->x, &local->y, &local->width, &local->height, local->flags);
 }
 
 void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_count, void** data) {
@@ -73,12 +73,12 @@ void dsda_InitMinimapHC(int x_offset, int y_offset, int vpt, int* args, int arg_
   local->scale = args[2];
 
   // Constants
-  xx = local->x;
-  ww = local->width;
-  hh = local->height;
+  local->xx = local->x;
+  local->ww = local->width;
+  local->hh = local->height;
 
-  yy_offset = y_offset;
-  flags = vpt;
+  local->yy_offset = y_offset;
+  local->flags = vpt;
 
   // Init scale
   if (local->scale < 64)

--- a/prboom2/src/dsda/stretch.c
+++ b/prboom2/src/dsda/stretch.c
@@ -15,6 +15,7 @@
 //	DSDA Stretch
 //
 
+#include "am_map.h"
 #include "doomdef.h"
 #include "doomtype.h"
 #include "hu_stuff.h"
@@ -246,6 +247,11 @@ void dsda_SetupStretchParams(void) {
   video_ex_text.height = ex_text_screenheight;
   GenLookup(video_ex_text.x1lookup, video_ex_text.x2lookup, video_ex_text.width, 320, video_ex_text.xstep);
   GenLookup(video_ex_text.y1lookup, video_ex_text.y2lookup, video_ex_text.height, 200, video_ex_text.ystep);
+}
+
+void dsda_UpdateStretchParams(void) {
+  dsda_SetupStretchParams();
+  AM_RefreshMinimap();
 }
 
 void dsda_EvaluatePatchScale(void) {

--- a/prboom2/src/dsda/stretch.h
+++ b/prboom2/src/dsda/stretch.h
@@ -68,5 +68,6 @@ extern int patches_scaley;
 stretch_param_t* dsda_StretchParams(int flags);
 void dsda_SetupStretchParams(void);
 void dsda_EvaluatePatchScale(void);
+void dsda_UpdateStretchParams(void);
 
 #endif

--- a/prboom2/src/f_finale.c
+++ b/prboom2/src/f_finale.c
@@ -93,7 +93,7 @@ void F_StartFinale (void)
 
   gameaction = ga_nothing;
   gamestate = GS_FINALE;
-  automap_active = false;
+  automap_full = false;
 
   // killough 3/28/98: clear accelerative text flags
   acceleratestage = midstage = 0;

--- a/prboom2/src/g_game.c
+++ b/prboom2/src/g_game.c
@@ -2214,7 +2214,7 @@ void G_DoCompleted (void)
   wminfo.totaltimes = totalleveltimes;
 
   gamestate = GS_INTERMISSION;
-  automap_active = false;
+  automap_full = false;
 
   // lmpwatch.pl engine-side demo testing support
   // print "FINISHED: <mapname>" when the player exits the current map
@@ -3083,7 +3083,7 @@ void G_InitNew(int skill, int episode, int map, dboolean prepare)
 
   dsda_ResetPauseMode();
   dsda_ResetCommandHistory();
-  automap_active = false;
+  automap_full = false;
   dsda_UpdateGameSkill(skill);
   dsda_UpdateGameMap(episode, map);
 

--- a/prboom2/src/gl_main.c
+++ b/prboom2/src/gl_main.c
@@ -146,7 +146,7 @@ void gld_MultisamplingSet(void)
   {
     extern int map_use_multisampling;
 
-    int use_multisampling = map_use_multisampling || automap_off;
+    int use_multisampling = map_use_multisampling || !automap_solid;
 
     gld_EnableMultisample(use_multisampling);
   }

--- a/prboom2/src/heretic/f_finale.c
+++ b/prboom2/src/heretic/f_finale.c
@@ -52,7 +52,7 @@ void Heretic_F_StartFinale(void)
 {
   gameaction = ga_nothing;
   gamestate = GS_FINALE;
-  automap_active = false;
+  automap_full = false;
 
   switch (gameepisode)
   {

--- a/prboom2/src/heretic/sb_bar.c
+++ b/prboom2/src/heretic/sb_bar.c
@@ -580,7 +580,7 @@ void SB_Drawer(dboolean statusbaron, dboolean refresh)
             }
             else
             {
-              if (!automap_active)
+              if (!automap_full)
               {
                   V_DrawNumPatch(38, 162, 0, LumpSTATBAR, CR_DEFAULT, VPT_STRETCH);
               }
@@ -600,7 +600,7 @@ void SB_Drawer(dboolean statusbaron, dboolean refresh)
             oldlife = -1;
             oldkeys = -1;
         }
-        if (heretic || !automap_active)
+        if (heretic || !automap_full)
         {
             DrawMainBar();
         }

--- a/prboom2/src/hexen/f_finale.c
+++ b/prboom2/src/hexen/f_finale.c
@@ -50,7 +50,7 @@ void Hexen_F_StartFinale(void)
 {
     gameaction = ga_nothing;
     gamestate = GS_FINALE;
-    automap_active = false;
+    automap_full = false;
 
     FinaleStage = 0;
     FinaleCount = 0;

--- a/prboom2/src/hu_stuff.c
+++ b/prboom2/src/hu_stuff.c
@@ -240,7 +240,7 @@ void HU_DrawCrosshair(void)
   if (
     !crosshair_nam[hudadd_crosshair] ||
     crosshair.lump == -1 ||
-    automap_active ||
+    automap_full ||
     menuactive ||
     dsda_Paused()
   )

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -5595,7 +5595,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
 
   if (dsda_InputActivated(dsda_input_zoomout))
   {
-    if (automap_active)
+    if (automap_full)
       return false;
     M_SizeDisplay(0);
     S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, true);
@@ -5604,7 +5604,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
 
   if (dsda_InputActivated(dsda_input_zoomin))
   {
-    if (automap_active)
+    if (automap_full)
       return false;
     M_SizeDisplay(1);
     S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, true);
@@ -5712,7 +5712,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
 
   if (dsda_InputActivated(dsda_input_hud))   // heads-up mode
   {
-    if (automap_active)              // jff 2/22/98
+    if (automap_full)                // jff 2/22/98
       return false;                  // HUD mode control
     M_SizeDisplay(2);
     return true;

--- a/prboom2/src/p_inter.c
+++ b/prboom2/src/p_inter.c
@@ -1038,7 +1038,7 @@ static void P_KillMobj(mobj_t *source, mobj_t *target)
       }
     }
 
-    if (target->player == &players[consoleplayer] && automap_active)
+    if (target->player == &players[consoleplayer] && automap_full)
       AM_Stop(true);    // don't die in auto map; switch view prior to dying
   }
 

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -455,7 +455,7 @@ void P_ArchiveMap(void)
 {
   int i;
 
-  P_SAVE_X(automap_active);
+  P_SAVE_X(automap_full);
   P_SAVE_X(markpointnum);
 
   for (i = 0; i < markpointnum; i++)
@@ -467,9 +467,9 @@ void P_ArchiveMap(void)
 
 void P_UnArchiveMap(void)
 {
-  P_LOAD_X(automap_active);
+  P_LOAD_X(automap_full);
 
-  if (automap_active)
+  if (automap_full)
     AM_Start(true);
 
   P_LOAD_X(markpointnum);

--- a/prboom2/src/p_saveg.c
+++ b/prboom2/src/p_saveg.c
@@ -470,7 +470,7 @@ void P_UnArchiveMap(void)
   P_LOAD_X(automap_full);
 
   if (automap_full)
-    AM_Start(true);
+    AM_Start(AM_OPEN_FULLAUTOMAP);
 
   P_LOAD_X(markpointnum);
 

--- a/prboom2/src/p_setup.c
+++ b/prboom2/src/p_setup.c
@@ -3968,7 +3968,7 @@ void P_SetupLevel(int episode, int map, int skill)
 
   if (dsda_ShowMinimap())
   {
-    AM_Start(false);
+    AM_Start(AM_OPEN_MINIMAP);
   }
 }
 

--- a/prboom2/src/r_draw.c
+++ b/prboom2/src/r_draw.c
@@ -150,7 +150,7 @@ dboolean R_PartialView(void)
 
 dboolean R_StatusBarVisible(void)
 {
-  return R_PartialView() || automap_on;
+  return R_PartialView() || automap_solid;
 }
 
 //
@@ -548,7 +548,7 @@ void R_FillBackColor (void)
 
 void R_FillBackScreen (void)
 {
-  int automap = automap_on;
+  int automap = automap_solid;
 
   if (grnrock.lumpnum == 0)
     return;

--- a/prboom2/src/r_main.c
+++ b/prboom2/src/r_main.c
@@ -1018,7 +1018,7 @@ static void R_InitDrawScene(void)
     // proff 11/99: clear buffers
     gld_InitDrawScene();
 
-    if (!automap_on)
+    if (!automap_solid)
     {
       // proff 11/99: switch to perspective mode
       gld_StartDrawScene();
@@ -1124,7 +1124,7 @@ void R_RenderPlayerView (player_t* player)
 
   FakeNetUpdate();
 
-  if (V_IsOpenGLMode() && !automap_on) {
+  if (V_IsOpenGLMode() && !automap_solid) {
     DSDA_ADD_CONTEXT(sf_draw_scene);
     gld_DrawScene(player);
     gld_EndDrawScene();

--- a/prboom2/src/v_video.c
+++ b/prboom2/src/v_video.c
@@ -1511,12 +1511,6 @@ void V_ChangeScreenResolution(void)
   {
     gld_PreprocessLevel();
   }
-
-  // Refresh Minimap Coordinates
-  if (dsda_ShowMinimap())
-  {
-    dsda_RefreshExHudMinimap();
-  }
 }
 
 void V_FillRectVPT(int scrn, int x, int y, int width, int height, byte color, enum patch_translation_e flags)


### PR DESCRIPTION
First off, I fixed the minimap coordinates to work correctly. When I rewrote Nyan's hud to allow for multiple fullscreen huds, I learned how you're supposed to do it, and notice my last PR #799 was kinda wrong.

Second, I made tweaks so that the automap doesn't change zoom scaling when changing resolution or renderer.

Third, I replaced the current automap variables with ones that make more sense (and match Nyan). It become harder to follow once the overlay automap was introduced.

This reworking also removed the requirement of having a minimap refresh function inside `V_ChangeScreenResolution`.