### PR TITLE
Fix Raven Font Kerning

### DIFF
--- a/prboom2/src/dsda/font.c
+++ b/prboom2/src/dsda/font.c
@@ -70,12 +70,14 @@ void dsda_InitFont(void) {
   hud_font.font = hu_font;
   hud_font.height = hu_font['0' - HU_FONTSTART].height;
   hud_font.line_height = hud_font.height + 1;
-  hud_font.space_width = 4;
+  hud_font.space_width = raven ? 5 : 4;
   hud_font.start = HU_FONTSTART;
+  hud_font.kerning = raven ? -1 : 0;
 
   exhud_font.font = hu_font2;
   exhud_font.height = hu_font2['0' - HU_FONTSTART].height;
   exhud_font.line_height = exhud_font.height + 1;
   exhud_font.space_width = 5;
   exhud_font.start = HU_FONTSTART;
+  exhud_font.kerning = 0;
 }

--- a/prboom2/src/dsda/font.h
+++ b/prboom2/src/dsda/font.h
@@ -30,6 +30,8 @@ typedef struct {
   int line_height;
   int space_width;
   int start;
+
+  int kerning; // Heretic/Hexen -1 kerning
 } dsda_font_t;
 
 extern dsda_font_t hud_font;

--- a/prboom2/src/dsda/global.c
+++ b/prboom2/src/dsda/global.c
@@ -421,7 +421,7 @@ static void dsda_InitHeretic(void) {
 
   g_menu_flat = "FLOOR30";
   g_menu_save_page_size = 5;
-  g_menu_font_spacing = 0;
+  g_menu_font_spacing = -1;
 
   g_skyflatname = "F_SKY1";
 
@@ -586,7 +586,7 @@ static void dsda_InitHexen(void) {
 
   g_menu_flat = "F_032";
   g_menu_save_page_size = 5;
-  g_menu_font_spacing = 0;
+  g_menu_font_spacing = -1;
 
   g_skyflatname = "F_SKY";
 

--- a/prboom2/src/hu_lib.c
+++ b/prboom2/src/hu_lib.c
@@ -89,6 +89,7 @@ void HUlib_initTextLine(hu_textline_t* t, int x, int y,
   t->flags = flags;
   t->line_height = f->line_height;
   t->space_width = f->space_width;
+  t->kerning = f->kerning;
   HUlib_clearTextLine(t);
 }
 
@@ -167,7 +168,7 @@ void HUlib_drawTextLine
     }
     else  if (c != ' ' && c >= l->sc && c <= 127)
     {
-      w = l->f[c - l->sc].width;
+      w = l->f[c - l->sc].width + l->kerning;
       if (x+w-l->f[c - l->sc].leftoffset > BASE_WIDTH)
         break;
       // killough 1/18/98 -- support multiple lines:
@@ -185,7 +186,7 @@ void HUlib_drawTextLine
   l->cm = oc; //jff 2/17/98 restore original color
 
   // draw the cursor if requested
-  if (drawcursor && x + l->f['_' - l->sc].width <= BASE_WIDTH)
+  if (drawcursor && x + l->f['_' - l->sc].width + l->kerning <= BASE_WIDTH)
   {
     // killough 1/18/98 -- support multiple lines
     // CPhipps - patch drawing updated
@@ -218,7 +219,7 @@ void HUlib_setTextXCenter(hu_textline_t* t)
   while (*s)
   {
     int c = toupper(*(s++)) - HU_FONTSTART;
-    t->x -= (c < 0 || c > HU_FONTSIZE ? t->space_width : t->f[c].width);
+    t->x -= (c < 0 || c > HU_FONTSIZE ? t->space_width : t->f[c].width + t->kerning);
   }
   if (t->x < 0)
     t->x = 0;

--- a/prboom2/src/hu_lib.h
+++ b/prboom2/src/hu_lib.h
@@ -68,6 +68,7 @@ typedef struct
   enum patch_translation_e flags;
 
   int line_height;
+  int kerning; // Heretic/Hexen -1 kerning
   int space_width;
 } hu_textline_t;
 


### PR DESCRIPTION
Nyan has had this for a while

Changes:
- Raven message font has -1 kerning
- Menu kerning matches messages
- Note that in Vanilla, the finale screens do not use -1 kerning, and instead use 0 kerning, so they are currently correct