### PR TITLE
Fix Optional Sounds Demo Desyncs

### DIFF
--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -105,6 +105,7 @@
 #include "dsda/skill_info.h"
 #include "dsda/skip.h"
 #include "dsda/sndinfo.h"
+#include "dsda/sfx.h"
 #include "dsda/time.h"
 #include "dsda/utility.h"
 #include "dsda/wad_stats.h"
@@ -2180,6 +2181,7 @@ static void D_DoomMainSetup(void)
   }
 
   PostProcessDeh();
+  dsda_AppendPortSFX();
   dsda_AppendZDoomMobjInfo();
   dsda_ApplyBinaryMapFormat();
 

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -145,7 +145,7 @@ static void dsda_InitDoom(void) {
   dsda_InitializeMobjInfo(DOOM_MT_ZERO, DOOM_NUMMOBJTYPES, DOOM_NUMMOBJTYPES);
   dsda_InitializeStates(doom_states, DOOM_NUMSTATES);
   dsda_InitializeSprites(doom_sprnames, DOOM_NUMSPRITES);
-  dsda_InitializeSFX(doom_S_sfx, DOOM_NUMSFX);
+  dsda_InitializeSFX(doom_S_sfx, DOOM_NUMSFX, DOOM_BASESFX_END);
   dsda_InitializeMusic(doom_S_music, DOOM_NUMMUSIC);
 
   demostates = doom_demostates;
@@ -284,7 +284,7 @@ static void dsda_InitHeretic(void) {
   dsda_InitializeMobjInfo(HERETIC_MT_ZERO, HERETIC_NUMMOBJTYPES, HERETIC_NUMMOBJTYPES);
   dsda_InitializeStates(heretic_states, HERETIC_NUMSTATES);
   dsda_InitializeSprites(heretic_sprnames, HERETIC_NUMSPRITES);
-  dsda_InitializeSFX(heretic_S_sfx, HERETIC_NUMSFX);
+  dsda_InitializeSFX(heretic_S_sfx, HERETIC_NUMSFX, HERETIC_BASESFX_END);
   dsda_InitializeMusic(heretic_S_music, HERETIC_NUMMUSIC);
 
   demostates = heretic_demostates;
@@ -441,7 +441,7 @@ static void dsda_InitHexen(void) {
   dsda_InitializeMobjInfo(HEXEN_MT_ZERO, HEXEN_NUMMOBJTYPES, TOTAL_NUMMOBJTYPES);
   dsda_InitializeStates(hexen_states, HEXEN_NUMSTATES);
   dsda_InitializeSprites(hexen_sprnames, HEXEN_NUMSPRITES);
-  dsda_InitializeSFX(hexen_S_sfx, HEXEN_NUMSFX);
+  dsda_InitializeSFX(hexen_S_sfx, HEXEN_NUMSFX, HEXEN_BASESFX_END);
   dsda_InitializeMusic(hexen_S_music, HEXEN_NUMMUSIC);
 
   demostates = hexen_demostates;

--- a/prboom2/src/dsda/sfx.c
+++ b/prboom2/src/dsda/sfx.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "doomdef.h"
 #include "doomtype.h"
 
 #include "dsda/configuration.h"
@@ -31,6 +32,7 @@ static int deh_soundnames_size;
 static char** deh_soundnames;
 static byte* sfx_state;
 static int highest_index;
+static int game_base_sfx_end;
 
 static void dsda_ResetSFX(int from, int to) {
   int i;
@@ -130,13 +132,14 @@ sfxinfo_t* dsda_NewSFX(int* index) {
   return dsda_SFXAtIndex(*index);
 }
 
-void dsda_InitializeSFX(sfxinfo_t* source, int count) {
+void dsda_InitializeSFX(sfxinfo_t* source, int count, int base_sfx_end) {
   int i;
   extern int raven;
 
   num_sfx = count;
   highest_index = count - 1;
   deh_soundnames_size = num_sfx + 1;
+  game_base_sfx_end = base_sfx_end;
 
   S_sfx = source;
 
@@ -152,6 +155,47 @@ void dsda_InitializeSFX(sfxinfo_t* source, int count) {
   deh_soundnames[num_sfx] = NULL;
 
   sfx_state = calloc(num_sfx, sizeof(*sfx_state));
+}
+
+void dsda_AppendPortSFX(void) {
+  int i;
+  extern dboolean heretic;
+  extern dboolean hexen;
+
+  dsda_PrepAllocation();
+  dsda_EnsureCapacity(game_base_sfx_end + NUM_PORT_SFX - 1);
+
+  for (i = 1; i < NUM_PORT_SFX; ++i) {
+    sfx_port_info_t *port_sfx = &port_S_sfx[i];
+    sfxinfo_t *sfx = &S_sfx[game_base_sfx_end + i];
+
+    // Doom name is fallback if heretic/hexen are NULL
+    const char *name = port_sfx->doom_name;
+
+    if (heretic && port_sfx->heretic_name)
+      name = port_sfx->heretic_name;
+    else if (hexen && port_sfx->hexen_name)
+      name = port_sfx->hexen_name;
+
+    sfx->name = name;
+    sfx->priority = port_sfx->priority;
+    sfx->link = port_sfx->link;
+    sfx->pitch = port_sfx->pitch;
+    sfx->data = port_sfx->data;
+    sfx->lumpnum = port_sfx->lumpnum;
+    sfx->numchannels = port_sfx->numchannels;
+    sfx->tagname = port_sfx->tagname;
+    sfx->parallel_tic = port_sfx->parallel_tic;
+    sfx->parallel_count = port_sfx->parallel_count;
+  }
+
+  if (highest_index < game_base_sfx_end + NUM_PORT_SFX - 1)
+    highest_index = game_base_sfx_end + NUM_PORT_SFX - 1;
+}
+
+int dsda_PortSFXIndex(int port_sfx_id)
+{
+  return game_base_sfx_end + port_sfx_id;
 }
 
 void dsda_FreeDehSFX(void) {

--- a/prboom2/src/dsda/sfx.h
+++ b/prboom2/src/dsda/sfx.h
@@ -24,7 +24,9 @@ int dsda_GetDehSFXIndex(const char* key, size_t length);
 int dsda_GetOriginalSFXIndex(const char* key);
 sfxinfo_t* dsda_GetDehSFX(int index);
 sfxinfo_t* dsda_NewSFX(int* index);
-void dsda_InitializeSFX(sfxinfo_t* source, int count);
+void dsda_InitializeSFX(sfxinfo_t* source, int count, int game_base_sfx_end);
+void dsda_AppendPortSFX(void);
+int dsda_PortSFXIndex(int port_sfx_id);
 void dsda_FreeDehSFX(void);
 dboolean dsda_BlockSFX(sfxinfo_t *sfx);
 

--- a/prboom2/src/heretic/sounds.c
+++ b/prboom2/src/heretic/sounds.c
@@ -83,23 +83,6 @@ musicinfo_t heretic_S_music[] = {
 sfxinfo_t heretic_S_sfx[] = {
     { "", 0, 0, -1, 0, 0, 0, "" },
 
-    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
-
-    // Optional menu/intermission sounds
-    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
-
     // Heretic sounds
     { "gldhit", 32, 0, -1, 0, 0, 2, "" },
     { "gntful", 32, 0, -1, 0, 0, -1, "" },

--- a/prboom2/src/hexen/sounds.c
+++ b/prboom2/src/hexen/sounds.c
@@ -29,23 +29,6 @@ musicinfo_t hexen_S_music[HEXEN_NUMMUSIC] = {
 sfxinfo_t hexen_S_sfx[] = {
     { "", 0, 0, 0, 0, 0, 0, "" },
 
-    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
-
-    // Optional menu/intermission sounds
-    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
-
     // Hexen sounds
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterNormalDeath" },
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterCrazyDeath" },

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -144,6 +144,11 @@ static mobj_t* GetSoundListener(void);
 static void Heretic_S_StopSound(void *_origin);
 static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, int loop_timeout);
 
+static dboolean S_IsSecretSound(int sfx_id)
+{
+  return sfx_id == sfx_secret;
+}
+
 void S_ResetSfxVolume(void)
 {
   snd_SfxVolume = dsda_IntConfig(dsda_config_sfx_volume);
@@ -333,7 +338,7 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume, dboolean impor
     return;
 
   // killough 4/25/98
-  if (sfx_id == sfx_secret)
+  if (S_IsSecretSound(sfx_id))
     params.sfx_class = sfx_class_secret;
   else if (important || sfx_id & PICKUP_SOUND || sfx_id == sfx_oof ||
       (compatibility_level >= prboom_2_compatibility && sfx_id == sfx_noway))
@@ -1197,7 +1202,7 @@ static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, 
   params.priority = sfx->priority;
   params.priority *= (10 - (dist / dist_adjust));
 
-  params.sfx_class = sfx_class_none;
+  params.sfx_class = S_IsSecretSound(sound_id) ? sfx_class_secret : sfx_class_none;
 
   cnum = Raven_S_getChannel(listener, origin, sfx, &params);
   if (cnum == channel_not_found)

--- a/prboom2/src/sounds.c
+++ b/prboom2/src/sounds.c
@@ -38,6 +38,8 @@
 #include "config.h"
 #endif
 
+#include <stddef.h>
+
 #include "doomtype.h"
 #include "sounds.h"
 
@@ -119,6 +121,31 @@ musicinfo_t doom_S_music[] = {
   { "musinfo", 0 }
 };
 
+//
+// Port specific / optional sfx
+//
+
+sfx_port_info_t port_S_sfx[] = {
+    { "dsnone", NULL, NULL, 0, 0, -1, 0, 0, 0, "" },
+
+    // DSDA
+    { "dssecret", "secret", "secret", 60, 0, -1, 0, 0, 0, "" }, // Secret
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnucls", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuact", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnubak", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnumov", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusli", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusel", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuerr", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttic", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttot", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnex", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnet", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+    { "dsintdms", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
+};
 
 //
 // Information about all the sfx
@@ -127,23 +154,6 @@ musicinfo_t doom_S_music[] = {
 sfxinfo_t doom_S_sfx[] = {
   // S_sfx[0] needs to be a dummy for odd reasons.
   { "dsnone", 0, 0, -1, 0, 0, 0, "" },
-
-  { "dssecret", 60, 0, -1, 0, 0, 0, "" },
-
-  // Optional menu/intermission sounds
-  { "dsmnuopn", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnucls", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnuact", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnubak", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnumov", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnusli", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnusel", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnuerr", 60, 0, -1, 0, 0, 0, "" },
-  { "dsinttic", 60, 0, -1, 0, 0, 0, "" },
-  { "dsinttot", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintnex", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintnet", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintdms", 60, 0, -1, 0, 0, 0, "" },
 
   // Doom sounds
   { "dspistol", 64, 0, -1, 0, 0, 0, "" },
@@ -788,5 +798,5 @@ sfxinfo_t doom_disambiguated_sfx[] = {
 
   DISAMBIGUATED_SFX(sfx_dgpain, "dog/pain"),
 
-  DISAMBIGUATED_SFX(sfx_secret, "misc/secret"),
+  //DISAMBIGUATED_SFX(sfx_secret, "misc/secret"),
 };

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -94,6 +94,27 @@ struct sfxinfo_struct {
   int parallel_count;
 };
 
+struct portsfxinfo_struct;
+
+typedef struct portsfxinfo_struct sfx_port_info_t;
+
+struct portsfxinfo_struct {
+  const char *doom_name; // up to 6-character name
+  const char *heretic_name; // 8-character name
+  const char *hexen_name;   // 8-character name
+
+  int priority;         // Sfx priority
+  sfxinfo_t *link;      // referenced sound if a link
+  int pitch;            // pitch if a link
+  void *data;           // sound data
+  int lumpnum;          // lump number of sfx
+  int numchannels;      // heretic - total number of channels a sound type may occupy
+  const char *tagname;  // hexen
+
+  int parallel_tic;
+  int parallel_count;
+};
+
 //
 // MusicInfo struct.
 //
@@ -263,28 +284,60 @@ typedef enum {
 } musicenum_t;
 
 //
+// Port specific / optional sfx
+//
+
+typedef enum {
+  port_sfx_None,
+
+  // DSDA
+  port_sfx_secret,
+
+  // Optional menu/intermission sounds
+  port_sfx_mnuopn, // swtchn
+  port_sfx_mnucls, // swtchx
+  port_sfx_mnuact, // pistol
+  port_sfx_mnubak,
+  port_sfx_mnumov, // pstop
+  port_sfx_mnusli, // stnmov
+  port_sfx_mnusel, // itemup
+  port_sfx_mnuerr, // oof
+  port_sfx_inttic, // pistol
+  port_sfx_inttot, // barex
+  port_sfx_intnex, // sgcock
+  port_sfx_intnet, // pldeth
+  port_sfx_intdms, // slop
+  NUM_PORT_SFX,
+} sfx_port_enum_t;
+
+int dsda_PortSFXIndex(int port_sfx_id);
+
+#define sfx_secret        (dsda_PortSFXIndex(port_sfx_secret))
+#define sfx_secret_subtle (dsda_PortSFXIndex(port_sfx_secret_subtle))
+#define sfx_idnut         (dsda_PortSFXIndex(port_sfx_idnut))
+#define sfx_gibdth        (dsda_PortSFXIndex(port_sfx_gibdth))
+
+#define sfx_mnuopn (dsda_PortSFXIndex(port_sfx_mnuopn))
+#define sfx_mnucls (dsda_PortSFXIndex(port_sfx_mnucls))
+#define sfx_mnuact (dsda_PortSFXIndex(port_sfx_mnuact))
+#define sfx_mnubak (dsda_PortSFXIndex(port_sfx_mnubak))
+#define sfx_mnumov (dsda_PortSFXIndex(port_sfx_mnumov))
+#define sfx_mnusli (dsda_PortSFXIndex(port_sfx_mnusli))
+#define sfx_mnusel (dsda_PortSFXIndex(port_sfx_mnusel))
+
+#define sfx_mnuerr (dsda_PortSFXIndex(port_sfx_mnuerr))
+#define sfx_inttic (dsda_PortSFXIndex(port_sfx_inttic))
+#define sfx_inttot (dsda_PortSFXIndex(port_sfx_inttot))
+#define sfx_intnex (dsda_PortSFXIndex(port_sfx_intnex))
+#define sfx_intnet (dsda_PortSFXIndex(port_sfx_intnet))
+#define sfx_intdms (dsda_PortSFXIndex(port_sfx_intdms))
+
+//
 // Identifiers for all sfx in game.
 //
 
 typedef enum {
   sfx_None,
-
-  sfx_secret,
-
-  // Optional menu/intermission sounds
-  sfx_mnuopn, // swtchn
-  sfx_mnucls, // swtchx
-  sfx_mnuact, // pistol
-  sfx_mnubak,
-  sfx_mnumov, // pstop
-  sfx_mnusli, // stnmov
-  sfx_mnusel, // itemup
-  sfx_mnuerr, // oof
-  sfx_inttic, // pistol
-  sfx_inttot, // barex
-  sfx_intnex, // sgcock
-  sfx_intnet, // pldeth
-  sfx_intdms, // slop
 
   BASE_NUMSFX,
 
@@ -403,6 +456,8 @@ typedef enum {
   sfx_dgact,
   sfx_dgdth,
   sfx_dgpain,
+
+  DOOM_BASESFX_END = sfx_dgpain,
 
   // Everything from here to 500 is reserved
 
@@ -755,6 +810,9 @@ typedef enum {
   heretic_sfx_amb9,
   heretic_sfx_amb10,
   heretic_sfx_amb11,
+
+  HERETIC_BASESFX_END = heretic_sfx_amb11,
+
   HERETIC_NUMSFX,
 
   // hexen
@@ -1002,6 +1060,9 @@ typedef enum {
   hexen_sfx_fireball,
   hexen_sfx_puppybeat,
   hexen_sfx_mysticincant,
+
+  HEXEN_BASESFX_END = hexen_sfx_mysticincant,
+
   HEXEN_NUMSFX
 } sfxenum_t;
 
@@ -1015,6 +1076,9 @@ extern musicinfo_t heretic_S_music[];
 
 extern sfxinfo_t doom_S_sfx[];
 extern musicinfo_t doom_S_music[];
+
+// DSDA sound effects
+extern sfx_port_info_t port_S_sfx[];
 
 extern sfxinfo_t* S_sfx;
 extern int num_sfx;


### PR DESCRIPTION
Move port / optional sounds into separate sfx list
- Append them dynamically after the base game sfx, but before dehextra and dsdhacked
- Allow different sounds per game for optional sounds
- Change raven games to use separate secret lump (SECRET instead of DSSECRET)
- Have raven games respect secret sounds not getting cut off

The main reason I took this approach is it means we can still just reference `sfx_secret` in other parts of the codebase.