### PR TITLE
Optional SFX Fix (Take II)

### DIFF
--- a/prboom2/src/SDL/i_video.c
+++ b/prboom2/src/SDL/i_video.c
@@ -425,7 +425,7 @@ static void I_GetEvent(void)
         break;
 
       case SDL_QUIT:
-        S_StartOptionalSound(sfx_mnucls, sfx_swtchn, true);
+        S_StartOptionalSound(g_sfx_mnucls, g_sfx_swtchn, true);
         M_QuitDOOM(0);
 
       default:

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1951,23 +1951,23 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint64_t value) {
     case 1: mi->spawnstate = (int)value; return;
     case 2: mi->spawnhealth = (int)value; return;
     case 3: mi->seestate = (int)value; return;
-    case 4: mi->seesound = dsda_TranslateDehSFXIndex((int)value); return;
+    case 4: mi->seesound = (int)value; return;
     case 5: mi->reactiontime = (int)value; return;
-    case 6: mi->attacksound = dsda_TranslateDehSFXIndex((int)value); return;
+    case 6: mi->attacksound = (int)value; return;
     case 7: mi->painstate = (int)value; return;
     case 8: mi->painchance = (int)value; return;
-    case 9: mi->painsound = dsda_TranslateDehSFXIndex((int)value); return;
+    case 9: mi->painsound = (int)value; return;
     case 10: mi->meleestate = (int)value; return;
     case 11: mi->missilestate = (int)value; return;
     case 12: mi->deathstate = (int)value; return;
     case 13: mi->xdeathstate = (int)value; return;
-    case 14: mi->deathsound = dsda_TranslateDehSFXIndex((int)value); return;
+    case 14: mi->deathsound = (int)value; return;
     case 15: mi->speed = (int)value; return;
     case 16: mi->radius = (int)value; return;
     case 17: mi->height = (int)value; return;
     case 18: mi->mass = (int)value; return;
     case 19: mi->damage = (int)value; return;
-    case 20: mi->activesound = dsda_TranslateDehSFXIndex((int)value); return;
+    case 20: mi->activesound = (int)value; return;
     case 21: mi->flags = value; return;
     // e6y
     // Correction of wrong processing of "Respawn frame" entry.
@@ -2019,7 +2019,7 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint64_t value) {
       }
       mi->splash_group = mi->splash_group + SG_END;
       return;
-    case 29: mi->ripsound = dsda_TranslateDehSFXIndex((int)value); return;
+    case 29: mi->ripsound = (int)value; return;
     case 30: mi->altspeed = (int)value; return;
     case 31: mi->meleerange = (int)value; return;
 

--- a/prboom2/src/d_deh.c
+++ b/prboom2/src/d_deh.c
@@ -1951,23 +1951,23 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint64_t value) {
     case 1: mi->spawnstate = (int)value; return;
     case 2: mi->spawnhealth = (int)value; return;
     case 3: mi->seestate = (int)value; return;
-    case 4: mi->seesound = (int)value; return;
+    case 4: mi->seesound = dsda_TranslateDehSFXIndex((int)value); return;
     case 5: mi->reactiontime = (int)value; return;
-    case 6: mi->attacksound = (int)value; return;
+    case 6: mi->attacksound = dsda_TranslateDehSFXIndex((int)value); return;
     case 7: mi->painstate = (int)value; return;
     case 8: mi->painchance = (int)value; return;
-    case 9: mi->painsound = (int)value; return;
+    case 9: mi->painsound = dsda_TranslateDehSFXIndex((int)value); return;
     case 10: mi->meleestate = (int)value; return;
     case 11: mi->missilestate = (int)value; return;
     case 12: mi->deathstate = (int)value; return;
     case 13: mi->xdeathstate = (int)value; return;
-    case 14: mi->deathsound = (int)value; return;
+    case 14: mi->deathsound = dsda_TranslateDehSFXIndex((int)value); return;
     case 15: mi->speed = (int)value; return;
     case 16: mi->radius = (int)value; return;
     case 17: mi->height = (int)value; return;
     case 18: mi->mass = (int)value; return;
     case 19: mi->damage = (int)value; return;
-    case 20: mi->activesound = (int)value; return;
+    case 20: mi->activesound = dsda_TranslateDehSFXIndex((int)value); return;
     case 21: mi->flags = value; return;
     // e6y
     // Correction of wrong processing of "Respawn frame" entry.
@@ -2019,7 +2019,7 @@ static void setMobjInfoValue(int mobjInfoIndex, int keyIndex, uint64_t value) {
       }
       mi->splash_group = mi->splash_group + SG_END;
       return;
-    case 29: mi->ripsound = (int)value; return;
+    case 29: mi->ripsound = dsda_TranslateDehSFXIndex((int)value); return;
     case 30: mi->altspeed = (int)value; return;
     case 31: mi->meleerange = (int)value; return;
 

--- a/prboom2/src/d_main.c
+++ b/prboom2/src/d_main.c
@@ -105,7 +105,6 @@
 #include "dsda/skill_info.h"
 #include "dsda/skip.h"
 #include "dsda/sndinfo.h"
-#include "dsda/sfx.h"
 #include "dsda/time.h"
 #include "dsda/utility.h"
 #include "dsda/wad_stats.h"
@@ -2181,7 +2180,6 @@ static void D_DoomMainSetup(void)
   }
 
   PostProcessDeh();
-  dsda_AppendPortSFX();
   dsda_AppendZDoomMobjInfo();
   dsda_ApplyBinaryMapFormat();
 

--- a/prboom2/src/dsda/console.c
+++ b/prboom2/src/dsda/console.c
@@ -2598,14 +2598,14 @@ static dboolean dsda_ExecuteConsole(const char* command_line, dboolean noise) {
             ret = false;
 
             if (noise)
-              S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, false);
+              S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, false);
           }
         }
         else {
           ret = false;
 
           if (noise)
-            S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, false);
+            S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, false);
         }
 
         break;
@@ -2617,7 +2617,7 @@ static dboolean dsda_ExecuteConsole(const char* command_line, dboolean noise) {
       ret = false;
 
       if (noise)
-        S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, false);
+        S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, false);
     }
   }
 

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -116,8 +116,24 @@ int g_sfx_pistol;
 int g_sfx_oof;
 int g_sfx_menu;
 int g_sfx_respawn;
+int g_sfx_secret;
 int g_sfx_revive;
 int g_sfx_console;
+
+// Optional menu/intermission sounds
+int g_sfx_mnuopn;
+int g_sfx_mnucls;
+int g_sfx_mnuact;
+int g_sfx_mnubak;
+int g_sfx_mnumov;
+int g_sfx_mnusli;
+int g_sfx_mnusel;
+int g_sfx_mnuerr;
+int g_sfx_inttic;
+int g_sfx_inttot;
+int g_sfx_intnex;
+int g_sfx_intnet;
+int g_sfx_intdms;
 
 int g_door_normal;
 int g_door_raise_in_5_mins;
@@ -187,8 +203,24 @@ static void dsda_InitDoom(void) {
   g_sfx_pistol = sfx_pistol;
   g_sfx_oof = sfx_oof;
   g_sfx_menu = sfx_pstop;
+  g_sfx_secret = sfx_secret;
   g_sfx_revive = sfx_slop;
   g_sfx_console = sfx_radio;
+
+  // Optional menu/intermission sounds
+  g_sfx_mnuopn = sfx_mnuopn;
+  g_sfx_mnucls = sfx_mnucls;
+  g_sfx_mnuact = sfx_mnuact;
+  g_sfx_mnubak = sfx_mnubak;
+  g_sfx_mnumov = sfx_mnumov;
+  g_sfx_mnusli = sfx_mnusli;
+  g_sfx_mnusel = sfx_mnusel;
+  g_sfx_mnuerr = sfx_mnuerr;
+  g_sfx_inttic = sfx_inttic;
+  g_sfx_inttot = sfx_inttot;
+  g_sfx_intnex = sfx_intnex;
+  g_sfx_intnet = sfx_intnet;
+  g_sfx_intdms = sfx_intdms;
 
   g_door_normal = normal;
   g_door_raise_in_5_mins = waitRaiseDoor;
@@ -358,9 +390,25 @@ static void dsda_InitHeretic(void) {
   g_sfx_pistol = heretic_sfx_gldhit;
   g_sfx_oof = heretic_sfx_plroof;
   g_sfx_menu = heretic_sfx_dorcls;
+  g_sfx_secret = heretic_sfx_secret;
   g_sfx_respawn = heretic_sfx_respawn;
   g_sfx_revive = heretic_sfx_telept;
   g_sfx_console = heretic_sfx_chat;
+
+  // Optional menu/intermission sounds
+  g_sfx_mnuopn = heretic_sfx_mnuopn;
+  g_sfx_mnucls = heretic_sfx_mnucls;
+  g_sfx_mnuact = heretic_sfx_mnuact;
+  g_sfx_mnubak = heretic_sfx_mnubak;
+  g_sfx_mnumov = heretic_sfx_mnumov;
+  g_sfx_mnusli = heretic_sfx_mnusli;
+  g_sfx_mnusel = heretic_sfx_mnusel;
+  g_sfx_mnuerr = heretic_sfx_mnuerr;
+  g_sfx_inttic = heretic_sfx_inttic;
+  g_sfx_inttot = heretic_sfx_inttot;
+  g_sfx_intnex = heretic_sfx_intnex;
+  g_sfx_intnet = heretic_sfx_intnet;
+  g_sfx_intdms = heretic_sfx_intdms;
 
   g_door_normal = vld_normal;
   g_door_raise_in_5_mins = vld_raiseIn5Mins;
@@ -511,9 +559,25 @@ static void dsda_InitHexen(void) {
   g_sfx_pistol = hexen_sfx_fighter_hammer_hitwall;
   g_sfx_oof = hexen_sfx_player_fighter_grunt;
   g_sfx_menu = hexen_sfx_door_light_close;
+  g_sfx_secret = hexen_sfx_secret;
   g_sfx_respawn = hexen_sfx_respawn;
   g_sfx_revive = hexen_sfx_teleport;
   g_sfx_console = hexen_sfx_chat;
+
+  // Optional menu/intermission sounds
+  g_sfx_mnuopn = hexen_sfx_mnuopn;
+  g_sfx_mnucls = hexen_sfx_mnucls;
+  g_sfx_mnuact = hexen_sfx_mnuact;
+  g_sfx_mnubak = hexen_sfx_mnubak;
+  g_sfx_mnumov = hexen_sfx_mnumov;
+  g_sfx_mnusli = hexen_sfx_mnusli;
+  g_sfx_mnusel = hexen_sfx_mnusel;
+  g_sfx_mnuerr = hexen_sfx_mnuerr;
+  g_sfx_inttic = hexen_sfx_inttic;
+  g_sfx_inttot = hexen_sfx_inttot;
+  g_sfx_intnex = hexen_sfx_intnex;
+  g_sfx_intnet = hexen_sfx_intnet;
+  g_sfx_intdms = hexen_sfx_intdms;
 
   g_st_height = 39;
   g_border_offset = 4;

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -145,7 +145,7 @@ static void dsda_InitDoom(void) {
   dsda_InitializeMobjInfo(DOOM_MT_ZERO, DOOM_NUMMOBJTYPES, DOOM_NUMMOBJTYPES);
   dsda_InitializeStates(doom_states, DOOM_NUMSTATES);
   dsda_InitializeSprites(doom_sprnames, DOOM_NUMSPRITES);
-  dsda_InitializeSFX(doom_S_sfx, DOOM_NUMSFX, DOOM_BASESFX_END);
+  dsda_InitializeSFX(doom_S_sfx, DOOM_NUMSFX);
   dsda_InitializeMusic(doom_S_music, DOOM_NUMMUSIC);
 
   demostates = doom_demostates;
@@ -284,7 +284,7 @@ static void dsda_InitHeretic(void) {
   dsda_InitializeMobjInfo(HERETIC_MT_ZERO, HERETIC_NUMMOBJTYPES, HERETIC_NUMMOBJTYPES);
   dsda_InitializeStates(heretic_states, HERETIC_NUMSTATES);
   dsda_InitializeSprites(heretic_sprnames, HERETIC_NUMSPRITES);
-  dsda_InitializeSFX(heretic_S_sfx, HERETIC_NUMSFX, HERETIC_BASESFX_END);
+  dsda_InitializeSFX(heretic_S_sfx, HERETIC_NUMSFX);
   dsda_InitializeMusic(heretic_S_music, HERETIC_NUMMUSIC);
 
   demostates = heretic_demostates;
@@ -441,7 +441,7 @@ static void dsda_InitHexen(void) {
   dsda_InitializeMobjInfo(HEXEN_MT_ZERO, HEXEN_NUMMOBJTYPES, TOTAL_NUMMOBJTYPES);
   dsda_InitializeStates(hexen_states, HEXEN_NUMSTATES);
   dsda_InitializeSprites(hexen_sprnames, HEXEN_NUMSPRITES);
-  dsda_InitializeSFX(hexen_S_sfx, HEXEN_NUMSFX, HEXEN_BASESFX_END);
+  dsda_InitializeSFX(hexen_S_sfx, HEXEN_NUMSFX);
   dsda_InitializeMusic(hexen_S_music, HEXEN_NUMMUSIC);
 
   demostates = hexen_demostates;

--- a/prboom2/src/dsda/global.h
+++ b/prboom2/src/dsda/global.h
@@ -88,8 +88,24 @@ extern int g_sfx_pistol;
 extern int g_sfx_oof;
 extern int g_sfx_menu;
 extern int g_sfx_respawn;
+extern int g_sfx_secret;
 extern int g_sfx_revive;
 extern int g_sfx_console;
+
+// Optional menu/intermission sounds
+extern int g_sfx_mnuopn;
+extern int g_sfx_mnucls;
+extern int g_sfx_mnuact;
+extern int g_sfx_mnubak;
+extern int g_sfx_mnumov;
+extern int g_sfx_mnusli;
+extern int g_sfx_mnusel;
+extern int g_sfx_mnuerr;
+extern int g_sfx_inttic;
+extern int g_sfx_inttot;
+extern int g_sfx_intnex;
+extern int g_sfx_intnet;
+extern int g_sfx_intdms;
 
 extern int g_door_normal;
 extern int g_door_raise_in_5_mins;

--- a/prboom2/src/dsda/sfx.c
+++ b/prboom2/src/dsda/sfx.c
@@ -74,20 +74,6 @@ static void dsda_EnsureCapacity(int limit) {
   }
 }
 
-int dsda_TranslateDehSFXIndex(int index) {
-  if (index > sfx_None)
-    return index + (BASE_NUMSFX - 1);
-    
-  return sfx_None;
-}
-
-static int dsda_UnTranslateDehSFXIndex(int index) {
-  if (index >= BASE_NUMSFX)
-    return index - (BASE_NUMSFX - 1);
-
-  return index;
-}
-
 int dsda_GetDehSFXIndex(const char* key, size_t length) {
   int i;
 
@@ -112,7 +98,7 @@ int dsda_GetOriginalSFXIndex(const char* key) {
 
   for (i = 1; deh_soundnames[i]; ++i)
     if (!strncasecmp(deh_soundnames[i], key, 6))
-      return dsda_UnTranslateDehSFXIndex(i);
+      return i;
 
   // is it a number?
   for (c = key; *c; c++)
@@ -120,7 +106,7 @@ int dsda_GetOriginalSFXIndex(const char* key) {
       return -1;
 
   i = atoi(key);
-  dsda_EnsureCapacity(dsda_TranslateDehSFXIndex(i));
+  dsda_EnsureCapacity(i);
 
   return i;
 }
@@ -135,7 +121,7 @@ static sfxinfo_t* dsda_SFXAtIndex(int index) {
 }
 
 sfxinfo_t* dsda_GetDehSFX(int index) {
-  return dsda_SFXAtIndex(dsda_TranslateDehSFXIndex(index));
+  return dsda_SFXAtIndex(index);
 }
 
 sfxinfo_t* dsda_NewSFX(int* index) {

--- a/prboom2/src/dsda/sfx.c
+++ b/prboom2/src/dsda/sfx.c
@@ -74,6 +74,20 @@ static void dsda_EnsureCapacity(int limit) {
   }
 }
 
+int dsda_TranslateDehSFXIndex(int index) {
+  if (index > sfx_None)
+    return index + (BASE_NUMSFX - 1);
+    
+  return sfx_None;
+}
+
+static int dsda_UnTranslateDehSFXIndex(int index) {
+  if (index >= BASE_NUMSFX)
+    return index - (BASE_NUMSFX - 1);
+
+  return index;
+}
+
 int dsda_GetDehSFXIndex(const char* key, size_t length) {
   int i;
 
@@ -98,7 +112,7 @@ int dsda_GetOriginalSFXIndex(const char* key) {
 
   for (i = 1; deh_soundnames[i]; ++i)
     if (!strncasecmp(deh_soundnames[i], key, 6))
-      return i;
+      return dsda_UnTranslateDehSFXIndex(i);
 
   // is it a number?
   for (c = key; *c; c++)
@@ -106,7 +120,7 @@ int dsda_GetOriginalSFXIndex(const char* key) {
       return -1;
 
   i = atoi(key);
-  dsda_EnsureCapacity(i);
+  dsda_EnsureCapacity(dsda_TranslateDehSFXIndex(i));
 
   return i;
 }
@@ -121,7 +135,7 @@ static sfxinfo_t* dsda_SFXAtIndex(int index) {
 }
 
 sfxinfo_t* dsda_GetDehSFX(int index) {
-  return dsda_SFXAtIndex(index);
+  return dsda_SFXAtIndex(dsda_TranslateDehSFXIndex(index));
 }
 
 sfxinfo_t* dsda_NewSFX(int* index) {

--- a/prboom2/src/dsda/sfx.c
+++ b/prboom2/src/dsda/sfx.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "doomdef.h"
 #include "doomtype.h"
 
 #include "dsda/configuration.h"
@@ -32,7 +31,6 @@ static int deh_soundnames_size;
 static char** deh_soundnames;
 static byte* sfx_state;
 static int highest_index;
-static int game_base_sfx_end;
 
 static void dsda_ResetSFX(int from, int to) {
   int i;
@@ -132,14 +130,13 @@ sfxinfo_t* dsda_NewSFX(int* index) {
   return dsda_SFXAtIndex(*index);
 }
 
-void dsda_InitializeSFX(sfxinfo_t* source, int count, int base_sfx_end) {
+void dsda_InitializeSFX(sfxinfo_t* source, int count) {
   int i;
   extern int raven;
 
   num_sfx = count;
   highest_index = count - 1;
   deh_soundnames_size = num_sfx + 1;
-  game_base_sfx_end = base_sfx_end;
 
   S_sfx = source;
 
@@ -155,47 +152,6 @@ void dsda_InitializeSFX(sfxinfo_t* source, int count, int base_sfx_end) {
   deh_soundnames[num_sfx] = NULL;
 
   sfx_state = calloc(num_sfx, sizeof(*sfx_state));
-}
-
-void dsda_AppendPortSFX(void) {
-  int i;
-  extern dboolean heretic;
-  extern dboolean hexen;
-
-  dsda_PrepAllocation();
-  dsda_EnsureCapacity(game_base_sfx_end + NUM_PORT_SFX - 1);
-
-  for (i = 1; i < NUM_PORT_SFX; ++i) {
-    sfx_port_info_t *port_sfx = &port_S_sfx[i];
-    sfxinfo_t *sfx = &S_sfx[game_base_sfx_end + i];
-
-    // Doom name is fallback if heretic/hexen are NULL
-    const char *name = port_sfx->doom_name;
-
-    if (heretic && port_sfx->heretic_name)
-      name = port_sfx->heretic_name;
-    else if (hexen && port_sfx->hexen_name)
-      name = port_sfx->hexen_name;
-
-    sfx->name = name;
-    sfx->priority = port_sfx->priority;
-    sfx->link = port_sfx->link;
-    sfx->pitch = port_sfx->pitch;
-    sfx->data = port_sfx->data;
-    sfx->lumpnum = port_sfx->lumpnum;
-    sfx->numchannels = port_sfx->numchannels;
-    sfx->tagname = port_sfx->tagname;
-    sfx->parallel_tic = port_sfx->parallel_tic;
-    sfx->parallel_count = port_sfx->parallel_count;
-  }
-
-  if (highest_index < game_base_sfx_end + NUM_PORT_SFX - 1)
-    highest_index = game_base_sfx_end + NUM_PORT_SFX - 1;
-}
-
-int dsda_PortSFXIndex(int port_sfx_id)
-{
-  return game_base_sfx_end + port_sfx_id;
 }
 
 void dsda_FreeDehSFX(void) {

--- a/prboom2/src/dsda/sfx.h
+++ b/prboom2/src/dsda/sfx.h
@@ -25,6 +25,7 @@ int dsda_GetOriginalSFXIndex(const char* key);
 sfxinfo_t* dsda_GetDehSFX(int index);
 sfxinfo_t* dsda_NewSFX(int* index);
 void dsda_InitializeSFX(sfxinfo_t* source, int count);
+int dsda_TranslateDehSFXIndex(int index);
 void dsda_FreeDehSFX(void);
 dboolean dsda_BlockSFX(sfxinfo_t *sfx);
 

--- a/prboom2/src/dsda/sfx.h
+++ b/prboom2/src/dsda/sfx.h
@@ -24,9 +24,7 @@ int dsda_GetDehSFXIndex(const char* key, size_t length);
 int dsda_GetOriginalSFXIndex(const char* key);
 sfxinfo_t* dsda_GetDehSFX(int index);
 sfxinfo_t* dsda_NewSFX(int* index);
-void dsda_InitializeSFX(sfxinfo_t* source, int count, int game_base_sfx_end);
-void dsda_AppendPortSFX(void);
-int dsda_PortSFXIndex(int port_sfx_id);
+void dsda_InitializeSFX(sfxinfo_t* source, int count);
 void dsda_FreeDehSFX(void);
 dboolean dsda_BlockSFX(sfxinfo_t *sfx);
 

--- a/prboom2/src/heretic/in_lude.c
+++ b/prboom2/src/heretic/in_lude.c
@@ -445,13 +445,13 @@ void IN_Ticker(void)
         {
             interstate = 2;
             skipintermission = false;
-            S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+            S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
             return;
         }
         interstate = 3;
         cnt = 10;
         skipintermission = false;
-        S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+        S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
     }
 }
 
@@ -520,7 +520,7 @@ void IN_Drawer(void)
 
     if (oldinterstate != 2 && interstate == 2)
     {
-        S_StartOptionalSound(sfx_intnex, heretic_sfx_pstop, false);
+        S_StartOptionalSound(g_sfx_intnex, heretic_sfx_pstop, false);
     }
     oldinterstate = interstate;
     switch (interstate)
@@ -698,7 +698,7 @@ void IN_DrawSingleStats(void)
     }
     if (sounds < 1 && intertime >= 30)
     {
-        S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+        S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
         sounds++;
     }
     IN_DrawNumber(players[consoleplayer].killcount, 200, 65 - yoffset, 3);
@@ -710,7 +710,7 @@ void IN_DrawSingleStats(void)
     }
     if (sounds < 2 && intertime >= 60)
     {
-        S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+        S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
         sounds++;
     }
     IN_DrawNumber(players[consoleplayer].itemcount, 200, 90 - yoffset, 3);
@@ -722,7 +722,7 @@ void IN_DrawSingleStats(void)
     }
     if (sounds < 3 && intertime >= 90)
     {
-        S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+        S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
         sounds++;
     }
     IN_DrawNumber(players[consoleplayer].secretcount, 200, 115 - yoffset, 3);
@@ -734,7 +734,7 @@ void IN_DrawSingleStats(void)
     }
     if (sounds < 4 && intertime >= 150)
     {
-        S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+        S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
         sounds++;
     }
 
@@ -803,7 +803,7 @@ void IN_DrawCoopStats(void)
             }
             else if (intertime >= 40 && sounds < 1)
             {
-                S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+                S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
                 sounds++;
             }
             IN_DrawNumber(killPercent[i], 85, ypos + 10, 3);
@@ -865,12 +865,12 @@ void IN_DrawDMStats(void)
     }
     if (intertime >= 20 && sounds < 1)
     {
-        S_StartOptionalSound(sfx_inttot, heretic_sfx_dorcls, false);
+        S_StartOptionalSound(g_sfx_inttot, heretic_sfx_dorcls, false);
         sounds++;
     }
     if (intertime >= 100 && slaughterboy && sounds < 2)
     {
-        S_StartOptionalSound(sfx_intdms, heretic_sfx_wpnup, false);
+        S_StartOptionalSound(g_sfx_intdms, heretic_sfx_wpnup, false);
         sounds++;
     }
     for (i = 0; i < g_maxplayers; i++)

--- a/prboom2/src/heretic/sounds.c
+++ b/prboom2/src/heretic/sounds.c
@@ -83,6 +83,23 @@ musicinfo_t heretic_S_music[] = {
 sfxinfo_t heretic_S_sfx[] = {
     { "", 0, 0, -1, 0, 0, 0, "" },
 
+    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
+
     // Heretic sounds
     { "gldhit", 32, 0, -1, 0, 0, 2, "" },
     { "gntful", 32, 0, -1, 0, 0, -1, "" },

--- a/prboom2/src/heretic/sounds.c
+++ b/prboom2/src/heretic/sounds.c
@@ -83,7 +83,8 @@ musicinfo_t heretic_S_music[] = {
 sfxinfo_t heretic_S_sfx[] = {
     { "", 0, 0, -1, 0, 0, 0, "" },
 
-    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
+    // DSDA
+    { "secret", 100, 0, -1, 0, 0, 1, "" }, // match heretic_sfx_chat
 
     // Optional menu/intermission sounds
     { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },

--- a/prboom2/src/heretic/sounds.c
+++ b/prboom2/src/heretic/sounds.c
@@ -83,24 +83,6 @@ musicinfo_t heretic_S_music[] = {
 sfxinfo_t heretic_S_sfx[] = {
     { "", 0, 0, -1, 0, 0, 0, "" },
 
-    // DSDA
-    { "secret", 100, 0, -1, 0, 0, 1, "" }, // match heretic_sfx_chat
-
-    // Optional menu/intermission sounds
-    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
-
     // Heretic sounds
     { "gldhit", 32, 0, -1, 0, 0, 2, "" },
     { "gntful", 32, 0, -1, 0, 0, -1, "" },
@@ -246,4 +228,22 @@ sfxinfo_t heretic_S_sfx[] = {
     { "amb9", 1, 0, -1, 0, 0, 1, "" },
     { "amb10", 1, 0, -1, 0, 0, 1, "" },
     { "amb11", 1, 0, -1, 0, 0, 0, "" },
+
+    // DSDA
+    { "secret", 100, 0, -1, 0, 0, 1, "" }, // match heretic_sfx_chat
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
 };

--- a/prboom2/src/hexen/sounds.c
+++ b/prboom2/src/hexen/sounds.c
@@ -29,24 +29,6 @@ musicinfo_t hexen_S_music[HEXEN_NUMMUSIC] = {
 sfxinfo_t hexen_S_sfx[] = {
     { "", 0, 0, 0, 0, 0, 0, "" },
 
-    // DSDA
-    { "secret", 512, 0, 1, 0, 0, 2, "" }, // match hexen_sfx_chat
-
-    // Optional menu/intermission sounds
-    { "dsmnuopn", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnucls", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnuact", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnubak", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnumov", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnusli", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnusel", 60, 0, 1, 0, 0, 1, "" },
-    { "dsmnuerr", 60, 0, 1, 0, 0, 1, "" },
-    { "dsinttic", 60, 0, 1, 0, 0, 1, "" },
-    { "dsinttot", 60, 0, 1, 0, 0, 1, "" },
-    { "dsintnex", 60, 0, 1, 0, 0, 1, "" },
-    { "dsintnet", 60, 0, 1, 0, 0, 1, "" },
-    { "dsintdms", 60, 0, 1, 0, 0, 1, "" },
-
     // Hexen sounds
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterNormalDeath" },
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterCrazyDeath" },
@@ -292,4 +274,22 @@ sfxinfo_t hexen_S_sfx[] = {
     { "", 32, 0, 1, 0, 0, 2, "Fireball" },
     { "", 30, 0, 1, 0, 0, 2, "PuppyBeat" },
     { "", 32, 0, 1, 0, 0, 4, "MysticIncant" },
+
+    // DSDA
+    { "secret", 512, 0, 1, 0, 0, 2, "" }, // match hexen_sfx_chat
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, 1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, 1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, 1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, 1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, 1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, 1, 0, 0, 1, "" },
 };

--- a/prboom2/src/hexen/sounds.c
+++ b/prboom2/src/hexen/sounds.c
@@ -29,22 +29,23 @@ musicinfo_t hexen_S_music[HEXEN_NUMMUSIC] = {
 sfxinfo_t hexen_S_sfx[] = {
     { "", 0, 0, 0, 0, 0, 0, "" },
 
-    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
+    // DSDA
+    { "secret", 512, 0, 1, 0, 0, 2, "" }, // match hexen_sfx_chat
 
     // Optional menu/intermission sounds
-    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
-    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuopn", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, 1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, 1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, 1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, 1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, 1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, 1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, 1, 0, 0, 1, "" },
 
     // Hexen sounds
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterNormalDeath" },

--- a/prboom2/src/hexen/sounds.c
+++ b/prboom2/src/hexen/sounds.c
@@ -29,6 +29,23 @@ musicinfo_t hexen_S_music[HEXEN_NUMMUSIC] = {
 sfxinfo_t hexen_S_sfx[] = {
     { "", 0, 0, 0, 0, 0, 0, "" },
 
+    { "dssecret", 60, 0, -1, 0, 0, 1, "" },
+
+    // Optional menu/intermission sounds
+    { "dsmnuopn", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnucls", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuact", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnubak", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnumov", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusli", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnusel", 60, 0, -1, 0, 0, 1, "" },
+    { "dsmnuerr", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttic", 60, 0, -1, 0, 0, 1, "" },
+    { "dsinttot", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnex", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintnet", 60, 0, -1, 0, 0, 1, "" },
+    { "dsintdms", 60, 0, -1, 0, 0, 1, "" },
+
     // Hexen sounds
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterNormalDeath" },
     { "", 256, 0, 1, 0, 0, 2, "PlayerFighterCrazyDeath" },

--- a/prboom2/src/m_menu.c
+++ b/prboom2/src/m_menu.c
@@ -4269,7 +4269,7 @@ static void M_SelectDone(setup_menu_t* ptr)
 {
   ptr->m_flags &= ~S_SELECT;
   ptr->m_flags |= S_HILITE;
-  S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+  S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
   setup_select = false;
   colorbox_active = false;
 }
@@ -4708,7 +4708,7 @@ static void M_HandleToggles(void)
         }
         else
         {
-          S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, true);
+          S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, true);
         }
       }
     }
@@ -4909,7 +4909,7 @@ static dboolean M_AutoResponder(int ch, int action, event_t* ev)
     {
       if (++color_palette_y == 16)
         color_palette_y = 0;
-      S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+      S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
       return true;
     }
 
@@ -4917,7 +4917,7 @@ static dboolean M_AutoResponder(int ch, int action, event_t* ev)
     {
       if (--color_palette_y < 0)
         color_palette_y = 15;
-      S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+      S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
       return true;
     }
 
@@ -4925,7 +4925,7 @@ static dboolean M_AutoResponder(int ch, int action, event_t* ev)
     {
       if (--color_palette_x < 0)
         color_palette_x = 15;
-      S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+      S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
       return true;
     }
 
@@ -4933,7 +4933,7 @@ static dboolean M_AutoResponder(int ch, int action, event_t* ev)
     {
       if (++color_palette_x == 16)
         color_palette_x = 0;
-      S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+      S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
       return true;
     }
 
@@ -5042,7 +5042,7 @@ static dboolean M_LevelTableResponder(int ch, int action, event_t* ev)
 
     M_LeaveSetupMenu();
     M_ClearMenus();
-    S_StartOptionalSound(sfx_mnucls, g_sfx_swtchx, false);
+    S_StartOptionalSound(g_sfx_mnucls, g_sfx_swtchx, false);
 
     return true;
   }
@@ -5125,7 +5125,7 @@ static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
             value = 0;
           if (old_value != value)
           {
-            S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+            S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
             strncpy(entry_string_index, ptr1->selectstrings[value], ENTRY_STRING_BFR_SIZE - 1);
           }
         }
@@ -5138,7 +5138,7 @@ static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
           } while (value > 0 && ptr1->selectstrings && ptr1->selectstrings[value][0] == '~');
 
           if (value >= 0 && choice_value != value) {
-            S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+            S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
             choice_value = value;
           }
         }
@@ -5154,7 +5154,7 @@ static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
             value = old_value;
           if (old_value != value)
           {
-            S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+            S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
             strncpy(entry_string_index, ptr1->selectstrings[value], ENTRY_STRING_BFR_SIZE - 1);
           }
         }
@@ -5167,7 +5167,7 @@ static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
           } while (ptr1->selectstrings && ptr1->selectstrings[value] && ptr1->selectstrings[value][0] == '~');
 
           if (ptr1->selectstrings[value] && choice_value != value) {
-            S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+            S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
             choice_value = value;
           }
         }
@@ -5191,13 +5191,13 @@ static dboolean M_SetupCommonSelectResponder(int ch, int action, event_t* ev)
       if (action == MENU_LEFT) {
         if (dsda_IntConfig(ptr1->config_id) > 0) {
           dsda_DecrementIntConfig(ptr1->config_id, true);
-          S_StartOptionalSound(sfx_mnusli, sfx_stnmov, true);
+          S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, true);
         }
       }
       else if (action == MENU_RIGHT) {
         if (dsda_IntConfig(ptr1->config_id) < 15) {
           dsda_IncrementIntConfig(ptr1->config_id, true);
-          S_StartOptionalSound(sfx_mnusli, sfx_stnmov, true);
+          S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, true);
         }
       }
       else if (action == MENU_ENTER) {
@@ -5262,12 +5262,12 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
     {
       if (ptr1->m_flags & S_NOCLEAR)
       {
-        S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, true);
+        S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, true);
       }
       else
       {
         dsda_InputReset(ptr1->input);
-        S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+        S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
       }
     }
 
@@ -5325,7 +5325,7 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
 
     ptr1->m_flags |= S_SELECT;
     setup_select = true;
-    S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+    S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
     return true;
   }
 
@@ -5339,10 +5339,10 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
       {
         M_ChangeMenu(currentMenu->prevMenu, mnact_nochange);
         itemOn = currentMenu->lastOn;
-        S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+        S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
       }
     ptr1->m_flags &= ~(S_HILITE|S_SELECT);// phares 4/19/98
-    S_StartOptionalSound(sfx_mnucls, g_sfx_swtchx, true);
+    S_StartOptionalSound(g_sfx_mnucls, g_sfx_swtchx, true);
     return true;
   }
 
@@ -5364,7 +5364,7 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
         ptr1->m_flags &= ~S_HILITE;
         M_SetSetupMenuItemOn(set_menu_itemon);
         M_UpdateSetupMenu(ptr2->menu);
-        S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+        S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
         previous_page = current_page;
         current_page--;
         return true;
@@ -5384,7 +5384,7 @@ static dboolean M_SetupNavigationResponder(int ch, int action, event_t* ev)
         ptr1->m_flags &= ~S_HILITE;
         M_SetSetupMenuItemOn(set_menu_itemon);
         M_UpdateSetupMenu(ptr2->menu);
-        S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+        S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
         previous_page = current_page;
         current_page++;
         return true;
@@ -5443,14 +5443,14 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     M_ChangeMenu(F1_menu, mnact_nochange);
 
     itemOn = 0;
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     return true;
   }
 
   if (dsda_InputActivated(dsda_input_savegame))
   {
     M_StartControlPanel();
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_SaveGame(0);
     return true;
   }
@@ -5458,7 +5458,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
   if (dsda_InputActivated(dsda_input_loadgame))
   {
     M_StartControlPanel();
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_LoadGame(0);
     return true;
   }
@@ -5466,7 +5466,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
   if (dsda_InputActivated(dsda_input_level_table))
   {
     M_StartControlPanel();
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_LevelTable(0);
     return true;
   }
@@ -5476,27 +5476,27 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     M_StartControlPanel ();
     M_ChangeMenu(&SoundDef, mnact_nochange);
     itemOn = sfx_vol;
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     return true;
   }
 
   if (dsda_InputActivated(dsda_input_quicksave))
   {
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_QuickSave();
     return true;
   }
 
   if (dsda_InputActivated(dsda_input_endgame))
   {
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_EndGame(0);
     return true;
   }
 
   if (dsda_InputActivated(dsda_input_quickload))
   {
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_QuickLoad();
     return true;
   }
@@ -5504,7 +5504,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
   if (dsda_InputActivated(dsda_input_quit))
   {
     if (!dsda_SkipQuitPrompt())
-      S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+      S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     M_QuitDOOM(0);
     return true;
   }
@@ -5526,7 +5526,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
   {
     int value = dsda_CycleConfig(dsda_config_input_profile, true);
     doom_printf("Input Profile %d", value);
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     return true;
   }
 
@@ -5534,7 +5534,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
   {
     dsda_CyclePlayPal();
     doom_printf("Palette %s", dsda_PlayPalData()->lump_name);
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     return true;
   }
 
@@ -5572,14 +5572,14 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
        dsda_InputActivated(dsda_input_fire) || dsda_InputActivated(dsda_input_use) || dsda_InputActivated(dsda_input_menu_enter)))) // phares
   {
     M_StartControlPanel();
-    S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+    S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     return true;
   }
 
   if (dsda_InputActivated(dsda_input_console))
   {
     if (dsda_OpenConsole())
-      S_StartOptionalSound(sfx_mnuopn, g_sfx_swtchn, true);
+      S_StartOptionalSound(g_sfx_mnuopn, g_sfx_swtchn, true);
     return true;
   }
 
@@ -5599,7 +5599,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     if (automap_full)
       return false;
     M_SizeDisplay(0);
-    S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, true);
+    S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, true);
     return true;
   }
 
@@ -5608,7 +5608,7 @@ static dboolean M_InactiveMenuResponder(int ch, int action, event_t* ev)
     if (automap_full)
       return false;
     M_SizeDisplay(1);
-    S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, true);
+    S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, true);
     return true;
   }
 
@@ -5748,7 +5748,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
         itemOn = 0;
       else
         itemOn++;
-      S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+      S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
     }
     while(currentMenu->menuitems[itemOn].status == -1);
     return true;
@@ -5762,7 +5762,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
         itemOn = currentMenu->numitems - 1;
       else
         itemOn--;
-      S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+      S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
     }
     while(currentMenu->menuitems[itemOn].status == -1);
     return true;
@@ -5773,7 +5773,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
     if (currentMenu->menuitems[itemOn].routine &&
         currentMenu->menuitems[itemOn].status == 2)
     {
-      S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, false);
+      S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, false);
       currentMenu->menuitems[itemOn].routine(0);
     }
     return true;
@@ -5784,7 +5784,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
     if (currentMenu->menuitems[itemOn].routine &&
         currentMenu->menuitems[itemOn].status == 2)
     {
-      S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, false);
+      S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, false);
       currentMenu->menuitems[itemOn].routine(1);
     }
     return true;
@@ -5799,12 +5799,12 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
       if (currentMenu->menuitems[itemOn].status == 2)
       {
         currentMenu->menuitems[itemOn].routine(1);   // right arrow
-        S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, false);
+        S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, false);
       }
       else
       {
         currentMenu->menuitems[itemOn].routine(itemOn);
-        S_StartOptionalSound(sfx_mnuact, g_sfx_pistol, true);
+        S_StartOptionalSound(g_sfx_mnuact, g_sfx_pistol, true);
       }
     }
     //jff 3/24/98 remember last skill selected
@@ -5816,7 +5816,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
   {
     currentMenu->lastOn = itemOn;
     M_ClearMenus ();
-    S_StartOptionalSound(sfx_mnubak, g_sfx_swtchx, true);
+    S_StartOptionalSound(g_sfx_mnubak, g_sfx_swtchx, true);
     return true;
   }
 
@@ -5843,12 +5843,12 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
       else
         M_ChangeMenu(currentMenu->prevMenu, mnact_nochange);
       itemOn = currentMenu->lastOn;
-      S_StartOptionalSound(sfx_mnubak, g_sfx_swtchn, true);
+      S_StartOptionalSound(g_sfx_mnubak, g_sfx_swtchn, true);
     }
     else
     {
       M_ClearMenus();
-      S_StartOptionalSound(sfx_mnubak, g_sfx_swtchx, true);
+      S_StartOptionalSound(g_sfx_mnubak, g_sfx_swtchx, true);
     }
     return true;
   }
@@ -5860,7 +5860,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
       if (ch && currentMenu->menuitems[i].alphaKey == ch)
       {
         itemOn = i;
-        S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+        S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
         return true;
       }
 
@@ -5868,7 +5868,7 @@ static dboolean M_MainNavigationResponder(int ch, int action, event_t* ev)
       if (ch && currentMenu->menuitems[i].alphaKey == ch)
       {
         itemOn = i;
-        S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+        S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
         return true;
       }
   }
@@ -5902,11 +5902,11 @@ static dboolean M_SaveResponder(int ch, int action, event_t* ev)
     {
       case confirmation_yes:
         M_DeleteSaveGame(itemOn + current_page * g_menu_save_page_size);
-        S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+        S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
         delete_verify = false;
         break;
       case confirmation_no:
-        S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+        S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
         delete_verify = false;
         break;
       case confirmation_null:
@@ -5980,9 +5980,9 @@ static dboolean M_SaveResponder(int ch, int action, event_t* ev)
         currentMenu->menuitems[itemOn].routine(itemOn);
 
         if (currentMenu == &SaveDef && current_page == 0)
-        S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, true);
+        S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, true);
         else
-          S_StartOptionalSound(sfx_mnuact, g_sfx_pistol, true);
+          S_StartOptionalSound(g_sfx_mnuact, g_sfx_pistol, true);
       }
 
       return true;
@@ -5995,7 +5995,7 @@ static dboolean M_SaveResponder(int ch, int action, event_t* ev)
 
     if (diff)
     {
-      S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+      S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
 
       current_page += diff;
       if (current_page < 0)
@@ -6011,14 +6011,14 @@ static dboolean M_SaveResponder(int ch, int action, event_t* ev)
   {
     if (LoadMenue[itemOn].status)
     {
-      S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+      S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
       currentMenu->lastOn = itemOn;
       delete_verify = true;
       return true;
     }
     else
     {
-      S_StartOptionalSound(sfx_mnuerr, g_sfx_oof, true);
+      S_StartOptionalSound(g_sfx_mnuerr, g_sfx_oof, true);
     }
   }
 
@@ -6042,7 +6042,7 @@ static dboolean M_MessageResponder(int ch, int action, event_t* ev)
     messageRoutine(confirmation);
 
   M_ChangeMenu(NULL, mnact_inactive);
-  S_StartOptionalSound(sfx_mnucls, g_sfx_swtchx, true);
+  S_StartOptionalSound(g_sfx_mnucls, g_sfx_swtchx, true);
   return true;
 }
 
@@ -6468,7 +6468,7 @@ static dboolean M_MouseUpdateMainHover(void)
   {
     menu_mouse_hover_main = index;
     itemOn = index;
-    S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+    S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
   }
 
   return true;
@@ -6537,7 +6537,7 @@ static dboolean M_MouseSetSoundSlider(int index)
     else if (index == music_vol && dsda_IntConfig(dsda_config_mute_music))
       dsda_ToggleConfig(dsda_config_mute_music, true);
 
-    S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, false);
+    S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, false);
   }
 
   itemOn = index;
@@ -6880,7 +6880,7 @@ static dboolean M_MouseUpdateTabHover(void)
   if (menu_mouse_hover_tab != target_page)
   {
     menu_mouse_hover_tab = target_page;
-    S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+    S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
   }
 
   return true;
@@ -6905,7 +6905,7 @@ static dboolean M_MouseSwitchSetupPage(setup_menu_t **pages, int target_page)
   setup_select = false;
   setup_gather = false;
   colorbox_active = false;
-  S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+  S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
 
   return true;
 }
@@ -6921,7 +6921,7 @@ static dboolean M_MouseSwitchSavePage(int target_page)
   M_MouseClearTabHover();
   current_page = target_page;
   M_ReadSaveStrings();
-  S_StartOptionalSound(sfx_mnumov, g_sfx_menu, true);
+  S_StartOptionalSound(g_sfx_mnumov, g_sfx_menu, true);
 
   return true;
 }
@@ -6962,7 +6962,7 @@ static void M_MouseSelectSetupItem(int index)
   setup_select = false;
   setup_gather = false;
   colorbox_active = false;
-  S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+  S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
 }
 
 static void M_MouseUpdateSetupHover(void)
@@ -7011,7 +7011,7 @@ static dboolean M_MouseSetSetupThermo(int index)
   if (dsda_IntConfig(item->config_id) != value)
   {
     dsda_UpdateIntConfig(item->config_id, value, true);
-    S_StartOptionalSound(sfx_mnusli, g_sfx_stnmov, false);
+    S_StartOptionalSound(g_sfx_mnusli, g_sfx_stnmov, false);
   }
 
   return true;
@@ -7068,7 +7068,7 @@ static dboolean M_MouseCycleSetupChoice(setup_menu_t *item)
   }
 
   if (next != current)
-    S_StartOptionalSound(sfx_mnusel, g_sfx_itemup, false);
+    S_StartOptionalSound(g_sfx_mnusel, g_sfx_itemup, false);
 
   return true;
 }

--- a/prboom2/src/p_spec.c
+++ b/prboom2/src/p_spec.c
@@ -1466,8 +1466,8 @@ void P_PlayerCollectSecret(player_t *player)
   {
     int sfx_id = heretic ? heretic_sfx_chat : hexen ? hexen_sfx_chat : sfx_itmbk;
 
-    if (I_GetSfxLumpNum(&S_sfx[sfx_secret]) != -1)
-      sfx_id = sfx_secret;
+    if (I_GetSfxLumpNum(&S_sfx[g_sfx_secret]) != -1)
+      sfx_id = g_sfx_secret;
 
     SetCustomMessage(player - players, s_HUSTR_SECRETFOUND, 2 * TICRATE, sfx_id);
   }

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -1204,7 +1204,10 @@ static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, 
   params.priority = sfx->priority;
   params.priority *= (10 - (dist / dist_adjust));
 
-  params.sfx_class = sfx_class_none;
+  if (sound_id == sfx_secret)
+    params.sfx_class = sfx_class_secret;
+  else
+    params.sfx_class = sfx_class_none;
 
   cnum = Raven_S_getChannel(listener, origin, sfx, &params);
   if (cnum == channel_not_found)

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -333,7 +333,7 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume, dboolean impor
     return;
 
   // killough 4/25/98
-  if (sfx_id == sfx_secret)
+  if (sfx_id == g_sfx_secret)
     params.sfx_class = sfx_class_secret;
   else if (important || sfx_id & PICKUP_SOUND || sfx_id == sfx_oof ||
       (compatibility_level >= prboom_2_compatibility && sfx_id == sfx_noway))
@@ -1204,7 +1204,7 @@ static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, 
   params.priority = sfx->priority;
   params.priority *= (10 - (dist / dist_adjust));
 
-  if (sound_id == sfx_secret)
+  if (sound_id == g_sfx_secret)
     params.sfx_class = sfx_class_secret;
   else
     params.sfx_class = sfx_class_none;

--- a/prboom2/src/s_sound.c
+++ b/prboom2/src/s_sound.c
@@ -144,11 +144,6 @@ static mobj_t* GetSoundListener(void);
 static void Heretic_S_StopSound(void *_origin);
 static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, int loop_timeout);
 
-static dboolean S_IsSecretSound(int sfx_id)
-{
-  return sfx_id == sfx_secret;
-}
-
 void S_ResetSfxVolume(void)
 {
   snd_SfxVolume = dsda_IntConfig(dsda_config_sfx_volume);
@@ -338,7 +333,7 @@ void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume, dboolean impor
     return;
 
   // killough 4/25/98
-  if (S_IsSecretSound(sfx_id))
+  if (sfx_id == sfx_secret)
     params.sfx_class = sfx_class_secret;
   else if (important || sfx_id & PICKUP_SOUND || sfx_id == sfx_oof ||
       (compatibility_level >= prboom_2_compatibility && sfx_id == sfx_noway))
@@ -1209,7 +1204,7 @@ static void Raven_S_StartSoundAtVolume(void *_origin, int sound_id, int volume, 
   params.priority = sfx->priority;
   params.priority *= (10 - (dist / dist_adjust));
 
-  params.sfx_class = S_IsSecretSound(sound_id) ? sfx_class_secret : sfx_class_none;
+  params.sfx_class = sfx_class_none;
 
   cnum = Raven_S_getChannel(listener, origin, sfx, &params);
   if (cnum == channel_not_found)

--- a/prboom2/src/sounds.c
+++ b/prboom2/src/sounds.c
@@ -128,24 +128,6 @@ sfxinfo_t doom_S_sfx[] = {
   // S_sfx[0] needs to be a dummy for odd reasons.
   { "dsnone", 0, 0, -1, 0, 0, 0, "" },
 
-  // DSDA
-  { "dssecret", 60, 0, -1, 0, 0, 0, "" },
-
-  // Optional menu/intermission sounds
-  { "dsmnuopn", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnucls", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnuact", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnubak", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnumov", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnusli", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnusel", 60, 0, -1, 0, 0, 0, "" },
-  { "dsmnuerr", 60, 0, -1, 0, 0, 0, "" },
-  { "dsinttic", 60, 0, -1, 0, 0, 0, "" },
-  { "dsinttot", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintnex", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintnet", 60, 0, -1, 0, 0, 0, "" },
-  { "dsintdms", 60, 0, -1, 0, 0, 0, "" },
-
   // Doom sounds
   { "dspistol", 64, 0, -1, 0, 0, 0, "" },
   { "dsshotgn", 64, 0, -1, 0, 0, 0, "" },
@@ -262,6 +244,24 @@ sfxinfo_t doom_S_sfx[] = {
   { "dsdgact", 120, 0, -1, 0, 0, 0, "" },
   { "dsdgdth", 70, 0, -1, 0, 0, 0, "" },
   { "dsdgpain", 96, 0, -1, 0, 0, 0, "" },
+
+  // DSDA
+  { "dssecret", 60, 0, -1, 0, 0, 0, "" },
+
+  // Optional menu/intermission sounds
+  { "dsmnuopn", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnucls", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnuact", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnubak", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnumov", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnusli", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnusel", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnuerr", 60, 0, -1, 0, 0, 0, "" },
+  { "dsinttic", 60, 0, -1, 0, 0, 0, "" },
+  { "dsinttot", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintnex", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintnet", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintdms", 60, 0, -1, 0, 0, 0, "" },
 
   // Everything from here up to 500 is reserved for future use.
 

--- a/prboom2/src/sounds.c
+++ b/prboom2/src/sounds.c
@@ -128,6 +128,7 @@ sfxinfo_t doom_S_sfx[] = {
   // S_sfx[0] needs to be a dummy for odd reasons.
   { "dsnone", 0, 0, -1, 0, 0, 0, "" },
 
+  // DSDA
   { "dssecret", 60, 0, -1, 0, 0, 0, "" },
 
   // Optional menu/intermission sounds

--- a/prboom2/src/sounds.c
+++ b/prboom2/src/sounds.c
@@ -38,8 +38,6 @@
 #include "config.h"
 #endif
 
-#include <stddef.h>
-
 #include "doomtype.h"
 #include "sounds.h"
 
@@ -121,31 +119,6 @@ musicinfo_t doom_S_music[] = {
   { "musinfo", 0 }
 };
 
-//
-// Port specific / optional sfx
-//
-
-sfx_port_info_t port_S_sfx[] = {
-    { "dsnone", NULL, NULL, 0, 0, -1, 0, 0, 0, "" },
-
-    // DSDA
-    { "dssecret", "secret", "secret", 60, 0, -1, 0, 0, 0, "" }, // Secret
-
-    // Optional menu/intermission sounds
-    { "dsmnuopn", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnucls", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuact", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnubak", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnumov", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusli", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnusel", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsmnuerr", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttic", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsinttot", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnex", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsintnet", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-    { "dsintdms", NULL, NULL, 60, 0, -1, 0, 0, 1, "" },
-};
 
 //
 // Information about all the sfx
@@ -154,6 +127,23 @@ sfx_port_info_t port_S_sfx[] = {
 sfxinfo_t doom_S_sfx[] = {
   // S_sfx[0] needs to be a dummy for odd reasons.
   { "dsnone", 0, 0, -1, 0, 0, 0, "" },
+
+  { "dssecret", 60, 0, -1, 0, 0, 0, "" },
+
+  // Optional menu/intermission sounds
+  { "dsmnuopn", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnucls", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnuact", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnubak", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnumov", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnusli", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnusel", 60, 0, -1, 0, 0, 0, "" },
+  { "dsmnuerr", 60, 0, -1, 0, 0, 0, "" },
+  { "dsinttic", 60, 0, -1, 0, 0, 0, "" },
+  { "dsinttot", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintnex", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintnet", 60, 0, -1, 0, 0, 0, "" },
+  { "dsintdms", 60, 0, -1, 0, 0, 0, "" },
 
   // Doom sounds
   { "dspistol", 64, 0, -1, 0, 0, 0, "" },
@@ -798,5 +788,5 @@ sfxinfo_t doom_disambiguated_sfx[] = {
 
   DISAMBIGUATED_SFX(sfx_dgpain, "dog/pain"),
 
-  //DISAMBIGUATED_SFX(sfx_secret, "misc/secret"),
+  DISAMBIGUATED_SFX(sfx_secret, "misc/secret"),
 };

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -94,27 +94,6 @@ struct sfxinfo_struct {
   int parallel_count;
 };
 
-struct portsfxinfo_struct;
-
-typedef struct portsfxinfo_struct sfx_port_info_t;
-
-struct portsfxinfo_struct {
-  const char *doom_name; // up to 6-character name
-  const char *heretic_name; // 8-character name
-  const char *hexen_name;   // 8-character name
-
-  int priority;         // Sfx priority
-  sfxinfo_t *link;      // referenced sound if a link
-  int pitch;            // pitch if a link
-  void *data;           // sound data
-  int lumpnum;          // lump number of sfx
-  int numchannels;      // heretic - total number of channels a sound type may occupy
-  const char *tagname;  // hexen
-
-  int parallel_tic;
-  int parallel_count;
-};
-
 //
 // MusicInfo struct.
 //
@@ -284,60 +263,28 @@ typedef enum {
 } musicenum_t;
 
 //
-// Port specific / optional sfx
-//
-
-typedef enum {
-  port_sfx_None,
-
-  // DSDA
-  port_sfx_secret,
-
-  // Optional menu/intermission sounds
-  port_sfx_mnuopn, // swtchn
-  port_sfx_mnucls, // swtchx
-  port_sfx_mnuact, // pistol
-  port_sfx_mnubak,
-  port_sfx_mnumov, // pstop
-  port_sfx_mnusli, // stnmov
-  port_sfx_mnusel, // itemup
-  port_sfx_mnuerr, // oof
-  port_sfx_inttic, // pistol
-  port_sfx_inttot, // barex
-  port_sfx_intnex, // sgcock
-  port_sfx_intnet, // pldeth
-  port_sfx_intdms, // slop
-  NUM_PORT_SFX,
-} sfx_port_enum_t;
-
-int dsda_PortSFXIndex(int port_sfx_id);
-
-#define sfx_secret        (dsda_PortSFXIndex(port_sfx_secret))
-#define sfx_secret_subtle (dsda_PortSFXIndex(port_sfx_secret_subtle))
-#define sfx_idnut         (dsda_PortSFXIndex(port_sfx_idnut))
-#define sfx_gibdth        (dsda_PortSFXIndex(port_sfx_gibdth))
-
-#define sfx_mnuopn (dsda_PortSFXIndex(port_sfx_mnuopn))
-#define sfx_mnucls (dsda_PortSFXIndex(port_sfx_mnucls))
-#define sfx_mnuact (dsda_PortSFXIndex(port_sfx_mnuact))
-#define sfx_mnubak (dsda_PortSFXIndex(port_sfx_mnubak))
-#define sfx_mnumov (dsda_PortSFXIndex(port_sfx_mnumov))
-#define sfx_mnusli (dsda_PortSFXIndex(port_sfx_mnusli))
-#define sfx_mnusel (dsda_PortSFXIndex(port_sfx_mnusel))
-
-#define sfx_mnuerr (dsda_PortSFXIndex(port_sfx_mnuerr))
-#define sfx_inttic (dsda_PortSFXIndex(port_sfx_inttic))
-#define sfx_inttot (dsda_PortSFXIndex(port_sfx_inttot))
-#define sfx_intnex (dsda_PortSFXIndex(port_sfx_intnex))
-#define sfx_intnet (dsda_PortSFXIndex(port_sfx_intnet))
-#define sfx_intdms (dsda_PortSFXIndex(port_sfx_intdms))
-
-//
 // Identifiers for all sfx in game.
 //
 
 typedef enum {
   sfx_None,
+
+  sfx_secret,
+
+  // Optional menu/intermission sounds
+  sfx_mnuopn, // swtchn
+  sfx_mnucls, // swtchx
+  sfx_mnuact, // pistol
+  sfx_mnubak,
+  sfx_mnumov, // pstop
+  sfx_mnusli, // stnmov
+  sfx_mnusel, // itemup
+  sfx_mnuerr, // oof
+  sfx_inttic, // pistol
+  sfx_inttot, // barex
+  sfx_intnex, // sgcock
+  sfx_intnet, // pldeth
+  sfx_intdms, // slop
 
   BASE_NUMSFX,
 
@@ -456,8 +403,6 @@ typedef enum {
   sfx_dgact,
   sfx_dgdth,
   sfx_dgpain,
-
-  DOOM_BASESFX_END = sfx_dgpain,
 
   // Everything from here to 500 is reserved
 
@@ -810,9 +755,6 @@ typedef enum {
   heretic_sfx_amb9,
   heretic_sfx_amb10,
   heretic_sfx_amb11,
-
-  HERETIC_BASESFX_END = heretic_sfx_amb11,
-
   HERETIC_NUMSFX,
 
   // hexen
@@ -1060,9 +1002,6 @@ typedef enum {
   hexen_sfx_fireball,
   hexen_sfx_puppybeat,
   hexen_sfx_mysticincant,
-
-  HEXEN_BASESFX_END = hexen_sfx_mysticincant,
-
   HEXEN_NUMSFX
 } sfxenum_t;
 
@@ -1076,9 +1015,6 @@ extern musicinfo_t heretic_S_music[];
 
 extern sfxinfo_t doom_S_sfx[];
 extern musicinfo_t doom_S_music[];
-
-// DSDA sound effects
-extern sfx_port_info_t port_S_sfx[];
 
 extern sfxinfo_t* S_sfx;
 extern int num_sfx;

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -269,24 +269,6 @@ typedef enum {
 typedef enum {
   sfx_None,
 
-  // DSDA
-  sfx_secret,
-
-  // Optional menu/intermission sounds
-  sfx_mnuopn, // swtchn
-  sfx_mnucls, // swtchx
-  sfx_mnuact, // pistol
-  sfx_mnubak,
-  sfx_mnumov, // pstop
-  sfx_mnusli, // stnmov
-  sfx_mnusel, // itemup
-  sfx_mnuerr, // oof
-  sfx_inttic, // pistol
-  sfx_inttot, // barex
-  sfx_intnex, // sgcock
-  sfx_intnet, // pldeth
-  sfx_intdms, // slop
-
   BASE_NUMSFX,
 
   sfx_pistol = BASE_NUMSFX,
@@ -404,6 +386,24 @@ typedef enum {
   sfx_dgact,
   sfx_dgdth,
   sfx_dgpain,
+
+  // DSDA
+  sfx_secret,
+
+  // Optional menu/intermission sounds
+  sfx_mnuopn, // swtchn
+  sfx_mnucls, // swtchx
+  sfx_mnuact, // pistol
+  sfx_mnubak,
+  sfx_mnumov, // pstop
+  sfx_mnusli, // stnmov
+  sfx_mnusel, // itemup
+  sfx_mnuerr, // oof
+  sfx_inttic, // pistol
+  sfx_inttot, // barex
+  sfx_intnex, // sgcock
+  sfx_intnet, // pldeth
+  sfx_intdms, // slop
 
   // Everything from here to 500 is reserved
 
@@ -757,6 +757,24 @@ typedef enum {
   heretic_sfx_amb10,
   heretic_sfx_amb11,
 
+  // DSDA
+  heretic_sfx_secret,
+
+  // Optional menu/intermission sounds
+  heretic_sfx_mnuopn, // swtchn
+  heretic_sfx_mnucls, // swtchx
+  heretic_sfx_mnuact, // pistol
+  heretic_sfx_mnubak,
+  heretic_sfx_mnumov, // pstop
+  heretic_sfx_mnusli, // stnmov
+  heretic_sfx_mnusel, // itemup
+  heretic_sfx_mnuerr, // oof
+  heretic_sfx_inttic, // pistol
+  heretic_sfx_inttot, // barex
+  heretic_sfx_intnex, // sgcock
+  heretic_sfx_intnet, // pldeth
+  heretic_sfx_intdms, // slop
+
   HERETIC_NUMSFX,
 
   // hexen
@@ -1004,6 +1022,24 @@ typedef enum {
   hexen_sfx_fireball,
   hexen_sfx_puppybeat,
   hexen_sfx_mysticincant,
+
+  // DSDA
+  hexen_sfx_secret,
+
+  // Optional menu/intermission sounds
+  hexen_sfx_mnuopn, // swtchn
+  hexen_sfx_mnucls, // swtchx
+  hexen_sfx_mnuact, // pistol
+  hexen_sfx_mnubak,
+  hexen_sfx_mnumov, // pstop
+  hexen_sfx_mnusli, // stnmov
+  hexen_sfx_mnusel, // itemup
+  hexen_sfx_mnuerr, // oof
+  hexen_sfx_inttic, // pistol
+  hexen_sfx_inttot, // barex
+  hexen_sfx_intnex, // sgcock
+  hexen_sfx_intnet, // pldeth
+  hexen_sfx_intdms, // slop
 
   HEXEN_NUMSFX
 } sfxenum_t;

--- a/prboom2/src/sounds.h
+++ b/prboom2/src/sounds.h
@@ -269,6 +269,7 @@ typedef enum {
 typedef enum {
   sfx_None,
 
+  // DSDA
   sfx_secret,
 
   // Optional menu/intermission sounds
@@ -755,6 +756,7 @@ typedef enum {
   heretic_sfx_amb9,
   heretic_sfx_amb10,
   heretic_sfx_amb11,
+
   HERETIC_NUMSFX,
 
   // hexen
@@ -1002,6 +1004,7 @@ typedef enum {
   hexen_sfx_fireball,
   hexen_sfx_puppybeat,
   hexen_sfx_mysticincant,
+
   HEXEN_NUMSFX
 } sfxenum_t;
 

--- a/prboom2/src/wi_stuff.c
+++ b/prboom2/src/wi_stuff.c
@@ -1310,7 +1310,7 @@ void WI_updateDeathmatchStats(void)
       }
     }
 
-    S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+    S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
     dm_state = 4;  // we're done with all 4 (or all we have to do)
   }
 
@@ -1318,7 +1318,7 @@ void WI_updateDeathmatchStats(void)
   if (dm_state == 2)
   {
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false); // noise while counting
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false); // noise while counting
 
     stillticking = false;
 
@@ -1357,7 +1357,7 @@ void WI_updateDeathmatchStats(void)
 
     if (!stillticking)
     {
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       dm_state++;
     }
   }
@@ -1365,7 +1365,7 @@ void WI_updateDeathmatchStats(void)
   {
     if (acceleratestage)
     {
-      S_StartOptionalSound(sfx_intdms, sfx_slop, false);
+      S_StartOptionalSound(g_sfx_intdms, sfx_slop, false);
 
       if ( gamemode == commercial)
         WI_initNoState();
@@ -1555,14 +1555,14 @@ void WI_updateNetgameStats(void)
       if (dofrags)
         cnt_frags[i] = WI_fragSum(i);  // we had frags
     }
-    S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+    S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
     ng_state = 10;
   }
 
   if (ng_state == 2)
   {
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     stillticking = false;
 
@@ -1581,14 +1581,14 @@ void WI_updateNetgameStats(void)
 
     if (!stillticking)
     {
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       ng_state++;
     }
   }
   else if (ng_state == 4)
   {
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     stillticking = false;
 
@@ -1606,14 +1606,14 @@ void WI_updateNetgameStats(void)
 
     if (!stillticking)
     {
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       ng_state++;
     }
   }
   else if (ng_state == 6)
   {
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     stillticking = false;
 
@@ -1632,14 +1632,14 @@ void WI_updateNetgameStats(void)
 
     if (!stillticking)
     {
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       ng_state += 1 + 2*!dofrags;
     }
   }
   else if (ng_state == 8)
   {
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     stillticking = false;
 
@@ -1658,7 +1658,7 @@ void WI_updateNetgameStats(void)
 
     if (!stillticking)
     {
-      S_StartOptionalSound(sfx_intnet, sfx_pldeth, false);
+      S_StartOptionalSound(g_sfx_intnet, sfx_pldeth, false);
       ng_state++;
     }
   }
@@ -1666,7 +1666,7 @@ void WI_updateNetgameStats(void)
   {
     if (acceleratestage)
     {
-      S_StartOptionalSound(sfx_intnex, sfx_sgcock, false);
+      S_StartOptionalSound(g_sfx_intnex, sfx_sgcock, false);
       if ( gamemode == commercial )
         WI_initNoState();
       else
@@ -1809,7 +1809,7 @@ void WI_updateStats(void)
     cnt_total_time = wbs->totaltimes / TICRATE;
     cnt_time = plrs[me].stime / TICRATE;
     cnt_par = wbs->partime / TICRATE;
-    S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+    S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
     sp_state = 10;
   }
 
@@ -1818,12 +1818,12 @@ void WI_updateStats(void)
     cnt_kills[0] += 2;
 
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     if (cnt_kills[0] >= WI_killLimit(me))
     {
       cnt_kills[0] = WI_killPercent(me);
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       sp_state++;
     }
   }
@@ -1832,12 +1832,12 @@ void WI_updateStats(void)
     cnt_items[0] += 2;
 
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     if (cnt_items[0] >= WI_itemLimit(me))
     {
       cnt_items[0] = WI_itemPercent(me);
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       sp_state++;
     }
   }
@@ -1846,19 +1846,19 @@ void WI_updateStats(void)
     cnt_secret[0] += 2;
 
     if (!(bcnt&3))
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     if (cnt_secret[0] >= WI_secretLimit(me))
     {
       cnt_secret[0] = WI_secretPercent(me);
-      S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+      S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
       sp_state++;
     }
   }
   else if (sp_state == 8)
   {
     if (!(bcnt&3) && play_early_explosion) //e6y: do not play count sound after explosion sound
-      S_StartOptionalSound(sfx_inttic, sfx_pistol, false);
+      S_StartOptionalSound(g_sfx_inttic, sfx_pistol, false);
 
     cnt_time += 3;
 
@@ -1884,7 +1884,7 @@ void WI_updateStats(void)
         if (compatibility_level < lxdoom_1_compatibility)
           cnt_total_time = wbs->totaltimes / TICRATE;
 
-        S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+        S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
         play_early_explosion = false; // do not play it twice or more
       }
     }
@@ -1900,7 +1900,7 @@ void WI_updateStats(void)
           cnt_total_time = wbs->totaltimes / TICRATE;
 
         if (!modifiedgame) //e6y: do not play explosion sound if it was already played
-          S_StartOptionalSound(sfx_inttot, sfx_barexp, false);
+          S_StartOptionalSound(g_sfx_inttot, sfx_barexp, false);
         sp_state++;
       }
     }
@@ -1909,7 +1909,7 @@ void WI_updateStats(void)
   {
     if (acceleratestage)
     {
-      S_StartOptionalSound(sfx_intnex, sfx_sgcock, false);
+      S_StartOptionalSound(g_sfx_intnex, sfx_sgcock, false);
 
       if (gamemode == commercial)
         WI_initNoState();


### PR DESCRIPTION
Instead we are going to keep the internal sfx table shifted with the port sounds near the top... Then in dehacked, we will translate the dehacked values into our internal sfx table.

Also Heretic/Hexen use different sound values. I'm not sure what's correct to use for secret / optional sounds, but we need to pay attention, because they do NOT work the same as in Doom.

Take a look at the individual commit to see what I tweaked regarding that.