### PR TITLE
Add new properties to umapinfo

### DIFF
--- a/prboom2/src/dsda/configuration.c
+++ b/prboom2/src/dsda/configuration.c
@@ -23,6 +23,7 @@
 #include "d_deh.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include "dsda/mapinfo.h"
 #include "hu_stuff.h"
 #include "g_overflow.h"
 #include "gl_struct.h"
@@ -135,7 +136,6 @@ void deh_changeCompTranslucency(void);
 void dsda_InitGameControllerParameters(void);
 void dsda_InitExHud(void);
 void dsda_UpdateFreeText(void);
-void dsda_ResetAirControl(void);
 void dsda_AlterGameFlags(void);
 void dsda_RefreshPistolStart(void);
 void dsda_RefreshAlwaysPistolStart(void);

--- a/prboom2/src/dsda/excmd.c
+++ b/prboom2/src/dsda/excmd.c
@@ -46,8 +46,6 @@ dboolean dsda_ExCmdDemo(void) {
 }
 
 void dsda_EnableCasualExCmdFeatures(void) {
-  void dsda_ResetAirControl(void);
-
   casual_excmd_features = true;
 
   dsda_ResetAirControl();
@@ -59,14 +57,14 @@ dboolean dsda_AllowCasualExCmdFeatures(void) {
 
 dboolean dsda_AllowJumping(void) {
   return (allow_incompatibility && dsda_IntConfig(dsda_config_allow_jumping))
-         // TODO: possible "allow jumping" mapinfo flag
+         || dsda_MapAllowsJumping()
          || dsda_AllowCasualExCmdFeatures();
 }
 
 dboolean dsda_FreeAim(void) {
   return ((allow_incompatibility || dsda_AllowCasualExCmdFeatures())
-         // TODO: possible "allow freelook" mapinfo flag
-         && dsda_IntConfig(dsda_config_freelook));
+         && dsda_IntConfig(dsda_config_freelook))
+         || dsda_MapAllowsFreeaim();
 }
 
 void dsda_ReadExCmd(ticcmd_t* cmd, const byte** p) {

--- a/prboom2/src/dsda/mapinfo.c
+++ b/prboom2/src/dsda/mapinfo.c
@@ -179,6 +179,50 @@ void dsda_ResetAirControl(void) {
   map_aircontrol = dsda_AirControl();
 }
 
+dboolean dsda_MapAllowsJumping(void)
+{
+  if (dsda_HexenMapAllowsJumping())
+    return true;
+  if (dsda_UMapAllowsJumping())
+    return true;
+  if (dsda_LegacyMapAllowsJumping())
+    return true;
+  return false;
+}
+
+dboolean dsda_MapAllowsFreeaim(void)
+{
+  if (dsda_HexenMapAllowsFreeAim())
+    return true;
+  if (dsda_UMapAllowsFreeAim())
+    return true;
+  if (dsda_LegacyMapAllowsFreeAim())
+    return true;
+  return false;
+}
+
+dboolean dsda_ExplodeIn3D(void)
+{
+  if (dsda_HexenExplodeIn3D())
+    return true;
+  if (dsda_UExplodeIn3D())
+    return true;
+  if (dsda_LegacyExplodeIn3D())
+    return true;
+  return false;
+}
+
+dboolean dsda_VerticalExplosionThrust(void)
+{
+  if (dsda_HexenVerticalExplosionThrust())
+    return true;
+  if (dsda_UVerticalExplosionThrust())
+    return true;
+  if (dsda_LegacyVerticalExplosionThrust())
+    return true;
+  return false;
+}
+
 void dsda_ResetLeaveData(void) {
   memset(&leave_data, 0, sizeof(leave_data));
 }

--- a/prboom2/src/dsda/mapinfo.h
+++ b/prboom2/src/dsda/mapinfo.h
@@ -40,6 +40,11 @@ void dsda_PrevMap(int* episode, int* map);
 void dsda_ShowNextLocBehaviour(int* behaviour);
 int dsda_SkipDrawShowNextLoc(void);
 void dsda_UpdateGameMap(int episode, int map);
+void dsda_ResetAirControl(void);
+dboolean dsda_MapAllowsJumping(void);
+dboolean dsda_MapAllowsFreeaim(void);
+dboolean dsda_ExplodeIn3D(void);
+dboolean dsda_VerticalExplosionThrust(void);
 void dsda_ResetLeaveData(void);
 void dsda_UpdateLeaveData(int map, int position, int flags, angle_t angle);
 dboolean dsda_FinaleShortcut(void);
@@ -74,5 +79,6 @@ int dsda_MapCluster(int map);
 short dsda_Sky1Texture(void);
 short dsda_Sky2Texture(void);
 void dsda_InitSky(void);
+dboolean dsda_RequireExCmd(void);
 
 #endif

--- a/prboom2/src/dsda/mapinfo/hexen.c
+++ b/prboom2/src/dsda/mapinfo/hexen.c
@@ -622,3 +622,23 @@ int dsda_HexenInitSky(void) {
 int dsda_HexenMapColorMap(int* colormap) {
   return false;
 }
+
+dboolean dsda_HexenMapAllowsJumping(void)
+{
+  return false;
+}
+
+dboolean dsda_HexenMapAllowsFreeAim(void)
+{
+  return false;
+}
+
+dboolean dsda_HexenExplodeIn3D(void)
+{
+  return false;
+}
+
+dboolean dsda_HexenVerticalExplosionThrust(void)
+{
+  return false;
+}

--- a/prboom2/src/dsda/mapinfo/hexen.h
+++ b/prboom2/src/dsda/mapinfo/hexen.h
@@ -64,5 +64,9 @@ int dsda_HexenGravity(fixed_t* gravity);
 int dsda_HexenAirControl(fixed_t* air_control);
 int dsda_HexenInitSky(void);
 int dsda_HexenMapColorMap(int* colormap);
+dboolean dsda_HexenMapAllowsJumping(void);
+dboolean dsda_HexenMapAllowsFreeAim(void);
+dboolean dsda_HexenExplodeIn3D(void);
+dboolean dsda_HexenVerticalExplosionThrust(void);
 
 #endif

--- a/prboom2/src/dsda/mapinfo/legacy.c
+++ b/prboom2/src/dsda/mapinfo/legacy.c
@@ -786,3 +786,23 @@ int dsda_LegacyMapColorMap(int* colormap) {
 
   return true;
 }
+
+dboolean dsda_LegacyMapAllowsJumping(void)
+{
+  return false;
+}
+
+dboolean dsda_LegacyMapAllowsFreeAim(void)
+{
+  return false;
+}
+
+dboolean dsda_LegacyExplodeIn3D(void)
+{
+  return false;
+}
+
+dboolean dsda_LegacyVerticalExplosionThrust(void)
+{
+  return false;
+}

--- a/prboom2/src/dsda/mapinfo/legacy.h
+++ b/prboom2/src/dsda/mapinfo/legacy.h
@@ -64,5 +64,9 @@ int dsda_LegacyGravity(fixed_t* gravity);
 int dsda_LegacyAirControl(fixed_t* air_control);
 int dsda_LegacyInitSky(void);
 int dsda_LegacyMapColorMap(int* colormap);
+dboolean dsda_LegacyMapAllowsJumping(void);
+dboolean dsda_LegacyMapAllowsFreeAim(void);
+dboolean dsda_LegacyExplodeIn3D(void);
+dboolean dsda_LegacyVerticalExplosionThrust(void);
 
 #endif

--- a/prboom2/src/dsda/mapinfo/u.c
+++ b/prboom2/src/dsda/mapinfo/u.c
@@ -21,10 +21,7 @@
 #include "lprintf.h"
 #include "p_enemy.h"
 #include "p_spec.h"
-#include "p_tick.h"
 #include "r_state.h"
-#include "s_sound.h"
-#include "sounds.h"
 #include "umapinfo.h"
 #include "v_video.h"
 #include "w_wad.h"
@@ -33,7 +30,6 @@
 #include "dsda/global.h"
 #include "dsda/map_format.h"
 #include "dsda/mapinfo.h"
-#include "dsda/preferences.h"
 
 #include "u.h"
 
@@ -342,6 +338,8 @@ void dsda_UFDrawer(void) {
 // `MapInfo_BossActionClear` means to do nothing.
 // positive values mean to check the list of boss actions and run all that apply.
 int dsda_UBossAction(mobj_t* mo) {
+  extern dboolean P_ExecuteZDoomLineSpecial(int special, int * args, line_t * line, int side, mobj_t * mo);
+
   int i;
   line_t junk;
 
@@ -371,11 +369,16 @@ int dsda_UBossAction(mobj_t* mo) {
     if (gamemapinfo->bossactions[i].type == mo->type) {
       junk = *lines;
       junk.special = (short) gamemapinfo->bossactions[i].special;
-      junk.special_args[0] = (short) gamemapinfo->bossactions[i].tag;
+      COLLAPSE_SPECIAL_ARGS(junk.special_args, gamemapinfo->bossactions[i].args);
 
-      // use special semantics for line activation to block problem types.
-      if (!P_UseSpecialLine(mo, &junk, 0, true))
-        map_format.cross_special_line(&junk, 0, mo, true);
+      if (gamemapinfo->bossactions[i].is_param) {
+        // explicitly defined from param actions
+        P_ExecuteZDoomLineSpecial(junk.special, junk.special_args, NULL, 0, mo);
+      } else {
+        // defined from classic actions
+        if (!P_UseSpecialLine(mo, &junk, 0, true))
+          map_format.cross_special_line(&junk, 0, mo, true);
+      }
     }
   }
 
@@ -620,4 +623,24 @@ int dsda_UInitSky(void) {
 
 int dsda_UMapColorMap(int* colormap) {
   return false;
+}
+
+dboolean dsda_UMapAllowsJumping(void)
+{
+  return gamemapinfo && (gamemapinfo->flags & MapInfo_Jumping);
+}
+
+dboolean dsda_UMapAllowsFreeAim(void)
+{
+  return gamemapinfo && (gamemapinfo->flags & MapInfo_FreeAim);
+}
+
+dboolean dsda_UExplodeIn3D(void)
+{
+  return gamemapinfo && (gamemapinfo->flags & MapInfo_EX_ExplodeIn3D);
+}
+
+dboolean dsda_UVerticalExplosionThrust(void)
+{
+  return gamemapinfo && (gamemapinfo->flags & MapInfo_EX_VerticalExplosionThrust);
 }

--- a/prboom2/src/dsda/mapinfo/u.h
+++ b/prboom2/src/dsda/mapinfo/u.h
@@ -20,7 +20,6 @@
 
 #include "p_mobj.h"
 
-#include "dsda/mapinfo.h"
 #include "dsda/utility.h"
 
 int dsda_UNameToMap(int* found, const char* name, int* episode, int* map);
@@ -66,5 +65,9 @@ int dsda_UGravity(fixed_t* gravity);
 int dsda_UAirControl(fixed_t* air_control);
 int dsda_UInitSky(void);
 int dsda_UMapColorMap(int* colormap);
+dboolean dsda_UMapAllowsJumping(void);
+dboolean dsda_UMapAllowsFreeAim(void);
+dboolean dsda_UExplodeIn3D(void);
+dboolean dsda_UVerticalExplosionThrust(void);
 
 #endif

--- a/prboom2/src/p_map.c
+++ b/prboom2/src/p_map.c
@@ -2864,8 +2864,7 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
 
   dist = dx > dy ? dx : dy;
 
-  // TODO: possible "3d explosion" mapinfo flag
-  if (map_format.zdoom &&
+  if (dsda_ExplodeIn3D() &&
       (bomb.spot->z < thing->z || bomb.spot->z >= thing->z + thing->height))
   {
     fixed_t dz;
@@ -2915,8 +2914,7 @@ dboolean PIT_RadiusAttack (mobj_t* thing)
 
     P_DamageMobj (thing, bomb.spot, bomb.source, damage);
 
-    // TODO: possible "vertical explosion thrust" mapinfo flag
-    if (map_format.zdoom && !(bomb.flags & BF_HORIZONTAL))
+    if (dsda_VerticalExplosionThrust() && !(bomb.flags & BF_HORIZONTAL))
     {
       fixed_t thrust;
       fixed_t dxy, dz;

--- a/prboom2/src/scanner.cpp
+++ b/prboom2/src/scanner.cpp
@@ -51,7 +51,7 @@ const char* const Scanner::TokenNames[TK_NumSpecialTokens] =
 	"Logical Or",
 	"Equals",
 	"Not Equals",
-	"Greater Than or Equals"
+	"Greater Than or Equals",
 	"Less Than or Equals",
 	"Left Shift",
 	"Right Shift"

--- a/prboom2/src/umapinfo.cpp
+++ b/prboom2/src/umapinfo.cpp
@@ -17,22 +17,22 @@
 //
 //-----------------------------------------------------------------------------
 
+#include <assert.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <assert.h>
-#include "umapinfo.h"
 #include "scanner.h"
+#include "umapinfo.h"
 
 extern "C"
 {
-#include "m_misc.h"
-#include "g_game.h"
 #include "doomdef.h"
 #include "doomstat.h"
-
 #include "dsda/episode.h"
 #include "dsda/name.h"
+#include "g_game.h"
+#include "lprintf.h"
+#include "m_misc.h"
 
 MapList Maps;
 }
@@ -130,6 +130,38 @@ static int ParseLumpName(Scanner &scanner, char *buffer)
 	buffer[8] = 0;
 	M_Strupr(buffer);
 	return 1;
+}
+
+// -----------------------------------------------
+//
+// Parses an advanced player movement option
+//
+// -----------------------------------------------
+static PlayerMovement ParsePlayerMovement(Scanner &scanner)
+{
+	auto pm = PM_Unset;
+	scanner.MustGetToken(TK_Identifier);
+	auto keyword = scanner.string;
+
+	if (!stricmp(keyword, "disallow"))
+	{
+		pm = PM_Disallow;
+	}
+	else if (!stricmp(keyword, "allow"))
+	{
+		pm = PM_Allow;
+	}
+	else if (!stricmp(keyword, "require"))
+	{
+		pm = PM_Require;
+	}
+
+	if (pm == PM_Unset)
+	{
+		scanner.ErrorF("Expected 'disallow', 'allow' or require, got %s", keyword);
+	}
+
+	return pm;
 }
 
 // -----------------------------------------------
@@ -372,9 +404,98 @@ static int ParseStandardProperty(Scanner &scanner, MapEntry *mape)
 				mape->bossactions = (struct BossAction *)Z_Realloc(mape->bossactions, sizeof(struct BossAction) * mape->numbossactions);
 				mape->bossactions[mape->numbossactions - 1].type = type;
 				mape->bossactions[mape->numbossactions - 1].special = special;
-				mape->bossactions[mape->numbossactions - 1].tag = tag;
+				mape->bossactions[mape->numbossactions - 1].args[0] = tag;
 			}
 
+		}
+	}
+	else if (!stricmp(pname, "jumping"))
+	{
+		switch (ParsePlayerMovement(scanner))
+		{
+			case PM_Disallow:
+				mape->flags &= ~MapInfo_Jumping;
+				break;
+			case PM_Allow:
+				mape->flags |= MapInfo_Jumping;
+				break;
+			case PM_Require:
+				mape->flags |= MapInfo_Jumping;
+				break;
+		}
+	}
+	else if (!stricmp(pname, "crouching"))
+	{
+		switch (ParsePlayerMovement(scanner))
+		{
+			case PM_Disallow:
+				mape->flags &= ~MapInfo_Crouching;
+				break;
+			case PM_Allow:
+				mape->flags |= MapInfo_Crouching;
+				break;
+			case PM_Require:
+				lprintf(LO_WARN,
+				        "Parsing UMAPINFO found a 'crounching = "
+				        "required' entry, but crouching is not "
+				        "supported, map %s may not work correctly.\n",
+				        mape->lumpname);
+				mape->flags |= MapInfo_Crouching;
+				break;
+		}
+	}
+	else if (!stricmp(pname, "freeaim"))
+	{
+		switch (ParsePlayerMovement(scanner))
+		{
+			case PM_Disallow:
+				mape->flags &= ~MapInfo_FreeAim;
+				break;
+			case PM_Allow:
+				mape->flags |= MapInfo_FreeAim;
+				break;
+			case PM_Require:
+				mape->flags |= MapInfo_FreeAim;
+				break;
+		}
+	}
+	else if (!stricmp(pname, "DSDADoom_VerticalExplosionThrust"))
+	{
+		scanner.MustGetToken(TK_BoolConst);
+		if (scanner.boolean) mape->flags |= MapInfo_EX_VerticalExplosionThrust;
+		else mape->flags &= ~MapInfo_EX_VerticalExplosionThrust;
+	}
+	else if (!stricmp(pname, "DSDADoom_ExplodeIn3D"))
+	{
+		scanner.MustGetToken(TK_BoolConst);
+		if (scanner.boolean) mape->flags |= MapInfo_EX_ExplodeIn3D;
+		else mape->flags &= ~MapInfo_EX_ExplodeIn3D;
+	}
+	else if (!stricmp(pname, "DSDADoom_SpecialAction"))
+	{
+		BossAction action = { 0 };
+		action.is_param = true;
+		scanner.MustGetString();
+		action.type = dsda_ActorNameToType(scanner.string);
+		scanner.MustGetToken(',');
+		scanner.MustGetString();
+		action.special = dsda_ActionNameToNumber(scanner.string);
+
+		for (int i = 0; i < 5; ++i)
+		{
+			if (!scanner.CheckToken(','))
+				break;
+			scanner.MustGetInteger();
+			action.args[i] = scanner.number;
+		}
+
+		if (action.type != NAME_NOT_FOUND && action.special != NAME_NOT_FOUND)
+		{
+			mape->numbossactions++;
+			mape->bossactions = (struct BossAction *)Z_Realloc(
+			      mape->bossactions,
+			      sizeof(struct BossAction) * mape->numbossactions);
+			mape->bossactions[mape->numbossactions - 1] = action;
 		}
 	}
 	else

--- a/prboom2/src/umapinfo.h
+++ b/prboom2/src/umapinfo.h
@@ -24,6 +24,7 @@
 extern "C"
 {
 #endif
+#include "r_defs.h"
 
 typedef enum MapinfoFlags
 {
@@ -41,16 +42,32 @@ typedef enum MapinfoFlags
 
 	MapInfo_BossActionClear = (1u << 9),
 
+	MapInfo_Jumping = (1u << 10),
+	MapInfo_FreeAim = (1u << 11),
+	MapInfo_Crouching = (1u << 12),
+
+	MapInfo_EX_VerticalExplosionThrust = (1u << 13),
+	MapInfo_EX_ExplodeIn3D = (1u << 14),
+
 	MapInfo_EndGameAny = (MapInfo_EndGameArt | MapInfo_EndGameStandard |
                         MapInfo_EndGameCast | MapInfo_EndGameBunny),
 } UMapinfoFlags;
 
 struct BossAction
 {
+	dboolean is_param;
 	int type;
 	int special;
-	int tag;
+	int args[LINE_ARG_COUNT];
 };
+
+typedef enum PlayerMovement
+{
+  PM_Unset,
+  PM_Disallow,
+  PM_Allow,
+  PM_Require,
+} PlayerMovement;
 
 struct MapEntry
 {


### PR DESCRIPTION
Part 3 of the plan described in #959, sequel to #960.

After looking into existing DSDA-UDMF mapsets, two cases were discovered that are actively regressed by the removal of ZDoom MAPINFO.

The first affected WAD release is Thorium, which actively blocks the ability for players to jump and crouch via `MAPINFO`. This is a simple enough case, the UMAPINFO spec has already addressed this with a new set of properties to let mappers control these advanced player movement options without needing to (otherwise needlessly) duplicate the entire UMAPINFO lump in ZMAPINFO, EMAPINFO, etc. As seen in the following:
* https://github.com/doom-cross-port-collab/umapinfo/pull/9
* https://github.com/UZDoom/UZDoom/pull/683
* https://github.com/odamex/odamex/pull/1473

The second case, is that of Worst's RJChannel, a rocket jumping focused map set. To enable the ability to do the intended rocket jumps, both 3d explosion hitboxes and 3d explosion thrust must be allowed, these were properties Kraf actively added to DSDA's MAPINFO parser (it didn't originally exist in it from ZDoom AFAICT), with the intent for mappers to use it, and it would not be ideal for one of the few intentionally mapsets intentionally made for DSDA to not work on it. The map also makes use of parameterized special actions, intended for the built-in music changer item, it also had to be ported.

In the case of RJC, these new properties were added via the "port-exclusive keywords" feature of UMAPINFO. While not a formal part of the spec, as of the writing of this PR, it was discussed and is already put in practice, with the Doom + Doom II port using these to keep track of achievements and other feature of the port. It will be formalized in the spec soon.

Said keywords are in a `<engine name>_<property>` format. Such as the following. No other keywords in the UMAPINFO spec use underscores to separate words. Keywords as always are case-insensitive.
* `DSDADoom_VerticalExplosionThrust = true`
* `DSDADoom_ExplodeIn3D = true`

I have already prepared new UMAPINFO versions of the existing MAPINFO lumps from these two maps, and will send them to the creators in question. Needs a run in the bulk demo tester to be sure.